### PR TITLE
ci: add Python 3.14 support to moyopy

### DIFF
--- a/.github/workflows/rw-python-tests.yaml
+++ b/.github/workflows/rw-python-tests.yaml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v6
       - uses: Swatinem/rust-cache@v2

--- a/moyopy/pyproject.toml
+++ b/moyopy/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering :: Mathematics",
     "Topic :: Scientific/Engineering :: Physics",
 ]


### PR DESCRIPTION
## Summary
- Add `Programming Language :: Python :: 3.14` classifier to `moyopy/pyproject.toml`
- Add Python 3.14 to the CI test matrix in `.github/workflows/rw-python-tests.yaml`
- No Rust code changes needed -- PyO3 `abi3-py39` stable ABI is forward-compatible with Python 3.14

## Test plan
- [x] CI passes for the new Python 3.14 matrix job
- [x] Existing Python 3.10-3.13 matrix jobs remain green

[Claude Code] Generated with [Claude Code](https://claude.com/claude-code)