### PR TITLE
Add python interface for space-group type: `moyopy.SpaceGroupType`

### DIFF
--- a/.github/workflows/ci-python.yaml
+++ b/.github/workflows/ci-python.yaml
@@ -51,6 +51,7 @@ jobs:
           uv pip install --system --no-index --find-links dist moyopy
           uv pip install --system moyopy[interface]
           python moyopy/examples/basic.py
+          python moyopy/examples/space_group_type.py
           python moyopy/examples/pymatgen_structure.py
 
   linux:

--- a/moyo/src/data.rs
+++ b/moyo/src/data.rs
@@ -9,8 +9,13 @@ mod point_group;
 mod setting;
 mod wyckoff;
 
-pub use arithmetic_crystal_class::ArithmeticNumber;
+pub use arithmetic_crystal_class::{
+    arithmetic_crystal_class_entry, ArithmeticCrystalClassEntry, ArithmeticNumber,
+};
 pub use centering::Centering;
+pub use classification::{
+    BravaisClass, CrystalFamily, CrystalSystem, GeometricCrystalClass, LatticeSystem,
+};
 pub use hall_symbol::{HallSymbol, MagneticHallSymbol};
 pub use hall_symbol_database::{hall_symbol_entry, HallNumber, HallSymbolEntry, Number};
 pub use magnetic_hall_symbol_database::{magnetic_hall_symbol_entry, MagneticHallSymbolEntry};
@@ -19,10 +24,7 @@ pub use magnetic_space_group::{
 };
 pub use setting::Setting;
 
-pub(super) use arithmetic_crystal_class::{
-    arithmetic_crystal_class_entry, iter_arithmetic_crystal_entry,
-};
-pub(super) use classification::{CrystalSystem, GeometricCrystalClass, LatticeSystem};
+pub(super) use arithmetic_crystal_class::iter_arithmetic_crystal_entry;
 pub(super) use magnetic_space_group::uni_number_range;
 pub(super) use point_group::PointGroupRepresentative;
 pub(super) use wyckoff::{iter_wyckoff_positions, WyckoffPosition, WyckoffPositionSpace};

--- a/moyo/src/data/arithmetic_crystal_class.rs
+++ b/moyo/src/data/arithmetic_crystal_class.rs
@@ -4,10 +4,13 @@ pub type ArithmeticNumber = i32;
 
 #[derive(Debug, Clone)]
 pub struct ArithmeticCrystalClassEntry {
+    /// Number for arithmetic crystal classes (1 - 73)
     pub arithmetic_number: ArithmeticNumber,
-    #[allow(dead_code)]
+    /// Symbol for arithmetic crystal class
     pub symbol: &'static str,
+    /// Geometric crystal class
     pub geometric_crystal_class: GeometricCrystalClass,
+    /// Bravais class
     pub bravais_class: BravaisClass,
 }
 
