### PR TITLE
Add `MoyoAdapter.from_py_obj` convenience method for generic structure conversion

### DIFF
--- a/moyopy/python/moyopy/interface.py
+++ b/moyopy/python/moyopy/interface.py
@@ -48,3 +48,20 @@ class MoyoAdapter:
             positions=positions,
             numbers=numbers,
         )
+
+    @staticmethod
+    def from_py_obj(struct: Structure | ase.Atoms) -> moyopy.Cell:
+        """Convert a Python atomic structure object to a Moyo Cell.
+
+        Args:
+            struct: Currently supports pymatgen Structure and ASE Atoms
+
+        Returns:
+            moyopy.Cell: The converted Moyo cell
+        """
+        if isinstance(struct, ase.Atoms):
+            return MoyoAdapter.from_atoms(struct)
+        elif isinstance(struct, Structure):
+            return MoyoAdapter.from_structure(struct)
+        else:
+            raise TypeError(f"Expected Structure or Atoms, got {type(struct).__name__}")

--- a/moyopy/python/tests/test_interface.py
+++ b/moyopy/python/tests/test_interface.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-import moyopy
 import numpy as np
 import pytest
+
+import moyopy
 from moyopy.interface import MoyoAdapter
 
 

--- a/moyopy/python/tests/test_interface.py
+++ b/moyopy/python/tests/test_interface.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-import numpy as np
-
 import moyopy
+import numpy as np
+import pytest
 from moyopy.interface import MoyoAdapter
 
 
@@ -20,3 +20,23 @@ def test_ase_moyopy(wurtzite: moyopy.Cell):
     assert np.allclose(cell.basis, wurtzite.basis)
     assert np.allclose(cell.positions, wurtzite.positions)
     assert cell.numbers == wurtzite.numbers
+
+
+def test_from_py_obj(wurtzite: moyopy.Cell):
+    # Test with pymatgen Structure
+    structure = MoyoAdapter.get_structure(wurtzite)
+    cell1 = MoyoAdapter.from_py_obj(structure)
+    assert np.allclose(cell1.basis, wurtzite.basis)
+    assert np.allclose(cell1.positions, wurtzite.positions)
+    assert cell1.numbers == wurtzite.numbers
+
+    # Test with ASE Atoms
+    atoms = MoyoAdapter.get_atoms(wurtzite)
+    cell2 = MoyoAdapter.from_py_obj(atoms)
+    assert np.allclose(cell2.basis, wurtzite.basis)
+    assert np.allclose(cell2.positions, wurtzite.positions)
+    assert cell2.numbers == wurtzite.numbers
+
+    # Test invalid input type
+    with pytest.raises(TypeError, match="Expected Structure or Atoms"):
+        MoyoAdapter.from_py_obj([1, 2, 3])


### PR DESCRIPTION
Converts any Python atomic structure object to `moyopy.Cell`. currently just switches between `MoyoAdapter.get_structure` and `MoyoAdapter.from_atoms` but named `from_py_obj` to allow extending to future structure classes beyond pymatgen and ASE.