### PR TITLE
Add `moyo-wasm/package.json`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @lan496
+moyo-wasm @janosh

--- a/.gitignore
+++ b/.gitignore
@@ -356,7 +356,6 @@ target/
 .ipynb_checkpoints/
 lcov.info
 
-*.json
 !**/assets/*.json
 .env
 *.png

--- a/moyo-wasm/package.json
+++ b/moyo-wasm/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "moyo-wasm",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "test": "vitest",
+    "build": "wasm-pack build --target web --release"
+  },
+  "devDependencies": {
+    "vitest": "^3.2.4"
+  }
+}


### PR DESCRIPTION
i left the version at 0.1.0 for the first test publish. but once the release action is dialed in, it probably makes sense to set it to v0.4.3  to match that of `moyo`

`moyo-wasm/package.json` was gitignored and i didn't notice it was never committed. adding it now to fix https://github.com/spglib/moyo/actions/runs/17181578915/job/48744634182