@@ -33,8 +36,10 @@ impl ArithmeticCrystalClassEntry {
 
 pub fn arithmetic_crystal_class_entry(
     arithmetic_number: ArithmeticNumber,
-) -> ArithmeticCrystalClassEntry {
-    ARITHMETIC_CRYSTAL_CLASS_DATABASE[arithmetic_number as usize - 1].clone()
+) -> Option<ArithmeticCrystalClassEntry> {
+    ARITHMETIC_CRYSTAL_CLASS_DATABASE
+        .get(arithmetic_number as usize - 1)
+        .cloned()
 }
 
 pub fn iter_arithmetic_crystal_entry() -> impl Iterator<Item = &'static ArithmeticCrystalClassEntry>

--- a/moyo/src/data/classification.rs
+++ b/moyo/src/data/classification.rs
@@ -47,6 +47,52 @@ pub enum GeometricCrystalClass {
     Oh, // m-3m
 }
 
+impl ToString for GeometricCrystalClass {
+    fn to_string(&self) -> String {
+        match self {
+            // Triclinic
+            GeometricCrystalClass::C1 => "1".to_string(),
+            GeometricCrystalClass::Ci => "-1".to_string(),
+            // Monoclinic
+            GeometricCrystalClass::C2 => "2".to_string(),
+            GeometricCrystalClass::C1h => "m".to_string(),
+            GeometricCrystalClass::C2h => "2/m".to_string(),
+            // Orthorhombic
+            GeometricCrystalClass::D2 => "222".to_string(),
+            GeometricCrystalClass::C2v => "mm2".to_string(),
+            GeometricCrystalClass::D2h => "mmm".to_string(),
+            // Tetragonal
+            GeometricCrystalClass::C4 => "4".to_string(),
+            GeometricCrystalClass::S4 => "-4".to_string(),
+            GeometricCrystalClass::C4h => "4/m".to_string(),
+            GeometricCrystalClass::D4 => "422".to_string(),
+            GeometricCrystalClass::C4v => "4mm".to_string(),
+            GeometricCrystalClass::D2d => "-42m".to_string(),
+            GeometricCrystalClass::D4h => "4/mmm".to_string(),
+            // Trigonal
+            GeometricCrystalClass::C3 => "3".to_string(),
+            GeometricCrystalClass::C3i => "-3".to_string(),
+            GeometricCrystalClass::D3 => "32".to_string(),
+            GeometricCrystalClass::C3v => "3m".to_string(),
+            GeometricCrystalClass::D3d => "-3m".to_string(),
+            // Hexagonal
+            GeometricCrystalClass::C6 => "6".to_string(),
+            GeometricCrystalClass::C3h => "-6".to_string(),
+            GeometricCrystalClass::C6h => "6/m".to_string(),
+            GeometricCrystalClass::D6 => "622".to_string(),
+            GeometricCrystalClass::C6v => "6mm".to_string(),
+            GeometricCrystalClass::D3h => "-6m2".to_string(),
+            GeometricCrystalClass::D6h => "6/mmm".to_string(),
+            // Cubic
+            GeometricCrystalClass::T => "23".to_string(),
+            GeometricCrystalClass::Th => "m-3".to_string(),
+            GeometricCrystalClass::O => "432".to_string(),
+            GeometricCrystalClass::Td => "-43m".to_string(),
+            GeometricCrystalClass::Oh => "m-3m".to_string(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, EnumIter)]
 pub enum LaueClass {
     Ci,  // -1
@@ -155,6 +201,20 @@ impl CrystalSystem {
     }
 }
 
+impl ToString for CrystalSystem {
+    fn to_string(&self) -> String {
+        match self {
+            CrystalSystem::Triclinic => "Triclinic".to_string(),
+            CrystalSystem::Monoclinic => "Monoclinic".to_string(),
+            CrystalSystem::Orthorhombic => "Orthorhombic".to_string(),
+            CrystalSystem::Tetragonal => "Tetragonal".to_string(),
+            CrystalSystem::Trigonal => "Trigonal".to_string(),
+            CrystalSystem::Hexagonal => "Hexagonal".to_string(),
+            CrystalSystem::Cubic => "Cubic".to_string(),
+        }
+    }
+}
+
 /// ===========================================================================
 /// Classification based on lattice
 /// ===========================================================================
@@ -162,20 +222,55 @@ impl CrystalSystem {
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, EnumIter)]
 pub enum BravaisClass {
+    // Triclinic
     aP,
+    // Monoclinic
     mP,
     mC,
+    // Orthorhombic
     oP,
     oS,
     oF,
     oI,
+    // Tetragonal
     tP,
     tI,
+    // Rhombohedral
     hR,
+    // Hexagonal
     hP,
+    // Cubic
     cP,
     cF,
     cI,
+}
+
+impl ToString for BravaisClass {
+    fn to_string(&self) -> String {
+        match self {
+            // Triclinic
+            BravaisClass::aP => "aP".to_string(),
+            // Monoclinic
+            BravaisClass::mP => "mP".to_string(),
+            BravaisClass::mC => "mC".to_string(),
+            // Orthorhombic
+            BravaisClass::oP => "oP".to_string(),
+            BravaisClass::oS => "oS".to_string(),
+            BravaisClass::oF => "oF".to_string(),
+            BravaisClass::oI => "oI".to_string(),
+            // Tetragonal
+            BravaisClass::tP => "tP".to_string(),
+            BravaisClass::tI => "tI".to_string(),
+            // Rhombohedral
+            BravaisClass::hR => "hR".to_string(),
+            // Hexagonal
+            BravaisClass::hP => "hP".to_string(),
+            // Cubic
+            BravaisClass::cP => "cP".to_string(),
+            BravaisClass::cF => "cF".to_string(),
+            BravaisClass::cI => "cI".to_string(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, EnumIter)]
@@ -202,6 +297,20 @@ impl LatticeSystem {
             BravaisClass::hR => LatticeSystem::Rhombohedral,
             BravaisClass::hP => LatticeSystem::Hexagonal,
             BravaisClass::cP | BravaisClass::cF | BravaisClass::cI => LatticeSystem::Cubic,
+        }
+    }
+}
+
+impl ToString for LatticeSystem {
+    fn to_string(&self) -> String {
+        match self {
+            LatticeSystem::Triclinic => "Triclinic".to_string(),
+            LatticeSystem::Monoclinic => "Monoclinic".to_string(),
+            LatticeSystem::Orthorhombic => "Orthorhombic".to_string(),
+            LatticeSystem::Tetragonal => "Tetragonal".to_string(),
+            LatticeSystem::Rhombohedral => "Rhombohedral".to_string(),
+            LatticeSystem::Hexagonal => "Hexagonal".to_string(),
+            LatticeSystem::Cubic => "Cubic".to_string(),
         }
     }
 }
@@ -242,6 +351,19 @@ impl CrystalFamily {
             LatticeSystem::Tetragonal => CrystalFamily::Tetragonal,
             LatticeSystem::Rhombohedral | LatticeSystem::Hexagonal => CrystalFamily::Hexagonal,
             LatticeSystem::Cubic => CrystalFamily::Cubic,
+        }
+    }
+}
+
+impl ToString for CrystalFamily {
+    fn to_string(&self) -> String {
+        match self {
+            CrystalFamily::Triclinic => "Triclinic".to_string(),
+            CrystalFamily::Monoclinic => "Monoclinic".to_string(),
+            CrystalFamily::Orthorhombic => "Orthorhombic".to_string(),
+            CrystalFamily::Tetragonal => "Tetragonal".to_string(),
+            CrystalFamily::Hexagonal => "Hexagonal".to_string(),
+            CrystalFamily::Cubic => "Cubic".to_string(),
         }
     }
 }

