### PR TITLE
fix(renovate): correct enableManagers -> enabledManagers

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -26,7 +26,7 @@
     "helpers:pinGitHubActionDigests",
   ],
 
-  "enableManagers": [
+  "enabledManagers": [
     "cargo",
     "github-actions",
     "npm",


### PR DESCRIPTION
## Summary

- Rename `enableManagers` -> `enabledManagers` in `.github/renovate.json5` (the previous spelling is not a valid Renovate option)
- This typo was introduced in #287 and caused Renovate to reject the configuration, which in turn stopped Renovate from opening PRs and triggered the "Action Required: Fix Renovate Configuration" issue (#288)

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, the Renovate config-error issue (#288) auto-closes and Renovate resumes opening PRs (e.g. the queued lock-file-maintenance / ci-and-devdependencies PRs surface again)

Closes #288

[Claude Code] Generated with [Claude Code](https://claude.com/claude-code)
