### PR TITLE
Add explicit PyO3 from_py_object opt-in

### DIFF
--- a/moyopy/src/base/cell.rs
+++ b/moyopy/src/base/cell.rs
@@ -10,7 +10,7 @@ use moyo::utils::{to_3_slice, to_3x3_slice, to_vector3};
 
 // Unfortunately, "PyCell" is already reversed by pyo3...
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[pyclass(name = "Cell", frozen)]
+#[pyclass(name = "Cell", frozen, from_py_object)]
 #[pyo3(module = "moyopy")]
 pub struct PyStructure(Cell);
 

--- a/moyopy/src/base/magnetic_cell.rs
+++ b/moyopy/src/base/magnetic_cell.rs
@@ -15,14 +15,14 @@ enum MagneticCellEnum {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[pyclass(name = "MagneticCell", frozen)]
+#[pyclass(name = "MagneticCell", frozen, from_py_object)]
 #[pyo3(module = "moyopy")]
 pub struct PyMagneticCell {
     magnetic_cell: MagneticCellEnum,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[pyclass(name = "CollinearMagneticCell", frozen)]
+#[pyclass(name = "CollinearMagneticCell", frozen, from_py_object)]
 #[pyo3(module = "moyopy")]
 pub struct PyCollinearMagneticCell(MagneticCell<Collinear>);
 
@@ -134,7 +134,7 @@ impl From<MagneticCell<Collinear>> for PyCollinearMagneticCell {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[pyclass(name = "NonCollinearMagneticCell", frozen)]
+#[pyclass(name = "NonCollinearMagneticCell", frozen, from_py_object)]
 #[pyo3(module = "moyopy")]
 pub struct PyNonCollinearMagneticCell(MagneticCell<NonCollinear>);
 

--- a/moyopy/src/base/operation.rs
+++ b/moyopy/src/base/operation.rs
@@ -9,7 +9,7 @@ use moyo::base::{MagneticOperations, Operations, UnimodularTransformation};
 use moyo::utils::{to_3_slice, to_3x3_slice};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[pyclass(name = "Operations", frozen)]
+#[pyclass(name = "Operations", frozen, from_py_object)]
 #[pyo3(module = "moyopy")]
 pub struct PyOperations(Operations);
 
@@ -87,7 +87,7 @@ impl From<Operations> for PyOperations {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[pyclass(name = "MagneticOperations", frozen)]
+#[pyclass(name = "MagneticOperations", frozen, from_py_object)]
 #[pyo3(module = "moyopy")]
 pub struct PyMagneticOperations(MagneticOperations);
 
@@ -176,7 +176,7 @@ impl From<MagneticOperations> for PyMagneticOperations {
 }
 
 #[derive(Debug, Clone)]
-#[pyclass(name = "UnimodularTransformation", frozen)]
+#[pyclass(name = "UnimodularTransformation", frozen, from_py_object)]
 #[pyo3(module = "moyopy")]
 pub struct PyUnimodularTransformation(UnimodularTransformation);
 

--- a/moyopy/src/data/arithmetic_crystal_class.rs
+++ b/moyopy/src/data/arithmetic_crystal_class.rs
@@ -8,7 +8,7 @@ use moyo::base::MoyoError;
 use moyo::data::{ArithmeticNumber, arithmetic_crystal_class_entry};
 
 #[derive(Debug, Clone, Serialize)]
-#[pyclass(name = "ArithmeticCrystalClass", frozen)]
+#[pyclass(name = "ArithmeticCrystalClass", frozen, from_py_object)]
 #[pyo3(module = "moyopy")]
 pub struct PyArithmeticCrystalClass {
     // Arithmetic crystal class

--- a/moyopy/src/data/centering.rs
+++ b/moyopy/src/data/centering.rs
@@ -7,7 +7,7 @@ use moyo::data::Centering;
 use moyo::utils::{to_3_slice, to_3x3_slice};
 
 #[derive(Debug, Clone, Serialize)]
-#[pyclass(name = "Centering", frozen)]
+#[pyclass(name = "Centering", frozen, from_py_object)]
 #[pyo3(module = "moyopy")]
 pub struct PyCentering(pub Centering);
 

--- a/moyopy/src/data/hall_symbol.rs
+++ b/moyopy/src/data/hall_symbol.rs
@@ -10,7 +10,7 @@ use moyo::data::{ArithmeticNumber, HallNumber, HallSymbolEntry, Number, hall_sym
 use super::centering::PyCentering;
 
 #[derive(Debug, Clone, Serialize)]
-#[pyclass(name = "HallSymbolEntry", frozen)]
+#[pyclass(name = "HallSymbolEntry", frozen, from_py_object)]
 #[pyo3(module = "moyopy")]
 pub struct PyHallSymbolEntry(pub HallSymbolEntry);
 

--- a/moyopy/src/data/magnetic_space_group_type.rs
+++ b/moyopy/src/data/magnetic_space_group_type.rs
@@ -9,7 +9,7 @@ use moyo::data::{
 };
 
 #[derive(Debug, Clone, Serialize)]
-#[pyclass(name = "MagneticSpaceGroupType", frozen)]
+#[pyclass(name = "MagneticSpaceGroupType", frozen, from_py_object)]
 pub struct PyMagneticSpaceGroupType(MagneticSpaceGroupType);
 
 #[pymethods]

--- a/moyopy/src/data/setting.rs
+++ b/moyopy/src/data/setting.rs
@@ -7,7 +7,7 @@ use serde_json;
 use moyo::data::Setting;
 
 #[derive(Debug, Clone, Serialize)]
-#[pyclass(name = "Setting", frozen)]
+#[pyclass(name = "Setting", frozen, from_py_object)]
 #[pyo3(module = "moyopy")]
 pub struct PySetting(pub Setting);
 

--- a/moyopy/src/data/space_group_type.rs
+++ b/moyopy/src/data/space_group_type.rs
@@ -12,7 +12,7 @@ use moyo::data::{
 use crate::base::PyMoyoError;
 
 #[derive(Debug, Clone, Serialize)]
-#[pyclass(name = "SpaceGroupType", frozen)]
+#[pyclass(name = "SpaceGroupType", frozen, from_py_object)]
 pub struct PySpaceGroupType {
     // Space group type
     #[pyo3(get)]

--- a/moyopy/src/dataset/magnetic_space_group.rs
+++ b/moyopy/src/dataset/magnetic_space_group.rs
@@ -13,7 +13,7 @@ use crate::base::{
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[pyclass(name = "MoyoCollinearMagneticDataset", frozen)]
+#[pyclass(name = "MoyoCollinearMagneticDataset", frozen, from_py_object)]
 #[pyo3(module = "moyopy")]
 pub struct PyMoyoCollinearMagneticDataset(MoyoMagneticDataset<Collinear>);
 
@@ -195,7 +195,7 @@ impl PyMoyoCollinearMagneticDataset {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[pyclass(name = "MoyoNonCollinearMagneticDataset", frozen)]
+#[pyclass(name = "MoyoNonCollinearMagneticDataset", frozen, from_py_object)]
 #[pyo3(module = "moyopy")]
 pub struct PyMoyoNonCollinearMagneticDataset(MoyoMagneticDataset<NonCollinear>);
 

--- a/moyopy/src/dataset/space_group.rs
+++ b/moyopy/src/dataset/space_group.rs
@@ -13,7 +13,7 @@ use crate::base::{PyMoyoError, PyOperations, PyStructure};
 use crate::data::PySetting;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[pyclass(name = "MoyoDataset", frozen)]
+#[pyclass(name = "MoyoDataset", frozen, from_py_object)]
 #[pyo3(module = "moyopy")]
 pub struct PyMoyoDataset(MoyoDataset);
 

--- a/moyopy/src/identify.rs
+++ b/moyopy/src/identify.rs
@@ -125,7 +125,7 @@ pub fn integral_normalizer(
 }
 
 #[derive(Debug, Clone, Serialize)]
-#[pyclass(name = "PointGroup", frozen)]
+#[pyclass(name = "PointGroup", frozen, from_py_object)]
 #[pyo3(module = "moyopy")]
 pub struct PyPointGroup(PointGroup);
 
@@ -197,7 +197,7 @@ impl From<PointGroup> for PyPointGroup {
 }
 
 #[derive(Debug, Clone, Serialize)]
-#[pyclass(name = "SpaceGroup", frozen)]
+#[pyclass(name = "SpaceGroup", frozen, from_py_object)]
 #[pyo3(module = "moyopy")]
 pub struct PySpaceGroup(SpaceGroup);
 
@@ -292,7 +292,7 @@ impl From<SpaceGroup> for PySpaceGroup {
 }
 
 #[derive(Debug, Clone, Serialize)]
-#[pyclass(name = "MagneticSpaceGroup", frozen)]
+#[pyclass(name = "MagneticSpaceGroup", frozen, from_py_object)]
 #[pyo3(module = "moyopy")]
 pub struct PyMagneticSpaceGroup(MagneticSpaceGroup);
 


### PR DESCRIPTION
## Summary
- add explicit `from_py_object` to cloneable `#[pyclass]` wrappers in `moyopy`
- preserve the current Python extraction behavior while removing PyO3 deprecation warnings

## Test plan
- [x] `cargo check -p moyopy`
- [x] `cargo test -p moyopy`
- [ ] `pre-commit run --all-files` (`pre-commit` was not installed in this environment)
