### PR TITLE
ci: add npm provenance with trusted publishing to WASM release workflow

### DIFF
--- a/.github/workflows/rw-wasm-release.yaml
+++ b/.github/workflows/rw-wasm-release.yaml
@@ -41,6 +41,4 @@ jobs:
       - name: Publish to npm
         if: "startsWith(github.ref, 'refs/tags/') && ! inputs.dry_run"
         working-directory: moyo-wasm/pkg
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public
+        run: npm publish --provenance --access public


### PR DESCRIPTION
Enables [npm trusted publishing](https://docs.npmjs.com/trusted-publishers) with cryptographic build provenance:
- Add --provenance flag to npm publish command
- Remove NODE_AUTH_TOKEN (replaced by OIDC id-token)

This allows users to verify packages were built by GitHub Actions from the spglib/moyo repository, improving supply chain security.