### PR TITLE
Support `MSONAtoms` in `MoyoAdapter`

### DIFF
--- a/moyopy/pyproject.toml
+++ b/moyopy/pyproject.toml
@@ -79,6 +79,7 @@ extend-ignore = [
     "D205",
     "D213",  # Conflict with D212
 ]
+isort.known-first-party = ["moyopy"]
 
 [tool.mypy]
 mypy_path = ["python"]

--- a/moyopy/python/moyopy/interface.py
+++ b/moyopy/python/moyopy/interface.py
@@ -51,11 +51,11 @@ class MoyoAdapter:
         )
 
     @staticmethod
-    def from_py_obj(struct: Structure | ase.Atoms) -> moyopy.Cell:
+    def from_py_obj(struct: Structure | ase.Atoms | MSONAtoms) -> moyopy.Cell:
         """Convert a Python atomic structure object to a Moyo Cell.
 
         Args:
-            struct: Currently supports pymatgen Structure and ASE Atoms
+            struct: Currently supports pymatgen Structure, ASE Atoms, and MSONAtoms
 
         Returns:
             moyopy.Cell: The converted Moyo cell
@@ -65,4 +65,5 @@ class MoyoAdapter:
         elif isinstance(struct, Structure):
             return MoyoAdapter.from_structure(struct)
         else:
-            raise TypeError(f"Expected Structure or Atoms, got {type(struct).__name__}")
+            cls_name = type(struct).__name__
+            raise TypeError(f"Expected Structure, Atoms, or MSONAtoms, got {cls_name}")

--- a/moyopy/python/moyopy/interface.py
+++ b/moyopy/python/moyopy/interface.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 try:
     import ase
     from pymatgen.core import Element, Structure
+    from pymatgen.io.ase import MSONAtoms
 except ImportError:
     raise ImportError("Try installing dependencies with `pip install moyopy[interface]`")
 
@@ -59,7 +60,7 @@ class MoyoAdapter:
         Returns:
             moyopy.Cell: The converted Moyo cell
         """
-        if isinstance(struct, ase.Atoms):
+        if isinstance(struct, (ase.Atoms, MSONAtoms)):
             return MoyoAdapter.from_atoms(struct)
         elif isinstance(struct, Structure):
             return MoyoAdapter.from_structure(struct)

--- a/moyopy/python/tests/test_interface.py
+++ b/moyopy/python/tests/test_interface.py
@@ -24,27 +24,18 @@ def test_ase_moyopy(wurtzite: moyopy.Cell):
 
 
 def test_from_py_obj(wurtzite: moyopy.Cell):
-    # Test with pymatgen Structure
+    # Create different structure types
     structure = MoyoAdapter.get_structure(wurtzite)
-    cell1 = MoyoAdapter.from_py_obj(structure)
-    assert np.allclose(cell1.basis, wurtzite.basis)
-    assert np.allclose(cell1.positions, wurtzite.positions)
-    assert cell1.numbers == wurtzite.numbers
-
-    # Test with ASE Atoms
     atoms = MoyoAdapter.get_atoms(wurtzite)
-    cell2 = MoyoAdapter.from_py_obj(atoms)
-    assert np.allclose(cell2.basis, wurtzite.basis)
-    assert np.allclose(cell2.positions, wurtzite.positions)
-    assert cell2.numbers == wurtzite.numbers
-
-    # Test with MSONAtoms
     mson_atoms = structure.to_ase_atoms()
-    cell3 = MoyoAdapter.from_py_obj(mson_atoms)
-    assert np.allclose(cell3.basis, wurtzite.basis)
-    assert np.allclose(cell3.positions, wurtzite.positions)
-    assert cell3.numbers == wurtzite.numbers
+
+    # Test conversion from each type
+    for struct in [structure, atoms, mson_atoms]:
+        cell = MoyoAdapter.from_py_obj(struct)
+        assert np.allclose(cell.basis, wurtzite.basis)
+        assert np.allclose(cell.positions, wurtzite.positions)
+        assert cell.numbers == wurtzite.numbers
 
     # Test invalid input type
-    with pytest.raises(TypeError, match="Expected Structure or Atoms"):
+    with pytest.raises(TypeError, match="Expected Structure, Atoms, or MSONAtoms, got list"):
         MoyoAdapter.from_py_obj([1, 2, 3])

--- a/moyopy/python/tests/test_interface.py
+++ b/moyopy/python/tests/test_interface.py
@@ -38,6 +38,13 @@ def test_from_py_obj(wurtzite: moyopy.Cell):
     assert np.allclose(cell2.positions, wurtzite.positions)
     assert cell2.numbers == wurtzite.numbers
 
+    # Test with MSONAtoms
+    mson_atoms = structure.to_ase_atoms()
+    cell3 = MoyoAdapter.from_py_obj(mson_atoms)
+    assert np.allclose(cell3.basis, wurtzite.basis)
+    assert np.allclose(cell3.positions, wurtzite.positions)
+    assert cell3.numbers == wurtzite.numbers
+
     # Test invalid input type
     with pytest.raises(TypeError, match="Expected Structure or Atoms"):
         MoyoAdapter.from_py_obj([1, 2, 3])

--- a/moyopy/python/tests/test_moyo_dataset.py
+++ b/moyopy/python/tests/test_moyo_dataset.py
@@ -19,7 +19,7 @@ def test_moyo_dataset_repr(wurtzite: moyopy.Cell):
     dataset = moyopy.MoyoDataset(wurtzite)
     dataset_str = str(dataset)
 
-    # Test that repr contains key information
+    # Test that string representation of MoyoDataset contains key information
     assert "MoyoDataset" in dataset_str
     assert f"number={dataset.number}" in dataset_str
     assert f"hall_number={dataset.hall_number}" in dataset_str


### PR DESCRIPTION
in #55, i forgot to account for the case where people use `pymatgen.Structure.to_ase_atoms()` which in fact returns an instance of `MSONAtoms` instead of `ase.Atoms`