--- a/moyo/src/identify/space_group.rs
+++ b/moyo/src/identify/space_group.rs
@@ -87,8 +87,9 @@ impl SpaceGroup {
 fn correction_transformation_matrices(
     arithmetic_number: ArithmeticNumber,
 ) -> Vec<UnimodularLinear> {
-    let geometric_crystal_class =
-        arithmetic_crystal_class_entry(arithmetic_number).geometric_crystal_class;
+    let geometric_crystal_class = arithmetic_crystal_class_entry(arithmetic_number)
+        .unwrap()
+        .geometric_crystal_class;
 
     // conventional -> conventional(standard)
     let convs = match geometric_crystal_class {

--- a/moyo/src/symmetrize/standardize.rs
+++ b/moyo/src/symmetrize/standardize.rs
@@ -112,7 +112,9 @@ impl StandardizedCell {
 
         // To standardized primitive cell
         let arithmetic_number = entry.arithmetic_number;
-        let lattice_system = arithmetic_crystal_class_entry(arithmetic_number).lattice_system();
+        let lattice_system = arithmetic_crystal_class_entry(arithmetic_number)
+            .unwrap()
+            .lattice_system();
         let prim_transformation = match lattice_system {
             LatticeSystem::Triclinic => standardize_triclinic_cell(&prim_cell.lattice),
             _ => space_group.transformation.clone(),

--- a/moyopy/README.md
+++ b/moyopy/README.md
@@ -5,7 +5,7 @@
 [![image](https://img.shields.io/pypi/v/moyopy.svg)](https://pypi.python.org/pypi/moyopy)
 [![image](https://img.shields.io/pypi/pyversions/moyopy.svg)](https://pypi.python.org/pypi/moyopy)
 
-Python interface of [moyo](https://github.com/spglib/moyo)
+Python interface of [moyo](https://github.com/spglib/moyo), a fast and robust crystal symmetry finder.
 
 - Document: <https://spglib.github.io/moyo/python/>
 - PyPI: <https://pypi.org/project/moyopy/>

--- a/moyopy/docs/conf.py
+++ b/moyopy/docs/conf.py
@@ -14,7 +14,7 @@ extensions = [
     "sphinxcontrib.bibtex",
     # "nbsphinx",
     "myst_parser",
-    "autodoc2",
+    "autoapi.extension",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -70,17 +70,10 @@ myst_dmath_double_inline = True
 myst_heading_anchors = 3
 
 # -----------------------------------------------------------------------------
-# autodoc2
+# autoapi
 # -----------------------------------------------------------------------------
-autodoc2_packages = [
-    {
-        "path": "../python/moyopy/_moyopy.pyi",
-        "module": project,
-    }
-]
-autodoc2_render_plugin = "myst"
-autodoc2_docstring_parser_regexes = [
-    (r".*", "rst"),
+autoapi_dirs = [
+    "../python/moyopy",
 ]
 
 # -----------------------------------------------------------------------------

--- a/moyopy/docs/examples/index.md
+++ b/moyopy/docs/examples/index.md
@@ -9,3 +9,10 @@ When we need a secondary symmetry information such as Hermann-Mauguin symbol for
 
 ```{literalinclude} ../../examples/basic.py
 ```
+
+## Accessing space-group type information
+
+You can access the space-group classification information using {py:class}`moyopy.SpaceGroupType`.
+
+```{literalinclude} ../../examples/space_group_type.py
+```

--- a/moyopy/docs/index.md
+++ b/moyopy/docs/index.md
@@ -6,8 +6,6 @@ hidden:
 ---
     Introduction <self>
     Examples <examples/index>
-    API Reference <apidocs/index>
-    Index <genindex>
 ```
 
 ```{include} ../README.md

--- a/moyopy/examples/space_group_type.py
+++ b/moyopy/examples/space_group_type.py
@@ -1,0 +1,9 @@
+# ruff: noqa: E501
+from moyopy import SpaceGroupType
+
+s = SpaceGroupType(15)  # ITA space group number (1 - 230)
+assert s.hm_short == "C 2/c"
+assert s.crystal_system == "Monoclinic"
+
+print(s)
+# -> PySpaceGroupType { number: 15, hm_short: "C 2/c", hm_full: "C 1 2/c 1", arithmetic_number: 8, arithmetic_symbol: "2/mC", geometric_crystal_class: "2/m", crystal_system: "Monoclinic", bravais_class: "mC", lattice_system: "Monoclinic", crystal_family: "Monoclinic" }

--- a/moyopy/pyproject.toml
+++ b/moyopy/pyproject.toml
@@ -45,7 +45,7 @@ docs = [
     "sphinx-autobuild",
     "sphinxcontrib-bibtex >= 2.5",
     "sphinx-book-theme",
-    "sphinx-autodoc2",
+    "sphinx-autoapi",
     "myst-parser >= 2.0",
     "linkify-it-py",
 ]

--- a/moyopy/python/moyopy/_data.pyi
+++ b/moyopy/python/moyopy/_data.pyi
@@ -43,4 +43,59 @@ class HallSymbolEntry:
     def centering(self) -> Centering:
         """Centering."""
 
+class SpaceGroupType:
+    """Space-group type information."""
+    def __init__(self, number: int): ...
+    # Space group type
+    @property
+    def number(self) -> int:
+        """ITA number for space group types (1 - 230)."""
+    @property
+    def hm_short(self) -> str:
+        """Hermann-Mauguin symbol in short notation."""
+    @property
+    def hm_full(self) -> str:
+        """Hermann-Mauguin symbol in full notation."""
+    # Arithmetic crystal class
+    @property
+    def arithmetic_number(self) -> int:
+        """Number for arithmetic crystal classes (1 - 73)."""
+    @property
+    def arithmetic_symbol(self) -> str:
+        """Symbol for arithmetic crystal class.
+
+        See moyo/src/data/arithmetic_crystal_class.rs for string values.
+        """
+    # Other classifications
+    @property
+    def geometric_crystal_class(self) -> str:
+        """Geometric crystal class.
+
+        See moyo/src/data/classification.rs for string values.
+        """
+    @property
+    def crystal_system(self) -> str:
+        """Crystal system.
+
+        See moyo/src/data/classification.rs for string values.
+        """
+    @property
+    def bravais_class(self) -> str:
+        """Bravais class.
+
+        See moyo/src/data/classification.rs for string values.
+        """
+    @property
+    def lattice_system(self) -> str:
+        """Lattice system.
+
+        See moyo/src/data/classification.rs for string values.
+        """
+    @property
+    def crystal_family(self) -> str:
+        """Crystal family.
+
+        See moyo/src/data/classification.rs for string values.
+        """
+
 def operations_from_number(number: int, setting: Setting) -> Operations: ...

--- a/moyopy/python/moyopy/_data.pyi
+++ b/moyopy/python/moyopy/_data.pyi
@@ -64,38 +64,44 @@ class SpaceGroupType:
     def arithmetic_symbol(self) -> str:
         """Symbol for arithmetic crystal class.
 
-        See moyo/src/data/arithmetic_crystal_class.rs for string values.
+        See https://github.com/spglib/moyo/blob/main/moyo/src/data/arithmetic_crystal_class.rs
+        for string values.
         """
     # Other classifications
     @property
     def geometric_crystal_class(self) -> str:
         """Geometric crystal class.
 
-        See moyo/src/data/classification.rs for string values.
+        See https://github.com/spglib/moyo/blob/main/moyo/src/data/classification.rs
+        for string values.
         """
     @property
     def crystal_system(self) -> str:
         """Crystal system.
 
-        See moyo/src/data/classification.rs for string values.
+        See https://github.com/spglib/moyo/blob/main/moyo/src/data/classification.rs
+        for string values.
         """
     @property
     def bravais_class(self) -> str:
         """Bravais class.
 
-        See moyo/src/data/classification.rs for string values.
+        See https://github.com/spglib/moyo/blob/main/moyo/src/data/classification.rs
+        for string values.
         """
     @property
     def lattice_system(self) -> str:
         """Lattice system.
 
-        See moyo/src/data/classification.rs for string values.
+        See https://github.com/spglib/moyo/blob/main/moyo/src/data/classification.rs
+        for string values.
         """
     @property
     def crystal_family(self) -> str:
         """Crystal family.
 
-        See moyo/src/data/classification.rs for string values.
+        See https://github.com/spglib/moyo/blob/main/moyo/src/data/classification.rs
+        for string values.
         """
 
 def operations_from_number(number: int, setting: Setting) -> Operations: ...

--- a/moyopy/python/moyopy/_moyopy.pyi
+++ b/moyopy/python/moyopy/_moyopy.pyi
@@ -1,5 +1,11 @@
 from moyopy._base import Cell, Operations  # noqa: F401
-from moyopy._data import Centering, HallSymbolEntry, Setting, operations_from_number  # noqa: F401
+from moyopy._data import (
+    Centering,
+    HallSymbolEntry,
+    Setting,
+    SpaceGroupType,
+    operations_from_number,
+)  # noqa: F401
 
 __version__: str
 
@@ -100,6 +106,7 @@ __all__ = [
     "Setting",
     "Centering",
     "HallSymbolEntry",
+    "SpaceGroupType",
     "operations_from_number",
     # lib
     "__version__",

--- a/moyopy/python/tests/test_space_group_type.py
+++ b/moyopy/python/tests/test_space_group_type.py
@@ -1,0 +1,25 @@
+from moyopy import SpaceGroupType
+
+
+def test_space_group_type():
+    s1 = SpaceGroupType(221)
+    assert s1.number == 221
+    assert s1.hm_short == "P m -3 m"
+    assert s1.arithmetic_number == 71
+    assert s1.arithmetic_symbol == "m-3mP"
+    assert s1.geometric_crystal_class == "m-3m"
+    assert s1.crystal_system == "Cubic"
+    assert s1.bravais_class == "cP"
+    assert s1.lattice_system == "Cubic"
+    assert s1.crystal_family == "Cubic"
+
+    s2 = SpaceGroupType(167)
+    assert s2.number == 167
+    assert s2.hm_short == "R -3 c"
+    assert s2.arithmetic_number == 50
+    assert s2.arithmetic_symbol == "-3mR"
+    assert s2.geometric_crystal_class == "-3m"
+    assert s2.crystal_system == "Trigonal"
+    assert s2.bravais_class == "hR"
+    assert s2.lattice_system == "Rhombohedral"
+    assert s2.crystal_family == "Hexagonal"

--- a/moyopy/src/data.rs
+++ b/moyopy/src/data.rs
@@ -1,8 +1,10 @@
 mod hall_symbol;
 mod setting;
+mod space_group_type;
 
 pub use hall_symbol::{PyCentering, PyHallSymbolEntry};
 pub use setting::PySetting;
+pub use space_group_type::PySpaceGroupType;
 
 use pyo3::prelude::*;
 

--- a/moyopy/src/data/space_group_type.rs
+++ b/moyopy/src/data/space_group_type.rs
@@ -1,0 +1,82 @@
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+
+use moyo::data::{
+    arithmetic_crystal_class_entry, hall_symbol_entry, ArithmeticNumber, CrystalFamily,
+    CrystalSystem, LatticeSystem, Number, Setting,
+};
+
+#[derive(Debug, Clone)]
+#[pyclass(name = "SpaceGroupType", frozen)]
+pub struct PySpaceGroupType {
+    // Space group type
+    #[pyo3(get)]
+    /// ITA number for space group types (1 - 230)
+    number: Number,
+    /// Hermann-Mauguin symbol in short notation
+    #[pyo3(get)]
+    hm_short: &'static str,
+    /// Hermann-Mauguin symbol in full notation
+    #[pyo3(get)]
+    hm_full: &'static str,
+    // Arithmetic crystal system
+    /// Number for arithmetic crystal classes (1 - 73)
+    #[pyo3(get)]
+    arithmetic_number: ArithmeticNumber,
+    /// Symbol for arithmetic crystal class
+    #[pyo3(get)]
+    arithmetic_symbol: &'static str,
+    // Other classifications
+    /// Geometric crystal class
+    #[pyo3(get)]
+    geometric_crystal_class: String,
+    /// Crystal system
+    #[pyo3(get)]
+    crystal_system: String,
+    /// Bravais class
+    #[pyo3(get)]
+    bravais_class: String,
+    /// Lattice system
+    #[pyo3(get)]
+    lattice_system: String,
+    /// Crystal family
+    #[pyo3(get)]
+    crystal_family: String,
+}
+
+#[pymethods]
+impl PySpaceGroupType {
+    #[new]
+    pub fn new(number: Number) -> Result<Self, PyErr> {
+        let ita_hall_number = Setting::Standard
+            .hall_number(number)
+            .ok_or(PyValueError::new_err(format!("Unknown number: {}", number)))?;
+        let ita_hall_symbol = hall_symbol_entry(ita_hall_number).unwrap();
+
+        let arithmetic_number = ita_hall_symbol.arithmetic_number;
+        let arithmetic_entry = arithmetic_crystal_class_entry(arithmetic_number).unwrap();
+
+        let geometric_crystal_class = arithmetic_entry.geometric_crystal_class;
+        let crystal_system = CrystalSystem::from_geometric_crystal_class(geometric_crystal_class);
+
+        let bravais_class = arithmetic_entry.bravais_class;
+        let lattice_system = LatticeSystem::from_bravais_class(bravais_class);
+        let crystal_family = CrystalFamily::from_lattice_system(lattice_system);
+
+        Ok(Self {
+            // Space group type
+            number,
+            hm_short: ita_hall_symbol.hm_short,
+            hm_full: ita_hall_symbol.hm_full,
+            // Arithmetic crystal system
+            arithmetic_number,
+            arithmetic_symbol: arithmetic_entry.symbol,
+            // Other classifications
+            geometric_crystal_class: geometric_crystal_class.to_string(),
+            crystal_system: crystal_system.to_string(),
+            bravais_class: bravais_class.to_string(),
+            lattice_system: lattice_system.to_string(),
+            crystal_family: crystal_family.to_string(),
+        })
+    }
+}

--- a/moyopy/src/data/space_group_type.rs
+++ b/moyopy/src/data/space_group_type.rs
@@ -79,4 +79,12 @@ impl PySpaceGroupType {
             crystal_family: crystal_family.to_string(),
         })
     }
+
+    fn __repr__(&self) -> String {
+        format!("SpaceGroupType({})", self.number)
+    }
+
+    fn __str__(&self) -> String {
+        format!("{:?}", self)
+    }
 }

--- a/moyopy/src/lib.rs
+++ b/moyopy/src/lib.rs
@@ -9,7 +9,9 @@ use moyo::data::Setting;
 use moyo::MoyoDataset;
 
 use crate::base::{PyMoyoError, PyOperations, PyStructure};
-use crate::data::{operations_from_number, PyCentering, PyHallSymbolEntry, PySetting};
+use crate::data::{
+    operations_from_number, PyCentering, PyHallSymbolEntry, PySetting, PySpaceGroupType,
+};
 
 #[derive(Debug)]
 #[pyclass(name = "MoyoDataset", frozen)]
@@ -177,6 +179,7 @@ fn moyopy(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyHallSymbolEntry>()?;
     m.add_class::<PySetting>()?;
     m.add_class::<PyCentering>()?;
+    m.add_class::<PySpaceGroupType>()?;
     m.add_wrapped(wrap_pyfunction!(operations_from_number))?;
 
     Ok(())


### PR DESCRIPTION
Closes https://github.com/spglib/moyo/issues/52

This PR introduces `moyopy.SpaceGroupType` to enable python interface to access space group labels and their classifications.

```python
from moyopy import SpaceGroupType

s = SpaceGroupType(15)  # ITA space group number (1 - 230)
assert s.hm_short == "C 2/c"
assert s.crystal_system == "Monoclinic"

print(s)
# -> PySpaceGroupType { number: 15, hm_short: "C 2/c", hm_full: "C 1 2/c 1", arithmetic_number: 8, arithmetic_symbol: "2/mC", geometric_crystal_class: "2/m", crystal_system: "Monoclinic", bravais_class: "mC", lattice_system: "Monoclinic", crystal_family: "Monoclinic" }
```