### PR TITLE
Drop numpy<2 pin

### DIFF
--- a/moyopy/pyproject.toml
+++ b/moyopy/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
 
 [project.optional-dependencies]
 interface = [
-    "numpy<2",  # pymatgen seems to be still incompatible with numpy>=2
+    "numpy",
     "pymatgen",
     "ase>=3.23",
 ]


### PR DESCRIPTION
`pymatgen` should be `numpy>=2` compatible as of about 6 months ago. related PRs:

- https://github.com/materialsproject/pymatgen/pull/3894
- https://github.com/materialsproject/pymatgen/pull/3992