### PR TITLE
Improve moyopy docs: port Rust docstrings, group API Reference

### DIFF
--- a/.claude/skills/port-rust-docs-to-pyi/SKILL.md
+++ b/.claude/skills/port-rust-docs-to-pyi/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: port-rust-docs-to-pyi
+description: Port docstrings between PyO3 bindings (`moyopy/src/**/*.rs`) and the Python type stubs (`moyopy/python/moyopy/*.pyi`). Use when adding/editing a class, getter, method, or `#[pyfunction]` so that `__doc__` (Rust `///`), the `.pyi` stub, and the Sphinx API reference all stay in sync.
+---
+
+# Port Rust docs to Python stubs
+
+The moyopy bindings have **two** documentation surfaces that must stay synchronized by hand:
+
+1. **Rust `///` doc comments** in `moyopy/src/**/*.rs` -- PyO3 forwards these to Python `__doc__` (visible from `help()`, IDE hover, Sphinx autoapi).
+1. **Hand-written `.pyi` stubs** in `moyopy/python/moyopy/*.pyi` -- read by mypy/Pyright/Pylance for type-checker tooltips.
+
+There is **no auto-generation step**. `pyo3-stub-gen` was evaluated and rejected (it forces `module = "<pkg>._<sub>"`, which leaks `_moyopy` into `__module__`). When you change docs in one place, you must mirror them in the other.
+
+## When to use
+
+- Adding a new `#[pyclass]`, `#[getter]`, `#[pymethods]`, or `#[pyfunction]` to `moyopy/src/`.
+- Editing an existing `///` doc comment on a binding.
+- Editing an existing docstring in a `.pyi` stub.
+- Reviewing a PR that adds Python-facing API and the docs feel uneven.
+
+## File mapping
+
+| Rust binding                                   | Python stub                | Public name(s)                                                          |
+| ---------------------------------------------- | -------------------------- | ----------------------------------------------------------------------- |
+| `moyopy/src/base/cell.rs`                      | `_base.pyi`                | `Cell`                                                                  |
+| `moyopy/src/base/magnetic_cell.rs`             | `_base.pyi`                | `CollinearMagneticCell`, `NonCollinearMagneticCell`                     |
+| `moyopy/src/base/operation.rs`                 | `_base.pyi`                | `Operations`, `MagneticOperations`, `UnimodularTransformation`          |
+| `moyopy/src/base/error.rs`                     | (not exposed in `.pyi`)    | `MoyoError`                                                             |
+| `moyopy/src/data/setting.rs`                   | `_data.pyi`                | `Setting`                                                               |
+| `moyopy/src/data/centering.rs`                 | `_data.pyi`                | `Centering`                                                             |
+| `moyopy/src/data/hall_symbol.rs`               | `_data.pyi`                | `HallSymbolEntry`                                                       |
+| `moyopy/src/data/space_group_type.rs`          | `_data.pyi`                | `SpaceGroupType`                                                        |
+| `moyopy/src/data/magnetic_space_group_type.rs` | `_data.pyi`                | `MagneticSpaceGroupType`                                                |
+| `moyopy/src/data/arithmetic_crystal_class.rs`  | `_data.pyi`                | `ArithmeticCrystalClass`                                                |
+| `moyopy/src/data.rs`                           | `_data.pyi`                | `operations_from_number`, `magnetic_operations_from_uni_number`         |
+| `moyopy/src/dataset/space_group.rs`            | `_dataset.pyi`             | `MoyoDataset`                                                           |
+| `moyopy/src/dataset/magnetic_space_group.rs`   | `_dataset.pyi`             | `MoyoCollinearMagneticDataset`, `MoyoNonCollinearMagneticDataset`       |
+| `moyopy/src/identify.rs`                       | `_identify.pyi`            | `PointGroup`, `SpaceGroup`, `MagneticSpaceGroup`, `integral_normalizer` |
+| `moyopy/src/lib.rs`                            | `_moyopy.pyi` (re-exports) | (top-level package)                                                     |
+
+`moyopy/python/moyopy/__init__.py` does `from ._moyopy import *`, and `_moyopy.pyi` re-imports symbols from the per-domain `.pyi` files for type-checker visibility.
+
+## Workflow
+
+### Adding or editing a binding item
+
+1. **Write `///` on the Rust side** above the `#[pyclass]` / `#[pymethods]` block, individual `#[getter]`, method, or `#[pyfunction]`. Place it **after** `#[derive(...)]` but **before** `#[pyclass(...)]`/`#[pymethods]`/`#[getter]`. PyO3 forwards it to `__doc__`.
+1. **Mirror it in the matching `.pyi` file** as a Python triple-quoted docstring on the same construct.
+1. **Verify** with the smoke test in "Verification" below.
+
+### Editing only the .pyi (rarely correct)
+
+Almost always wrong -- if the docstring isn't in the Rust `///`, it doesn't show in `help()`, IDE hover, or Sphinx. Move the prose into the Rust source first, then mirror back to `.pyi`.
+
+### Editing only the Rust /// (also rarely correct)
+
+Type-checker tooltips will go stale. After editing the Rust side, mirror to the matching `.pyi`.
+
+## Conventions
+
+- **Style**: NumPy-style. Class-level docstring first, then per-method/getter/property. Constructors get a `Parameters` section. Avoid Google-style `Args:` -- the project uses NumPy throughout.
+- **Inline code**: double backticks (RST/Sphinx style): ` `cell.basis` `, ` `symprec` `. Markdown single backticks render wrong in Sphinx.
+- **Code blocks in Rust `///`**: never use indented blocks (rustdoc treats them as Rust and runs them as doctests). Use fenced ```` ```text ```` blocks:
+  ````rust
+  /// Same transformation convention as the standardized cell:
+  ///
+  /// ```text
+  /// std_cell.basis.T = std_rotation_matrix @ cell.basis.T @ std_linear
+  /// ```
+  ````
+- **Code blocks in `.pyi`**: RST `::` followed by indent, OR fenced -- both render in Sphinx. Match the existing surrounding style in the file you're editing.
+- **Cross-references in `.pyi`**: use `:attr:`, `:class:`, `:func:` (Sphinx). In Rust `///`, plain prose is fine -- the Rust doc tree is not used by the Python project.
+- **Module attribute** (CRITICAL): keep `#[pyo3(module = "moyopy")]` on every `#[pyclass]` and `#[pyfunction]`. Do **not** change to `"moyopy._moyopy"` -- it leaks the hidden submodule into `__module__`, `repr()`, and pickle. The reviewer rejected this.
+- **No `pyo3-stub-gen` re-introduction**: this was tried and reverted (PR #294). It hard-rejects items declared above `module-name` in `pyproject.toml`, with no escape hatch as of v0.22. If you want auto-generation, do it via a different mechanism (mypy stubgen, custom introspection script).
+
+## Verification
+
+After porting, run all of:
+
+```
+# rebuild bindings
+PYO3_PYTHON=/path/to/moyopy/.venv/bin/python uv run --directory moyopy maturin develop --release --manifest-path Cargo.toml
+
+# pytest
+moyopy/.venv/bin/python -m pytest -q moyopy/python/tests
+
+# spot-check __doc__ at runtime
+moyopy/.venv/bin/python -c 'import moyopy; print(moyopy.MoyoDataset.std_cell.__doc__)'
+
+# pre-commit
+prek run --all-files
+
+# cargo doc-tests pick up bad indented blocks
+PYO3_PYTHON=/path/to/.venv/bin/python PYTHONHOME=$(/path/to/.venv/bin/python -c 'import sys; print(sys.base_prefix)') \
+  cargo test --manifest-path moyopy/Cargo.toml
+```
+
+If `cargo test` fails on a doc-test like `expected one of '!' or '::', found '.'`, you have an indented code block in a `///` -- fence it as ```` ```text ````.
+
+## Pitfalls
+
+- **Indented code in `///`**: rustdoc treats it as Rust and tries to run it as a doctest. Always use ```` ```text ```` fences for non-Rust example blocks.
+- **Forgetting to mirror**: the Rust side and the `.pyi` drift silently if you only edit one. Set yourself a checklist: every binding edit touches at least two files (the `.rs` and the matching `.pyi`).
+- **Changing `module = "moyopy"`**: do not. See "Conventions" above.
+- **Re-adding `pyo3-stub-gen`**: do not (without addressing the parent-module constraint upstream first).
+- **`MoyoError` is not in `.pyi`**: it's `#[pyclass]` but not registered in `#[pymodule]` / not in `__all__`. Don't add it to `_base.pyi` unless you also expose it.
+- **Re-exports in `_moyopy.pyi`**: when adding a new class, also add it to `__init__.py`'s `__all__` and to `_moyopy.pyi`'s import list and `__all__`.
+
+## Why two surfaces?
+
+PyO3's `///` -> `__doc__` only covers runtime `help()` / hover. Mypy / Pyright read `.pyi` instead and ignore the `__doc__` of the compiled extension. Until pyo3-stub-gen (or an alternative) fits the project's constraints, both surfaces have to be maintained by hand.

--- a/moyopy/docs/api.md
+++ b/moyopy/docs/api.md
@@ -1,0 +1,151 @@
+# API Reference
+
+```{eval-rst}
+.. currentmodule:: moyopy
+```
+
+The public API mirrors the Rust crate layout: `base` (crystal structures and
+operation containers), `dataset` (symmetry analysis results), `data`
+(crystallographic classification tables), and `identify` (group identification
+primitives). The :mod:`moyopy.interface` adapters provide conversion helpers
+to/from pymatgen and ASE.
+
+## Crystal structures
+
+Lattice + sites with optional magnetic moments, plus symmetry-operation
+containers.
+
+```{eval-rst}
+.. autoapisummary::
+
+   moyopy.Cell
+   moyopy.CollinearMagneticCell
+   moyopy.NonCollinearMagneticCell
+   moyopy.Operations
+   moyopy.MagneticOperations
+   moyopy.UnimodularTransformation
+
+.. autoapiclass:: moyopy.Cell
+   :members:
+
+.. autoapiclass:: moyopy.CollinearMagneticCell
+   :members:
+
+.. autoapiclass:: moyopy.NonCollinearMagneticCell
+   :members:
+
+.. autoapiclass:: moyopy.Operations
+   :members:
+
+.. autoapiclass:: moyopy.MagneticOperations
+   :members:
+
+.. autoapiclass:: moyopy.UnimodularTransformation
+   :members:
+```
+
+## Symmetry datasets
+
+Run a symmetry analysis on a :class:`Cell` or magnetic cell and inspect the
+result.
+
+```{eval-rst}
+.. autoapisummary::
+
+   moyopy.MoyoDataset
+   moyopy.MoyoCollinearMagneticDataset
+   moyopy.MoyoNonCollinearMagneticDataset
+
+.. autoapiclass:: moyopy.MoyoDataset
+   :members:
+
+.. autoapiclass:: moyopy.MoyoCollinearMagneticDataset
+   :members:
+
+.. autoapiclass:: moyopy.MoyoNonCollinearMagneticDataset
+   :members:
+```
+
+## Crystallographic data
+
+Hall symbols, settings, centering, classification tables, and helpers to fetch
+operations by ITA / UNI number.
+
+```{eval-rst}
+.. autoapisummary::
+
+   moyopy.Setting
+   moyopy.Centering
+   moyopy.HallSymbolEntry
+   moyopy.SpaceGroupType
+   moyopy.MagneticSpaceGroupType
+   moyopy.ArithmeticCrystalClass
+   moyopy.operations_from_number
+   moyopy.magnetic_operations_from_uni_number
+
+.. autoapiclass:: moyopy.Setting
+   :members:
+
+.. autoapiclass:: moyopy.Centering
+   :members:
+
+.. autoapiclass:: moyopy.HallSymbolEntry
+   :members:
+
+.. autoapiclass:: moyopy.SpaceGroupType
+   :members:
+
+.. autoapiclass:: moyopy.MagneticSpaceGroupType
+   :members:
+
+.. autoapiclass:: moyopy.ArithmeticCrystalClass
+   :members:
+
+.. autoapifunction:: moyopy.operations_from_number
+
+.. autoapifunction:: moyopy.magnetic_operations_from_uni_number
+```
+
+## Group identification
+
+Identify point groups, space groups, and magnetic space groups from a primitive
+list of symmetry operations.
+
+```{eval-rst}
+.. autoapisummary::
+
+   moyopy.PointGroup
+   moyopy.SpaceGroup
+   moyopy.MagneticSpaceGroup
+   moyopy.integral_normalizer
+
+.. autoapiclass:: moyopy.PointGroup
+   :members:
+
+.. autoapiclass:: moyopy.SpaceGroup
+   :members:
+
+.. autoapiclass:: moyopy.MagneticSpaceGroup
+   :members:
+
+.. autoapifunction:: moyopy.integral_normalizer
+```
+
+## Adapters
+
+Convert between :class:`moyopy.Cell` / :class:`moyopy.NonCollinearMagneticCell`
+and pymatgen `Structure` / ASE `Atoms`. Requires the optional dependencies
+installed via `pip install moyopy[interface]`.
+
+```{eval-rst}
+.. autoapisummary::
+
+   moyopy.interface.MoyoAdapter
+   moyopy.interface.MoyoNonCollinearMagneticAdapter
+
+.. autoapiclass:: moyopy.interface.MoyoAdapter
+   :members:
+
+.. autoapiclass:: moyopy.interface.MoyoNonCollinearMagneticAdapter
+   :members:
+```

--- a/moyopy/docs/conf.py
+++ b/moyopy/docs/conf.py
@@ -75,6 +75,21 @@ myst_heading_anchors = 3
 autoapi_dirs = [
     "../python/moyopy",
 ]
+# Drop `private-members` (default-on) so leading-underscore helpers like
+# `_species_from_numbers` don't appear in the rendered API reference.
+autoapi_options = [
+    "members",
+    "undoc-members",
+    "show-inheritance",
+    "show-module-summary",
+    "special-members",
+    "imported-members",
+]
+# We hand-curate the API Reference into grouped sections in `api.md` and use
+# autoapi's directives there. Stop autoapi from generating its own per-module
+# stub pages so we don't end up with two competing entry points.
+autoapi_add_toctree_entry = False
+autoapi_generate_api_docs = False
 
 # -----------------------------------------------------------------------------
 # sphinx-book-theme

--- a/moyopy/docs/conf.py
+++ b/moyopy/docs/conf.py
@@ -101,7 +101,7 @@ html_theme_options = {
     "use_repository_button": True,
     "navigation_with_keys": True,
     "globaltoc_includehidden": "true",
-    "show_toc_level": 1,
+    "show_toc_level": 2,
 }
 
 # hide sphinx footer

--- a/moyopy/docs/conf.py
+++ b/moyopy/docs/conf.py
@@ -101,7 +101,7 @@ html_theme_options = {
     "use_repository_button": True,
     "navigation_with_keys": True,
     "globaltoc_includehidden": "true",
-    "show_toc_level": 3,
+    "show_toc_level": 1,
 }
 
 # hide sphinx footer

--- a/moyopy/docs/index.md
+++ b/moyopy/docs/index.md
@@ -8,6 +8,7 @@ hidden:
     Examples <examples/index>
     Standardization of Crystal Structures <standardization>
     Migration Guide from spglib <migration>
+    API Reference <api>
 ```
 
 ```{include} ../README.md

--- a/moyopy/python/moyopy/__init__.py
+++ b/moyopy/python/moyopy/__init__.py
@@ -1,1 +1,54 @@
-from ._moyopy import *  # noqa: F403
+from moyopy._moyopy import (
+    ArithmeticCrystalClass,
+    Cell,
+    Centering,
+    CollinearMagneticCell,
+    HallSymbolEntry,
+    MagneticOperations,
+    MagneticSpaceGroup,
+    MagneticSpaceGroupType,
+    MoyoCollinearMagneticDataset,
+    MoyoDataset,
+    MoyoNonCollinearMagneticDataset,
+    NonCollinearMagneticCell,
+    Operations,
+    PointGroup,
+    Setting,
+    SpaceGroup,
+    SpaceGroupType,
+    UnimodularTransformation,
+    __version__,
+    integral_normalizer,
+    magnetic_operations_from_uni_number,
+    operations_from_number,
+)
+
+__all__ = [
+    # base
+    "Cell",
+    "CollinearMagneticCell",
+    "MagneticOperations",
+    "NonCollinearMagneticCell",
+    "Operations",
+    "UnimodularTransformation",
+    # data
+    "ArithmeticCrystalClass",
+    "Centering",
+    "HallSymbolEntry",
+    "MagneticSpaceGroupType",
+    "Setting",
+    "SpaceGroupType",
+    "magnetic_operations_from_uni_number",
+    "operations_from_number",
+    # dataset
+    "MoyoCollinearMagneticDataset",
+    "MoyoDataset",
+    "MoyoNonCollinearMagneticDataset",
+    # identify
+    "MagneticSpaceGroup",
+    "PointGroup",
+    "SpaceGroup",
+    "integral_normalizer",
+    # lib
+    "__version__",
+]

--- a/moyopy/python/moyopy/_base.pyi
+++ b/moyopy/python/moyopy/_base.pyi
@@ -1,140 +1,207 @@
 from typing import Any
 
 class Cell:
+    """A crystal structure: a lattice plus fractional positions and atomic numbers."""
     def __init__(
         self,
         basis: list[list[float]],
         positions: list[list[float]],
         numbers: list[int],
-    ): ...
+    ):
+        """Create a new ``Cell``.
+
+        Parameters
+        ----------
+        basis : list[list[float]]
+            Row-wise basis vectors of the lattice. ``basis[i]`` is the i-th basis vector.
+        positions : list[list[float]]
+            Fractional coordinates of each site.
+        numbers : list[int]
+            Atomic number of each site. Must have the same length as ``positions``.
+        """
     @property
-    def basis(self) -> list[list[float]]: ...
+    def basis(self) -> list[list[float]]:
+        """Row-wise basis vectors of the lattice."""
     @property
-    def positions(self) -> list[list[float]]: ...
+    def positions(self) -> list[list[float]]:
+        """Fractional coordinates of each site."""
     @property
-    def numbers(self) -> list[int]: ...
+    def numbers(self) -> list[int]:
+        """Atomic number of each site."""
     @property
-    def num_atoms(self) -> int: ...
+    def num_atoms(self) -> int:
+        """Number of atoms in the cell."""
     # Serialization and deserialization
     def serialize_json(self) -> str:
-        """Serialize an object to a JSON string"""
+        """Serialize this object to a JSON string."""
     @classmethod
     def deserialize_json(cls, json_str: str) -> Cell:
-        """Deserialize a JSON string to an object"""
+        """Deserialize an object from a JSON string."""
     def as_dict(self) -> dict[str, Any]:
-        """Convert an object to a dictionary"""
+        """Convert this object to a dictionary."""
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> Cell:
-        """Create an object from a dictionary"""
+        """Create an object from a dictionary."""
 
 class CollinearMagneticCell:
+    """A crystal structure with collinear magnetic moments."""
     def __init__(
         self,
         basis: list[list[float]],
         positions: list[list[float]],
         numbers: list[int],
         magnetic_moments: list[float],
-    ): ...
+    ):
+        """Create a new ``CollinearMagneticCell``.
+
+        Parameters
+        ----------
+        basis : list[list[float]]
+            Row-wise basis vectors of the lattice.
+        positions : list[list[float]]
+            Fractional coordinates of each site.
+        numbers : list[int]
+            Atomic number of each site.
+        magnetic_moments : list[float]
+            Scalar magnetic moment of each site (collinear).
+        """
     @property
-    def basis(self) -> list[list[float]]: ...
+    def basis(self) -> list[list[float]]:
+        """Row-wise basis vectors of the lattice."""
     @property
-    def positions(self) -> list[list[float]]: ...
+    def positions(self) -> list[list[float]]:
+        """Fractional coordinates of each site."""
     @property
-    def numbers(self) -> list[int]: ...
+    def numbers(self) -> list[int]:
+        """Atomic number of each site."""
     @property
-    def magnetic_moments(self) -> list[float]: ...
+    def magnetic_moments(self) -> list[float]:
+        """Scalar magnetic moment of each site."""
     @property
-    def num_atoms(self) -> int: ...
+    def num_atoms(self) -> int:
+        """Number of atoms in the magnetic cell."""
     # Serialization and deserialization
     def serialize_json(self) -> str:
-        """Serialize an object to a JSON string"""
+        """Serialize this object to a JSON string."""
     @classmethod
     def deserialize_json(cls, json_str: str) -> CollinearMagneticCell:
-        """Deserialize a JSON string to an object"""
+        """Deserialize an object from a JSON string."""
     def as_dict(self) -> dict[str, Any]:
-        """Convert an object to a dictionary"""
+        """Convert this object to a dictionary."""
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> CollinearMagneticCell:
-        """Create an object from a dictionary"""
+        """Create an object from a dictionary."""
 
 class NonCollinearMagneticCell:
+    """A crystal structure with non-collinear (vector) magnetic moments."""
     def __init__(
         self,
         basis: list[list[float]],
         positions: list[list[float]],
         numbers: list[int],
         magnetic_moments: list[list[float]],
-    ): ...
+    ):
+        """Create a new ``NonCollinearMagneticCell``.
+
+        Parameters
+        ----------
+        basis : list[list[float]]
+            Row-wise basis vectors of the lattice.
+        positions : list[list[float]]
+            Fractional coordinates of each site.
+        numbers : list[int]
+            Atomic number of each site.
+        magnetic_moments : list[list[float]]
+            Three-component magnetic moment vector of each site.
+        """
     @property
-    def basis(self) -> list[list[float]]: ...
+    def basis(self) -> list[list[float]]:
+        """Row-wise basis vectors of the lattice."""
     @property
-    def positions(self) -> list[list[float]]: ...
+    def positions(self) -> list[list[float]]:
+        """Fractional coordinates of each site."""
     @property
-    def numbers(self) -> list[int]: ...
+    def numbers(self) -> list[int]:
+        """Atomic number of each site."""
     @property
-    def magnetic_moments(self) -> list[list[float]]: ...
+    def magnetic_moments(self) -> list[list[float]]:
+        """Three-component magnetic moment vector of each site."""
     @property
-    def num_atoms(self) -> int: ...
+    def num_atoms(self) -> int:
+        """Number of atoms in the magnetic cell."""
     # Serialization and deserialization
     def serialize_json(self) -> str:
-        """Serialize an object to a JSON string"""
+        """Serialize this object to a JSON string."""
     @classmethod
     def deserialize_json(cls, json_str: str) -> NonCollinearMagneticCell:
-        """Deserialize a JSON string to an object"""
+        """Deserialize an object from a JSON string."""
     def as_dict(self) -> dict[str, Any]:
-        """Convert an object to a dictionary"""
+        """Convert this object to a dictionary."""
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> NonCollinearMagneticCell:
-        """Create an object from a dictionary"""
+        """Create an object from a dictionary."""
 
 class Operations:
+    """A list of crystallographic symmetry operations (rotation + translation)."""
     @property
-    def rotations(self) -> list[list[list[float]]]: ...
+    def rotations(self) -> list[list[list[float]]]:
+        """Rotation parts of the symmetry operations."""
     @property
-    def translations(self) -> list[list[float]]: ...
+    def translations(self) -> list[list[float]]:
+        """Translation parts of the symmetry operations (fractional coordinates)."""
     @property
-    def num_operations(self) -> int: ...
+    def num_operations(self) -> int:
+        """Number of symmetry operations."""
     def __len__(self) -> int: ...
     # Serialization and deserialization
     def serialize_json(self) -> str:
-        """Serialize an object to a JSON string"""
+        """Serialize this object to a JSON string."""
     @classmethod
     def deserialize_json(cls, json_str: str) -> Operations:
-        """Deserialize a JSON string to an object"""
+        """Deserialize an object from a JSON string."""
     def as_dict(self) -> dict[str, Any]:
-        """Convert an object to a dictionary"""
+        """Convert this object to a dictionary."""
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> Operations:
-        """Create an object from a dictionary"""
+        """Create an object from a dictionary."""
 
 class MagneticOperations:
+    """A list of magnetic symmetry operations (rotation + translation + time reversal)."""
     @property
-    def rotations(self) -> list[list[list[float]]]: ...
+    def rotations(self) -> list[list[list[float]]]:
+        """Rotation parts of the magnetic symmetry operations."""
     @property
-    def translations(self) -> list[list[float]]: ...
+    def translations(self) -> list[list[float]]:
+        """Translation parts of the magnetic symmetry operations (fractional coordinates)."""
     @property
-    def time_reversals(self) -> list[bool]: ...
+    def time_reversals(self) -> list[bool]:
+        """Time-reversal flag for each magnetic symmetry operation."""
     @property
-    def num_operations(self) -> int: ...
+    def num_operations(self) -> int:
+        """Number of magnetic symmetry operations."""
     def __len__(self) -> int: ...
     # Serialization and deserialization
     def serialize_json(self) -> str:
-        """Serialize an object to a JSON string"""
+        """Serialize this object to a JSON string."""
     @classmethod
     def deserialize_json(cls, json_str: str) -> MagneticOperations:
-        """Deserialize a JSON string to an object"""
+        """Deserialize an object from a JSON string."""
     def as_dict(self) -> dict[str, Any]:
-        """Convert an object to a dictionary"""
+        """Convert this object to a dictionary."""
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> MagneticOperations:
-        """Create an object from a dictionary"""
+        """Create an object from a dictionary."""
 
 class UnimodularTransformation:
+    """A unimodular transformation: an integer linear part with determinant +-1 plus an
+    origin shift."""
     @property
-    def linear(self) -> list[list[int]]: ...
+    def linear(self) -> list[list[int]]:
+        """Linear part (integer 3x3 matrix with determinant +-1)."""
     @property
-    def origin_shift(self) -> list[float]: ...
+    def origin_shift(self) -> list[float]:
+        """Origin shift (fractional coordinates)."""
     def serialize_json(self) -> str:
-        """Serialize an object to a JSON string"""
+        """Serialize this object to a JSON string."""
     def as_dict(self) -> dict[str, Any]:
-        """Convert an object to a dictionary"""
+        """Convert this object to a dictionary."""

--- a/moyopy/python/moyopy/_dataset.pyi
+++ b/moyopy/python/moyopy/_dataset.pyi
@@ -53,11 +53,11 @@ class MoyoDataset:
     # Site symmetry
     @property
     def orbits(self) -> list[int]:
-        """Spglib's `crystallographic_orbits` not `equivalent_atoms`.
+        """Spglib's ``crystallographic_orbits`` not ``equivalent_atoms``.
 
-        The `i`th atom in the input cell is equivalent to the `orbits[i]`th atom in the **input**
-        cell. For example, orbits=[0, 0, 2, 2, 2, 2] means the first two atoms are equivalent
-        and the last four atoms are equivalent to each other.
+        The ``i``-th atom in the input cell is equivalent to the ``orbits[i]``-th atom in the
+        **input** cell. For example, ``orbits=[0, 0, 2, 2, 2, 2]`` means the first two atoms
+        are equivalent and the last four atoms are equivalent to each other.
         """
     @property
     def wyckoffs(self) -> list[str]:
@@ -121,16 +121,16 @@ class MoyoDataset:
     def mapping_std_prim(self) -> list[int]:
         """Mapping sites in the input cell to those in the primitive standardized cell.
 
-        The `i`th atom in the input cell is mapped to the `mapping_to_std_prim[i]`th atom in the
-        primitive standardized cell.
+        The ``i``-th atom in the input cell is mapped to the ``mapping_to_std_prim[i]``-th atom
+        in the primitive standardized cell.
         """
     # Final parameters
     @property
     def symprec(self) -> float:
-        """Actually used `symprec` in iterative symmetry search."""
+        """Actually used ``symprec`` in iterative symmetry search."""
     @property
     def angle_tolerance(self) -> float | None:
-        """Actually used `angle_tolerance` in iterative symmetry search."""
+        """Actually used ``angle_tolerance`` in iterative symmetry search."""
     # Serialization and deserialization
     def serialize_json(self) -> str:
         """Serialize an object to a JSON string."""
@@ -184,8 +184,8 @@ class MoyoCollinearMagneticDataset:
     # Site symmetry
     @property
     def orbits(self) -> list[int]:
-        """The `i`th atom in the input magnetic cell is equivalent to the `orbits[i]`th atom
-        in the **input** magnetic cell. For example, orbits=[0, 0, 2, 2, 2, 2] means
+        """The ``i``-th atom in the input magnetic cell is equivalent to the ``orbits[i]``-th
+        atom in the **input** magnetic cell. For example, ``orbits=[0, 0, 2, 2, 2, 2]`` means
         the first two atoms are equivalent and the last four atoms are equivalent to each other.
         """
     # Standardized magnetic cell
@@ -241,20 +241,22 @@ class MoyoCollinearMagneticDataset:
         standardized magnetic cell."""
     @property
     def mapping_std_prim(self) -> list[int]:
-        """Mapping sites in the input magnetic cell to those in the primitive standardized magnetic
-        cell. The `i`th atom in the input magnetic cell is mapped to the `mapping_to_std_prim[i]`th
-        atom in the primitive standardized magnetic cell.
+        """Mapping sites in the input magnetic cell to those in the primitive standardized
+        magnetic cell.
+
+        The ``i``-th atom in the input magnetic cell is mapped to the
+        ``mapping_to_std_prim[i]``-th atom in the primitive standardized magnetic cell.
         """
     # Final parameters
     @property
     def symprec(self) -> float:
-        """Actually used `symprec` in iterative symmetry search."""
+        """Actually used ``symprec`` in iterative symmetry search."""
     @property
     def angle_tolerance(self) -> float | None:
-        """Actually used `angle_tolerance` in iterative symmetry search."""
+        """Actually used ``angle_tolerance`` in iterative symmetry search."""
     @property
     def mag_symprec(self) -> float | None:
-        """Actually used `mag_symprec` in iterative symmetry search."""
+        """Actually used ``mag_symprec`` in iterative symmetry search."""
     # Serialization and deserialization
     def serialize_json(self) -> str:
         """Serialize an object to a JSON string."""
@@ -308,8 +310,8 @@ class MoyoNonCollinearMagneticDataset:
     # Site symmetry
     @property
     def orbits(self) -> list[int]:
-        """The `i`th atom in the input magnetic cell is equivalent to the `orbits[i]`th atom
-        in the **input** magnetic cell. For example, orbits=[0, 0, 2, 2, 2, 2] means
+        """The ``i``-th atom in the input magnetic cell is equivalent to the ``orbits[i]``-th
+        atom in the **input** magnetic cell. For example, ``orbits=[0, 0, 2, 2, 2, 2]`` means
         the first two atoms are equivalent and the last four atoms are equivalent to each other.
         """
     # Standardized magnetic cell
@@ -365,20 +367,22 @@ class MoyoNonCollinearMagneticDataset:
         standardized magnetic cell."""
     @property
     def mapping_std_prim(self) -> list[int]:
-        """Mapping sites in the input magnetic cell to those in the primitive standardized magnetic
-        cell. The `i`th atom in the input magnetic cell is mapped to the `mapping_to_std_prim[i]`th
-        atom in the primitive standardized magnetic cell.
+        """Mapping sites in the input magnetic cell to those in the primitive standardized
+        magnetic cell.
+
+        The ``i``-th atom in the input magnetic cell is mapped to the
+        ``mapping_to_std_prim[i]``-th atom in the primitive standardized magnetic cell.
         """
     # Final parameters
     @property
     def symprec(self) -> float:
-        """Actually used `symprec` in iterative symmetry search."""
+        """Actually used ``symprec`` in iterative symmetry search."""
     @property
     def angle_tolerance(self) -> float | None:
-        """Actually used `angle_tolerance` in iterative symmetry search."""
+        """Actually used ``angle_tolerance`` in iterative symmetry search."""
     @property
     def mag_symprec(self) -> float | None:
-        """Actually used `mag_symprec` in iterative symmetry search."""
+        """Actually used ``mag_symprec`` in iterative symmetry search."""
     # Serialization and deserialization
     def serialize_json(self) -> str:
         """Serialize an object to a JSON string."""

--- a/moyopy/python/moyopy/_identify.pyi
+++ b/moyopy/python/moyopy/_identify.pyi
@@ -4,20 +4,32 @@ from moyopy._base import UnimodularTransformation
 from moyopy._data import Setting
 
 class PointGroup:
-    def __init__(
-        self, prim_rotations: list[list[int]], *, basis: list[list[float]] | None = None
-    ): ...
+    """Point group identified from a list of rotation matrices."""
+    def __init__(self, prim_rotations: list[list[int]], *, basis: list[list[float]] | None = None):
+        """Identify the point group of the given primitive rotations.
+
+        Parameters
+        ----------
+        prim_rotations : list[list[list[int]]]
+            Rotation matrices in the primitive cell.
+        basis : list[list[float]] | None
+            Row-wise basis vectors of the primitive lattice. If ``None``, an identity basis
+            is assumed.
+        """
     @property
-    def arithmetic_number(self) -> int: ...
+    def arithmetic_number(self) -> int:
+        """Number for the arithmetic crystal class (1 - 73)."""
     @property
-    def prim_trans_mat(self) -> list[list[int]]: ...
+    def prim_trans_mat(self) -> list[list[int]]:
+        """Transformation matrix from the input primitive basis to the standardized basis."""
     # Serialization
     def serialize_json(self) -> str:
-        """Serialize an object to a JSON string"""
+        """Serialize this object to a JSON string."""
     def as_dict(self) -> dict[str, Any]:
-        """Convert an object to a dictionary"""
+        """Convert this object to a dictionary."""
 
 class SpaceGroup:
+    """Space group identified from a list of primitive symmetry operations."""
     def __init__(
         self,
         prim_rotations: list[list[int]],
@@ -26,22 +38,45 @@ class SpaceGroup:
         basis: list[list[float]] | None = None,
         setting: Setting | None = None,
         epsilon: float = 1e-4,
-    ): ...
+    ):
+        """Identify the space group from primitive rotations and translations.
+
+        Parameters
+        ----------
+        prim_rotations : list[list[list[int]]]
+            Rotation matrices of the symmetry operations of the primitive cell.
+        prim_translations : list[list[float]]
+            Translation vectors of the symmetry operations of the primitive cell.
+        basis : list[list[float]] | None
+            Row-wise basis vectors of the primitive lattice. If ``None``, an identity basis
+            is assumed.
+        setting : Setting | None
+            Preference for the standardized setting of the detected space-group type.
+        epsilon : float
+            Numerical tolerance for matching translations.
+        """
     @property
-    def number(self) -> int: ...
+    def number(self) -> int:
+        """ITA number for the identified space group (1 - 230)."""
     @property
-    def hall_number(self) -> int: ...
+    def hall_number(self) -> int:
+        """Hall symbol number (1 - 530) for the chosen setting."""
     @property
-    def linear(self) -> list[list[int]]: ...
+    def linear(self) -> list[list[int]]:
+        """Linear part of the transformation from the input primitive basis to the
+        standardized basis."""
     @property
-    def origin_shift(self) -> list[float]: ...
+    def origin_shift(self) -> list[float]:
+        """Origin shift of the transformation from the input primitive basis to the
+        standardized basis."""
     # Serialization
     def serialize_json(self) -> str:
-        """Serialize an object to a JSON string"""
+        """Serialize this object to a JSON string."""
     def as_dict(self) -> dict[str, Any]:
-        """Convert an object to a dictionary"""
+        """Convert this object to a dictionary."""
 
 class MagneticSpaceGroup:
+    """Magnetic space group identified from a list of primitive magnetic operations."""
     def __init__(
         self,
         prim_rotations: list[list[int]],
@@ -50,18 +85,39 @@ class MagneticSpaceGroup:
         *,
         basis: list[list[float]] | None = None,
         epsilon: float = 1e-4,
-    ): ...
+    ):
+        """Identify the magnetic space group from primitive magnetic operations.
+
+        Parameters
+        ----------
+        prim_rotations : list[list[list[int]]]
+            Rotation matrices of the magnetic operations of the primitive cell.
+        prim_translations : list[list[float]]
+            Translation vectors of the magnetic operations of the primitive cell.
+        prim_time_reversals : list[bool]
+            Time-reversal flag for each magnetic operation of the primitive cell.
+        basis : list[list[float]] | None
+            Row-wise basis vectors of the primitive lattice. If ``None``, an identity basis
+            is assumed.
+        epsilon : float
+            Numerical tolerance for matching translations.
+        """
     @property
-    def uni_number(self) -> int: ...
+    def uni_number(self) -> int:
+        """Serial number of UNI (and BNS) symbols."""
     @property
-    def linear(self) -> list[list[int]]: ...
+    def linear(self) -> list[list[int]]:
+        """Linear part of the transformation from the input primitive basis to the
+        standardized basis."""
     @property
-    def origin_shift(self) -> list[float]: ...
+    def origin_shift(self) -> list[float]:
+        """Origin shift of the transformation from the input primitive basis to the
+        standardized basis."""
     # Serialization
     def serialize_json(self) -> str:
-        """Serialize an object to a JSON string"""
+        """Serialize this object to a JSON string."""
     def as_dict(self) -> dict[str, Any]:
-        """Convert an object to a dictionary"""
+        """Convert this object to a dictionary."""
 
 def integral_normalizer(
     prim_rotations: list[list[list[int]]],
@@ -69,4 +125,20 @@ def integral_normalizer(
     *,
     prim_generators: list[int] | None = None,
     epsilon: float = 1e-4,
-) -> list[UnimodularTransformation]: ...
+) -> list[UnimodularTransformation]:
+    """Compute the integral normalizer of a space group.
+
+    Returns the unimodular transformations that conjugate the given space group into itself.
+
+    Parameters
+    ----------
+    prim_rotations : list[list[list[int]]]
+        Rotation matrices of the symmetry operations of the primitive cell.
+    prim_translations : list[list[float]]
+        Translation vectors of the symmetry operations of the primitive cell.
+    prim_generators : list[int] | None
+        Optional indices of operations to use as generators. If ``None``, a small generating
+        set is derived automatically.
+    epsilon : float
+        Numerical tolerance for matching translations.
+    """

--- a/moyopy/python/moyopy/_moyopy.pyi
+++ b/moyopy/python/moyopy/_moyopy.pyi
@@ -1,6 +1,7 @@
 from moyopy._base import (  # noqa: F401
     Cell,
     CollinearMagneticCell,
+    MagneticOperations,
     NonCollinearMagneticCell,
     Operations,
     UnimodularTransformation,
@@ -33,6 +34,7 @@ __all__ = [
     # base
     "Cell",
     "CollinearMagneticCell",
+    "MagneticOperations",
     "NonCollinearMagneticCell",
     "Operations",
     "UnimodularTransformation",

--- a/moyopy/src/base/cell.rs
+++ b/moyopy/src/base/cell.rs
@@ -8,7 +8,8 @@ use serde_json;
 use moyo::base::{Cell, Lattice};
 use moyo::utils::to_vector3;
 
-// Unfortunately, "PyCell" is already reversed by pyo3...
+/// A crystal structure: a lattice plus fractional positions and atomic numbers.
+// Note: `PyCell` is reserved by pyo3, so we name the wrapper `PyStructure`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[pyclass(name = "Cell", frozen, from_py_object)]
 #[pyo3(module = "moyopy")]
@@ -16,8 +17,17 @@ pub struct PyStructure(Cell);
 
 #[pymethods]
 impl PyStructure {
+    /// Create a new ``Cell``.
+    ///
+    /// Parameters
+    /// ----------
+    /// basis : list[list[float]]
+    ///     Row-wise basis vectors of the lattice. ``basis[i]`` is the i-th basis vector.
+    /// positions : list[list[float]]
+    ///     Fractional coordinates of each site.
+    /// numbers : list[int]
+    ///     Atomic number of each site. Must have the same length as ``positions``.
     #[new]
-    /// basis: row-wise basis vectors
     pub fn new(
         basis: [[f64; 3]; 3],
         positions: Vec<[f64; 3]>,
@@ -36,21 +46,25 @@ impl PyStructure {
         Ok(Self(cell))
     }
 
+    /// Row-wise basis vectors of the lattice.
     #[getter]
     pub fn basis(&self) -> [[f64; 3]; 3] {
         self.0.lattice.basis_as_array()
     }
 
+    /// Fractional coordinates of each site.
     #[getter]
     pub fn positions(&self) -> Vec<[f64; 3]> {
         self.0.positions_as_arrays()
     }
 
+    /// Atomic number of each site.
     #[getter]
     pub fn numbers(&self) -> Vec<i32> {
         self.0.numbers.clone()
     }
 
+    /// Number of atoms in the cell.
     #[getter]
     pub fn num_atoms(&self) -> usize {
         self.0.num_atoms()
@@ -70,15 +84,18 @@ impl PyStructure {
     // ------------------------------------------------------------------------
     // Serialization
     // ------------------------------------------------------------------------
+    /// Serialize this object to a JSON string.
     pub fn serialize_json(&self) -> String {
         serde_json::to_string(&self.0).expect("Serialization should not fail")
     }
 
+    /// Deserialize an object from a JSON string.
     #[classmethod]
     pub fn deserialize_json(_cls: &Bound<'_, PyType>, s: &str) -> PyResult<Self> {
         serde_json::from_str(s).map_err(|e| PyValueError::new_err(e.to_string()))
     }
 
+    /// Convert this object to a dictionary.
     pub fn as_dict(&self) -> PyResult<Py<PyAny>> {
         Python::attach(|py| {
             let obj = pythonize(py, &self.0).expect("Python object conversion should not fail");
@@ -86,6 +103,7 @@ impl PyStructure {
         })
     }
 
+    /// Create an object from a dictionary.
     #[classmethod]
     pub fn from_dict(_cls: &Bound<'_, PyType>, obj: &Bound<'_, PyAny>) -> PyResult<Self> {
         Python::attach(|_| {

--- a/moyopy/src/base/error.rs
+++ b/moyopy/src/base/error.rs
@@ -3,6 +3,7 @@ use pyo3::prelude::*;
 
 use moyo::base::MoyoError;
 
+/// Error returned by moyo when a symmetry analysis fails.
 #[derive(Debug)]
 #[pyclass(name = "MoyoError", frozen)]
 #[pyo3(module = "moyopy")]

--- a/moyopy/src/base/magnetic_cell.rs
+++ b/moyopy/src/base/magnetic_cell.rs
@@ -21,6 +21,7 @@ pub struct PyMagneticCell {
     magnetic_cell: MagneticCellEnum,
 }
 
+/// A crystal structure with collinear magnetic moments.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[pyclass(name = "CollinearMagneticCell", frozen, from_py_object)]
 #[pyo3(module = "moyopy")]
@@ -28,8 +29,19 @@ pub struct PyCollinearMagneticCell(MagneticCell<Collinear>);
 
 #[pymethods]
 impl PyCollinearMagneticCell {
+    /// Create a new ``CollinearMagneticCell``.
+    ///
+    /// Parameters
+    /// ----------
+    /// basis : list[list[float]]
+    ///     Row-wise basis vectors of the lattice.
+    /// positions : list[list[float]]
+    ///     Fractional coordinates of each site.
+    /// numbers : list[int]
+    ///     Atomic number of each site.
+    /// magnetic_moments : list[float]
+    ///     Scalar magnetic moment of each site (collinear).
     #[new]
-    /// basis: row-wise basis vectors
     pub fn new(
         basis: [[f64; 3]; 3],
         positions: Vec<[f64; 3]>,
@@ -55,26 +67,31 @@ impl PyCollinearMagneticCell {
         Ok(Self(magnetic_cell))
     }
 
+    /// Row-wise basis vectors of the lattice.
     #[getter]
     pub fn basis(&self) -> [[f64; 3]; 3] {
         self.0.cell.lattice.basis_as_array()
     }
 
+    /// Fractional coordinates of each site.
     #[getter]
     pub fn positions(&self) -> Vec<[f64; 3]> {
         self.0.cell.positions_as_arrays()
     }
 
+    /// Atomic number of each site.
     #[getter]
     pub fn numbers(&self) -> Vec<i32> {
         self.0.cell.numbers.clone()
     }
 
+    /// Scalar magnetic moment of each site.
     #[getter]
     pub fn magnetic_moments(&self) -> Vec<f64> {
         self.0.magnetic_moments.iter().map(|m| m.0).collect()
     }
 
+    /// Number of atoms in the magnetic cell.
     #[getter]
     pub fn num_atoms(&self) -> usize {
         self.0.num_atoms()
@@ -94,15 +111,18 @@ impl PyCollinearMagneticCell {
     // ------------------------------------------------------------------------
     // Serialization
     // ------------------------------------------------------------------------
+    /// Serialize this object to a JSON string.
     pub fn serialize_json(&self) -> String {
         serde_json::to_string(&self.0).expect("Serialization should not fail")
     }
 
+    /// Deserialize an object from a JSON string.
     #[classmethod]
     pub fn deserialize_json(_cls: &Bound<'_, PyType>, s: &str) -> PyResult<Self> {
         serde_json::from_str(s).map_err(|e| PyValueError::new_err(e.to_string()))
     }
 
+    /// Convert this object to a dictionary.
     pub fn as_dict(&self) -> PyResult<Py<PyAny>> {
         Python::attach(|py| {
             let obj = pythonize(py, &self.0).expect("Python object conversion should not fail");
@@ -110,6 +130,7 @@ impl PyCollinearMagneticCell {
         })
     }
 
+    /// Create an object from a dictionary.
     #[classmethod]
     pub fn from_dict(_cls: &Bound<'_, PyType>, obj: &Bound<'_, PyAny>) -> PyResult<Self> {
         Python::attach(|_| {
@@ -132,6 +153,7 @@ impl From<MagneticCell<Collinear>> for PyCollinearMagneticCell {
     }
 }
 
+/// A crystal structure with non-collinear (vector) magnetic moments.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[pyclass(name = "NonCollinearMagneticCell", frozen, from_py_object)]
 #[pyo3(module = "moyopy")]
@@ -139,8 +161,19 @@ pub struct PyNonCollinearMagneticCell(MagneticCell<NonCollinear>);
 
 #[pymethods]
 impl PyNonCollinearMagneticCell {
+    /// Create a new ``NonCollinearMagneticCell``.
+    ///
+    /// Parameters
+    /// ----------
+    /// basis : list[list[float]]
+    ///     Row-wise basis vectors of the lattice.
+    /// positions : list[list[float]]
+    ///     Fractional coordinates of each site.
+    /// numbers : list[int]
+    ///     Atomic number of each site.
+    /// magnetic_moments : list[list[float]]
+    ///     Three-component magnetic moment vector of each site.
     #[new]
-    /// basis: row-wise basis vectors
     pub fn new(
         basis: [[f64; 3]; 3],
         positions: Vec<[f64; 3]>,
@@ -169,21 +202,25 @@ impl PyNonCollinearMagneticCell {
         Ok(Self(magnetic_cell))
     }
 
+    /// Row-wise basis vectors of the lattice.
     #[getter]
     pub fn basis(&self) -> [[f64; 3]; 3] {
         self.0.cell.lattice.basis_as_array()
     }
 
+    /// Fractional coordinates of each site.
     #[getter]
     pub fn positions(&self) -> Vec<[f64; 3]> {
         self.0.cell.positions_as_arrays()
     }
 
+    /// Atomic number of each site.
     #[getter]
     pub fn numbers(&self) -> Vec<i32> {
         self.0.cell.numbers.clone()
     }
 
+    /// Three-component magnetic moment vector of each site.
     #[getter]
     pub fn magnetic_moments(&self) -> Vec<[f64; 3]> {
         self.0
@@ -193,6 +230,7 @@ impl PyNonCollinearMagneticCell {
             .collect()
     }
 
+    /// Number of atoms in the magnetic cell.
     #[getter]
     pub fn num_atoms(&self) -> usize {
         self.0.num_atoms()
@@ -212,15 +250,18 @@ impl PyNonCollinearMagneticCell {
     // ------------------------------------------------------------------------
     // Serialization
     // ------------------------------------------------------------------------
+    /// Serialize this object to a JSON string.
     pub fn serialize_json(&self) -> String {
         serde_json::to_string(&self.0).expect("Serialization should not fail")
     }
 
+    /// Deserialize an object from a JSON string.
     #[classmethod]
     pub fn deserialize_json(_cls: &Bound<'_, PyType>, s: &str) -> PyResult<Self> {
         serde_json::from_str(s).map_err(|e| PyValueError::new_err(e.to_string()))
     }
 
+    /// Convert this object to a dictionary.
     pub fn as_dict(&self) -> PyResult<Py<PyAny>> {
         Python::attach(|py| {
             let obj = pythonize(py, &self.0).expect("Python object conversion should not fail");
@@ -228,6 +269,7 @@ impl PyNonCollinearMagneticCell {
         })
     }
 
+    /// Create an object from a dictionary.
     #[classmethod]
     pub fn from_dict(_cls: &Bound<'_, PyType>, obj: &Bound<'_, PyAny>) -> PyResult<Self> {
         Python::attach(|_| {

--- a/moyopy/src/base/operation.rs
+++ b/moyopy/src/base/operation.rs
@@ -7,6 +7,7 @@ use serde_json;
 
 use moyo::base::{MagneticOperations, Operations, UnimodularTransformation};
 
+/// A list of crystallographic symmetry operations (rotation + translation).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[pyclass(name = "Operations", frozen, from_py_object)]
 #[pyo3(module = "moyopy")]
@@ -14,16 +15,19 @@ pub struct PyOperations(Operations);
 
 #[pymethods]
 impl PyOperations {
+    /// Rotation parts of the symmetry operations.
     #[getter]
     pub fn rotations(&self) -> Vec<[[i32; 3]; 3]> {
         self.0.iter().map(|x| x.rotation_as_array()).collect()
     }
 
+    /// Translation parts of the symmetry operations (fractional coordinates).
     #[getter]
     pub fn translations(&self) -> Vec<[f64; 3]> {
         self.0.iter().map(|x| x.translation_as_array()).collect()
     }
 
+    /// Number of symmetry operations.
     #[getter]
     pub fn num_operations(&self) -> usize {
         self.0.len()
@@ -47,15 +51,18 @@ impl PyOperations {
     // ------------------------------------------------------------------------
     // Serialization
     // ------------------------------------------------------------------------
+    /// Serialize this object to a JSON string.
     pub fn serialize_json(&self) -> String {
         serde_json::to_string(&self.0).expect("Serialization should not fail")
     }
 
+    /// Deserialize an object from a JSON string.
     #[classmethod]
     pub fn deserialize_json(_cls: &Bound<'_, PyType>, s: &str) -> PyResult<Self> {
         serde_json::from_str(s).map_err(|e| PyValueError::new_err(e.to_string()))
     }
 
+    /// Convert this object to a dictionary.
     pub fn as_dict(&self) -> PyResult<Py<PyAny>> {
         Python::attach(|py| {
             let obj = pythonize(py, &self.0).expect("Python object conversion should not fail");
@@ -63,6 +70,7 @@ impl PyOperations {
         })
     }
 
+    /// Create an object from a dictionary.
     #[classmethod]
     pub fn from_dict(_cls: &Bound<'_, PyType>, obj: &Bound<'_, PyAny>) -> PyResult<Self> {
         Python::attach(|_| {
@@ -85,6 +93,7 @@ impl From<Operations> for PyOperations {
     }
 }
 
+/// A list of magnetic symmetry operations (rotation + translation + time reversal).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[pyclass(name = "MagneticOperations", frozen, from_py_object)]
 #[pyo3(module = "moyopy")]
@@ -92,6 +101,7 @@ pub struct PyMagneticOperations(MagneticOperations);
 
 #[pymethods]
 impl PyMagneticOperations {
+    /// Rotation parts of the magnetic symmetry operations.
     #[getter]
     pub fn rotations(&self) -> Vec<[[i32; 3]; 3]> {
         self.0
@@ -100,6 +110,7 @@ impl PyMagneticOperations {
             .collect()
     }
 
+    /// Translation parts of the magnetic symmetry operations (fractional coordinates).
     #[getter]
     pub fn translations(&self) -> Vec<[f64; 3]> {
         self.0
@@ -108,11 +119,13 @@ impl PyMagneticOperations {
             .collect()
     }
 
+    /// Time-reversal flag for each magnetic symmetry operation.
     #[getter]
     pub fn time_reversals(&self) -> Vec<bool> {
         self.0.iter().map(|x| x.time_reversal).collect()
     }
 
+    /// Number of magnetic symmetry operations.
     #[getter]
     pub fn num_operations(&self) -> usize {
         self.0.len()
@@ -136,15 +149,18 @@ impl PyMagneticOperations {
     // ------------------------------------------------------------------------
     // Serialization
     // ------------------------------------------------------------------------
+    /// Serialize this object to a JSON string.
     pub fn serialize_json(&self) -> String {
         serde_json::to_string(&self.0).expect("Serialization should not fail")
     }
 
+    /// Deserialize an object from a JSON string.
     #[classmethod]
     pub fn deserialize_json(_cls: &Bound<'_, PyType>, s: &str) -> PyResult<Self> {
         serde_json::from_str(s).map_err(|e| PyValueError::new_err(e.to_string()))
     }
 
+    /// Convert this object to a dictionary.
     pub fn as_dict(&self) -> PyResult<Py<PyAny>> {
         Python::attach(|py| {
             let obj = pythonize(py, &self.0).expect("Python object conversion should not fail");
@@ -152,6 +168,7 @@ impl PyMagneticOperations {
         })
     }
 
+    /// Create an object from a dictionary.
     #[classmethod]
     pub fn from_dict(_cls: &Bound<'_, PyType>, obj: &Bound<'_, PyAny>) -> PyResult<Self> {
         Python::attach(|_| {
@@ -174,6 +191,8 @@ impl From<MagneticOperations> for PyMagneticOperations {
     }
 }
 
+/// A unimodular transformation: an integer linear part with determinant +-1 plus an origin
+/// shift.
 #[derive(Debug, Clone)]
 #[pyclass(name = "UnimodularTransformation", frozen, from_py_object)]
 #[pyo3(module = "moyopy")]
@@ -196,11 +215,13 @@ impl PyUnimodularTransformation {
 
 #[pymethods]
 impl PyUnimodularTransformation {
+    /// Linear part (integer 3x3 matrix with determinant +-1).
     #[getter]
     pub fn linear(&self) -> [[i32; 3]; 3] {
         self.0.linear_as_array()
     }
 
+    /// Origin shift (fractional coordinates).
     #[getter]
     pub fn origin_shift(&self) -> [f64; 3] {
         self.0.origin_shift_as_array()
@@ -214,10 +235,12 @@ impl PyUnimodularTransformation {
         self.__repr__()
     }
 
+    /// Serialize this object to a JSON string.
     pub fn serialize_json(&self) -> String {
         serde_json::to_string(&self.repr()).expect("Serialization should not fail")
     }
 
+    /// Convert this object to a dictionary.
     pub fn as_dict(&self) -> PyResult<Py<PyAny>> {
         Python::attach(|py| {
             let obj =

--- a/moyopy/src/data.rs
+++ b/moyopy/src/data.rs
@@ -21,6 +21,17 @@ use moyo::data::{
     magnetic_hall_symbol_entry,
 };
 
+/// Return symmetry operations for the given space-group ITA ``number``.
+///
+/// Parameters
+/// ----------
+/// number : int
+///     ITA number of the space group (1 - 230).
+/// setting : Setting, optional
+///     Setting of the space group. If ``None``, the spglib default is used.
+/// primitive : bool, optional
+///     If ``True``, return operations of the primitive cell; otherwise return operations
+///     of the conventional cell.
 #[pyfunction]
 #[pyo3(signature = (number, *, setting=None, primitive=false))]
 pub fn operations_from_number(
@@ -65,6 +76,15 @@ pub fn operations_from_number(
     Ok(PyOperations::from(operations))
 }
 
+/// Return magnetic symmetry operations for the given UNI number.
+///
+/// Parameters
+/// ----------
+/// uni_number : int
+///     UNI (and BNS) serial number of the magnetic space group.
+/// primitive : bool, optional
+///     If ``True``, return magnetic operations of the primitive cell; otherwise return
+///     operations of the conventional cell.
 #[pyfunction]
 #[pyo3(signature = (uni_number, *, primitive=false))]
 pub fn magnetic_operations_from_uni_number(

--- a/moyopy/src/data/arithmetic_crystal_class.rs
+++ b/moyopy/src/data/arithmetic_crystal_class.rs
@@ -7,21 +7,21 @@ use crate::base::PyMoyoError;
 use moyo::base::MoyoError;
 use moyo::data::{ArithmeticNumber, arithmetic_crystal_class_entry};
 
+/// Arithmetic crystal class information.
 #[derive(Debug, Clone, Serialize)]
 #[pyclass(name = "ArithmeticCrystalClass", frozen, from_py_object)]
 #[pyo3(module = "moyopy")]
 pub struct PyArithmeticCrystalClass {
-    // Arithmetic crystal class
+    /// Number for arithmetic crystal classes (1 - 73).
     #[pyo3(get)]
-    /// Number for arithmetic crystal classes (1 - 73)
     pub arithmetic_number: ArithmeticNumber,
-    /// Symbol for arithmetic crystal class
+    /// Symbol for arithmetic crystal class.
     #[pyo3(get)]
     pub symbol: &'static str,
-    /// Geometric crystal class
+    /// Geometric crystal class.
     #[pyo3(get)]
     pub geometric_crystal_class: String,
-    /// Bravais class
+    /// Bravais class.
     #[pyo3(get)]
     pub bravais_class: String,
 }
@@ -54,10 +54,12 @@ impl PyArithmeticCrystalClass {
     // ------------------------------------------------------------------------
     // Serialization
     // ------------------------------------------------------------------------
+    /// Serialize this object to a JSON string.
     pub fn serialize_json(&self) -> String {
         serde_json::to_string(&self).expect("Serialization should not fail")
     }
 
+    /// Convert this object to a dictionary.
     pub fn as_dict(&self) -> PyResult<Py<PyAny>> {
         Python::attach(|py| {
             let obj = pythonize(py, &self).expect("Python object conversion should not fail");

--- a/moyopy/src/data/centering.rs
+++ b/moyopy/src/data/centering.rs
@@ -6,6 +6,7 @@ use serde_json;
 use moyo::data::Centering;
 use moyo::utils::{to_3_slice, to_3x3_slice};
 
+/// Centering of a conventional cell.
 #[derive(Debug, Clone, Serialize)]
 #[pyclass(name = "Centering", frozen, from_py_object)]
 #[pyo3(module = "moyopy")]
@@ -13,16 +14,19 @@ pub struct PyCentering(pub Centering);
 
 #[pymethods]
 impl PyCentering {
+    /// Order of the centering.
     #[getter]
     pub fn order(&self) -> usize {
         self.0.order()
     }
 
+    /// Transformation matrix from a primitive cell to the conventional cell.
     #[getter]
     pub fn linear(&self) -> [[i32; 3]; 3] {
         to_3x3_slice(&self.0.linear())
     }
 
+    /// Unique lattice points (in fractional coordinates) of the conventional cell.
     #[getter]
     pub fn lattice_points(&self) -> Vec<[f64; 3]> {
         self.0.lattice_points().iter().map(to_3_slice).collect()
@@ -42,10 +46,12 @@ impl PyCentering {
     // ------------------------------------------------------------------------
     // Serialization
     // ------------------------------------------------------------------------
+    /// Serialize this object to a JSON string.
     pub fn serialize_json(&self) -> String {
         serde_json::to_string(&self).expect("Serialization should not fail")
     }
 
+    /// Convert this object to a dictionary.
     pub fn as_dict(&self) -> PyResult<Py<PyAny>> {
         Python::attach(|py| {
             let obj = pythonize(py, &self).expect("Python object conversion should not fail");

--- a/moyopy/src/data/hall_symbol.rs
+++ b/moyopy/src/data/hall_symbol.rs
@@ -9,6 +9,7 @@ use moyo::data::{ArithmeticNumber, HallNumber, HallSymbolEntry, Number, hall_sym
 
 use super::centering::PyCentering;
 
+/// An entry containing space-group information for a specified ``hall_number``.
 #[derive(Debug, Clone, Serialize)]
 #[pyclass(name = "HallSymbolEntry", frozen, from_py_object)]
 #[pyo3(module = "moyopy")]
@@ -22,41 +23,49 @@ impl PyHallSymbolEntry {
         Ok(Self(entry))
     }
 
+    /// Number for Hall symbols (1 - 530).
     #[getter]
     pub fn hall_number(&self) -> HallNumber {
         self.0.hall_number
     }
 
+    /// ITA number for space group types (1 - 230).
     #[getter]
     pub fn number(&self) -> Number {
         self.0.number
     }
 
+    /// Number for arithmetic crystal classes (1 - 73).
     #[getter]
     pub fn arithmetic_number(&self) -> ArithmeticNumber {
         self.0.arithmetic_number
     }
 
+    /// Setting.
     #[getter]
     pub fn setting(&self) -> &str {
         self.0.setting
     }
 
+    /// Hall symbol.
     #[getter]
     pub fn hall_symbol(&self) -> &str {
         self.0.hall_symbol
     }
 
+    /// Hermann-Mauguin symbol in short notation.
     #[getter]
     pub fn hm_short(&self) -> &str {
         self.0.hm_short
     }
 
+    /// Hermann-Mauguin symbol in full notation.
     #[getter]
     pub fn hm_full(&self) -> &str {
         self.0.hm_full
     }
 
+    /// Centering.
     #[getter]
     pub fn centering(&self) -> PyCentering {
         self.0.centering.into()
@@ -76,10 +85,12 @@ impl PyHallSymbolEntry {
     // ------------------------------------------------------------------------
     // Serialization
     // ------------------------------------------------------------------------
+    /// Serialize this object to a JSON string.
     pub fn serialize_json(&self) -> String {
         serde_json::to_string(&self).expect("Serialization should not fail")
     }
 
+    /// Convert this object to a dictionary.
     pub fn as_dict(&self) -> PyResult<Py<PyAny>> {
         Python::attach(|py| {
             let obj = pythonize(py, &self).expect("Python object conversion should not fail");

--- a/moyopy/src/data/magnetic_space_group_type.rs
+++ b/moyopy/src/data/magnetic_space_group_type.rs
@@ -8,8 +8,10 @@ use moyo::data::{
     ConstructType, MagneticSpaceGroupType, Number, UNINumber, get_magnetic_space_group_type,
 };
 
+/// Magnetic space-group type information.
 #[derive(Debug, Clone, Serialize)]
 #[pyclass(name = "MagneticSpaceGroupType", frozen, from_py_object)]
+#[pyo3(module = "moyopy")]
 pub struct PyMagneticSpaceGroupType(MagneticSpaceGroupType);
 
 #[pymethods]
@@ -22,31 +24,38 @@ impl PyMagneticSpaceGroupType {
         Ok(PyMagneticSpaceGroupType(magnetic_space_group_type))
     }
 
+    /// Serial number of UNI (and BNS) symbols.
     #[getter]
     pub fn uni_number(&self) -> UNINumber {
         self.0.uni_number
     }
 
+    /// Serial number in Litvin's `Magnetic group tables
+    /// <https://www.iucr.org/publ/978-0-9553602-2-0>`_.
     #[getter]
     pub fn litvin_number(&self) -> i32 {
         self.0.litvin_number
     }
 
+    /// BNS number, e.g. ``"151.32"``.
     #[getter]
     pub fn bns_number(&self) -> String {
         self.0.bns_number.to_string()
     }
 
+    /// OG number, e.g. ``"153.4.1270"``.
     #[getter]
     pub fn og_number(&self) -> String {
         self.0.og_number.to_string()
     }
 
+    /// ITA number for the reference space group in BNS setting.
     #[getter]
     pub fn number(&self) -> Number {
         self.0.number
     }
 
+    /// Construct type of the magnetic space group, from 1 to 4.
     #[getter]
     pub fn construct_type(&self) -> i32 {
         match self.0.construct_type {
@@ -71,10 +80,12 @@ impl PyMagneticSpaceGroupType {
     // ------------------------------------------------------------------------
     // Serialization
     // ------------------------------------------------------------------------
+    /// Serialize this object to a JSON string.
     pub fn serialize_json(&self) -> String {
         serde_json::to_string(&self).expect("Serialization should not fail")
     }
 
+    /// Convert this object to a dictionary.
     pub fn as_dict(&self) -> PyResult<Py<PyAny>> {
         Python::attach(|py| {
             let obj = pythonize(py, &self).expect("Python object conversion should not fail");

--- a/moyopy/src/data/setting.rs
+++ b/moyopy/src/data/setting.rs
@@ -6,6 +6,7 @@ use serde_json;
 
 use moyo::data::Setting;
 
+/// Preference for the setting of the space group.
 #[derive(Debug, Clone, Serialize)]
 #[pyclass(name = "Setting", frozen, from_py_object)]
 #[pyo3(module = "moyopy")]
@@ -13,16 +14,20 @@ pub struct PySetting(pub Setting);
 
 #[pymethods]
 impl PySetting {
+    /// The setting with the smallest Hall number.
     #[classmethod]
     pub fn spglib(_cls: &Bound<'_, PyType>) -> PyResult<Self> {
         Ok(Self(Setting::Spglib))
     }
 
+    /// Unique axis b, cell choice 1 for monoclinic, hexagonal axes for rhombohedral, and origin
+    /// choice 2 for centrosymmetric space groups.
     #[classmethod]
     pub fn standard(_cls: &Bound<'_, PyType>) -> PyResult<Self> {
         Ok(Self(Setting::Standard))
     }
 
+    /// Specific Hall number from 1 to 530.
     #[classmethod]
     pub fn hall_number(_cls: &Bound<'_, PyType>, hall_number: i32) -> PyResult<Self> {
         Ok(Self(Setting::HallNumber(hall_number)))
@@ -42,10 +47,12 @@ impl PySetting {
     // ------------------------------------------------------------------------
     // Serialization
     // ------------------------------------------------------------------------
+    /// Serialize this object to a JSON string.
     pub fn serialize_json(&self) -> String {
         serde_json::to_string(&self).expect("Serialization should not fail")
     }
 
+    /// Convert this object to a dictionary.
     pub fn as_dict(&self) -> PyResult<Py<PyAny>> {
         Python::attach(|py| {
             let obj = pythonize(py, &self).expect("Python object conversion should not fail");

--- a/moyopy/src/data/space_group_type.rs
+++ b/moyopy/src/data/space_group_type.rs
@@ -11,40 +11,60 @@ use moyo::data::{
 
 use crate::base::PyMoyoError;
 
+/// Space-group type information.
 #[derive(Debug, Clone, Serialize)]
 #[pyclass(name = "SpaceGroupType", frozen, from_py_object)]
+#[pyo3(module = "moyopy")]
 pub struct PySpaceGroupType {
     // Space group type
+    /// ITA number for space group types (1 - 230).
     #[pyo3(get)]
-    /// ITA number for space group types (1 - 230)
     number: Number,
-    /// Hermann-Mauguin symbol in short notation
+    /// Hermann-Mauguin symbol in short notation.
     #[pyo3(get)]
     hm_short: &'static str,
-    /// Hermann-Mauguin symbol in full notation
+    /// Hermann-Mauguin symbol in full notation.
     #[pyo3(get)]
     hm_full: &'static str,
     // Arithmetic crystal system
-    /// Number for arithmetic crystal classes (1 - 73)
+    /// Number for arithmetic crystal classes (1 - 73).
     #[pyo3(get)]
     arithmetic_number: ArithmeticNumber,
-    /// Symbol for arithmetic crystal class
+    /// Symbol for arithmetic crystal class.
+    ///
+    /// See <https://github.com/spglib/moyo/blob/main/moyo/src/data/arithmetic_crystal_class.rs>
+    /// for string values.
     #[pyo3(get)]
     arithmetic_symbol: &'static str,
     // Other classifications
-    /// Geometric crystal class
+    /// Geometric crystal class.
+    ///
+    /// See <https://github.com/spglib/moyo/blob/main/moyo/src/data/classification.rs>
+    /// for string values.
     #[pyo3(get)]
     geometric_crystal_class: String,
-    /// Crystal system
+    /// Crystal system.
+    ///
+    /// See <https://github.com/spglib/moyo/blob/main/moyo/src/data/classification.rs>
+    /// for string values.
     #[pyo3(get)]
     crystal_system: String,
-    /// Bravais class
+    /// Bravais class.
+    ///
+    /// See <https://github.com/spglib/moyo/blob/main/moyo/src/data/classification.rs>
+    /// for string values.
     #[pyo3(get)]
     bravais_class: String,
-    /// Lattice system
+    /// Lattice system.
+    ///
+    /// See <https://github.com/spglib/moyo/blob/main/moyo/src/data/classification.rs>
+    /// for string values.
     #[pyo3(get)]
     lattice_system: String,
-    /// Crystal family
+    /// Crystal family.
+    ///
+    /// See <https://github.com/spglib/moyo/blob/main/moyo/src/data/classification.rs>
+    /// for string values.
     #[pyo3(get)]
     crystal_family: String,
 }
@@ -99,10 +119,12 @@ impl PySpaceGroupType {
     // ------------------------------------------------------------------------
     // Serialization
     // ------------------------------------------------------------------------
+    /// Serialize this object to a JSON string.
     pub fn serialize_json(&self) -> String {
         serde_json::to_string(&self).expect("Serialization should not fail")
     }
 
+    /// Convert this object to a dictionary.
     pub fn as_dict(&self) -> PyResult<Py<PyAny>> {
         Python::attach(|py| {
             let obj = pythonize(py, &self).expect("Python object conversion should not fail");

--- a/moyopy/src/dataset/magnetic_space_group.rs
+++ b/moyopy/src/dataset/magnetic_space_group.rs
@@ -11,6 +11,7 @@ use crate::base::{
     PyCollinearMagneticCell, PyMagneticOperations, PyMoyoError, PyNonCollinearMagneticCell,
 };
 
+/// A dataset containing magnetic symmetry information of a collinear magnetic structure.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[pyclass(name = "MoyoCollinearMagneticDataset", frozen, from_py_object)]
 #[pyo3(module = "moyopy")]
@@ -18,6 +19,24 @@ pub struct PyMoyoCollinearMagneticDataset(MoyoMagneticDataset<Collinear>);
 
 #[pymethods]
 impl PyMoyoCollinearMagneticDataset {
+    /// Run magnetic symmetry analysis on a collinear magnetic structure.
+    ///
+    /// Parameters
+    /// ----------
+    /// magnetic_cell : CollinearMagneticCell
+    ///     Input collinear magnetic structure.
+    /// symprec : float
+    ///     Symmetry search tolerance in the unit of ``magnetic_cell.basis``.
+    /// angle_tolerance : float | None
+    ///     Symmetry search tolerance in radians.
+    /// mag_symprec : float | None
+    ///     Tolerance for matching magnetic moments. If ``None``, ``symprec`` is reused.
+    /// is_axial : bool
+    ///     If ``True``, magnetic moments transform as axial vectors. Defaults to ``False``
+    ///     for collinear moments.
+    /// rotate_basis : bool
+    ///     Whether to rotate the basis vectors of the input cell to those of the standardized
+    ///     cell.
     #[new]
     #[pyo3(signature = (magnetic_cell, *, symprec=1e-4, angle_tolerance=None, mag_symprec=None, is_axial=false, rotate_basis=true))]
     pub fn new(
@@ -53,7 +72,7 @@ impl PyMoyoCollinearMagneticDataset {
     // ------------------------------------------------------------------------
     // Magnetic space-group type
     // ------------------------------------------------------------------------
-
+    /// Serial number of UNI (and BNS) symbols.
     #[getter]
     pub fn uni_number(&self) -> i32 {
         self.0.uni_number
@@ -62,7 +81,7 @@ impl PyMoyoCollinearMagneticDataset {
     // ------------------------------------------------------------------------
     // Magnetic symmetry operations in the input cell
     // ------------------------------------------------------------------------
-
+    /// Magnetic symmetry operations in the input cell.
     #[getter]
     pub fn magnetic_operations(&self) -> PyMagneticOperations {
         self.0.magnetic_operations.clone().into()
@@ -71,7 +90,10 @@ impl PyMoyoCollinearMagneticDataset {
     // ------------------------------------------------------------------------
     // Site symmetry
     // ------------------------------------------------------------------------
-
+    /// Spglib's ``crystallographic_orbits``, not ``equivalent_atoms``.
+    ///
+    /// The ``i`` th atom in the input magnetic cell is equivalent to the ``orbits[i]`` th
+    /// atom in the **input** magnetic cell.
     #[getter]
     pub fn orbits(&self) -> Vec<usize> {
         self.0.orbits.clone()
@@ -80,22 +102,29 @@ impl PyMoyoCollinearMagneticDataset {
     // ------------------------------------------------------------------------
     // Standardized magnetic cell
     // ------------------------------------------------------------------------
-
+    /// Standardized magnetic cell.
+    ///
+    /// Same transformation convention as :attr:`MoyoDataset.std_cell`.
     #[getter]
     pub fn std_mag_cell(&self) -> PyCollinearMagneticCell {
         self.0.std_mag_cell.clone().into()
     }
 
+    /// Linear part of the transformation from the input cell to the standardized magnetic
+    /// cell.
     #[getter]
     pub fn std_linear(&self) -> [[f64; 3]; 3] {
         self.0.std_linear_as_array()
     }
 
+    /// Origin shift of the transformation from the input cell to the standardized magnetic
+    /// cell.
     #[getter]
     pub fn std_origin_shift(&self) -> [f64; 3] {
         self.0.std_origin_shift_as_array()
     }
 
+    /// Rigid rotation (orthogonal matrix) applied to the lattice basis.
     #[getter]
     pub fn std_rotation_matrix(&self) -> [[f64; 3]; 3] {
         self.0.std_rotation_matrix_as_array()
@@ -104,22 +133,28 @@ impl PyMoyoCollinearMagneticDataset {
     // ------------------------------------------------------------------------
     // Primitive standardized magnetic cell
     // ------------------------------------------------------------------------
-
+    /// Primitive standardized magnetic cell.
     #[getter]
     pub fn prim_std_mag_cell(&self) -> PyCollinearMagneticCell {
         self.0.prim_std_mag_cell.clone().into()
     }
 
+    /// Linear part of the transformation from the input cell to the primitive standardized
+    /// magnetic cell.
     #[getter]
     pub fn prim_std_linear(&self) -> [[f64; 3]; 3] {
         self.0.prim_std_linear_as_array()
     }
 
+    /// Origin shift of the transformation from the input cell to the primitive standardized
+    /// magnetic cell.
     #[getter]
     pub fn prim_std_origin_shift(&self) -> [f64; 3] {
         self.0.prim_std_origin_shift_as_array()
     }
 
+    /// Mapping of sites in the input magnetic cell to those in the primitive standardized
+    /// magnetic cell.
     #[getter]
     pub fn mapping_std_prim(&self) -> Vec<usize> {
         self.0.mapping_std_prim.clone()
@@ -128,12 +163,13 @@ impl PyMoyoCollinearMagneticDataset {
     // ------------------------------------------------------------------------
     // Final parameters
     // ------------------------------------------------------------------------
-
+    /// Actual ``symprec`` used in iterative symmetry search.
     #[getter]
     pub fn symprec(&self) -> f64 {
         self.0.symprec
     }
 
+    /// Actual ``angle_tolerance`` used in iterative symmetry search.
     #[getter]
     pub fn angle_tolerance(&self) -> Option<f64> {
         if let AngleTolerance::Radian(angle_tolerance) = self.0.angle_tolerance {
@@ -143,6 +179,7 @@ impl PyMoyoCollinearMagneticDataset {
         }
     }
 
+    /// Actual ``mag_symprec`` used in iterative magnetic-moment matching.
     #[getter]
     pub fn mag_symprec(&self) -> f64 {
         self.0.mag_symprec
@@ -167,15 +204,18 @@ impl PyMoyoCollinearMagneticDataset {
     // ------------------------------------------------------------------------
     // Serialization
     // ------------------------------------------------------------------------
+    /// Serialize this object to a JSON string.
     pub fn serialize_json(&self) -> String {
         serde_json::to_string(&self.0).expect("Serialization should not fail")
     }
 
+    /// Deserialize an object from a JSON string.
     #[classmethod]
     pub fn deserialize_json(_cls: &Bound<'_, PyType>, s: &str) -> PyResult<Self> {
         serde_json::from_str(s).map_err(|e| PyValueError::new_err(e.to_string()))
     }
 
+    /// Convert this object to a dictionary.
     pub fn as_dict(&self) -> PyResult<Py<PyAny>> {
         Python::attach(|py| {
             let obj = pythonize(py, &self.0).expect("Python object conversion should not fail");
@@ -183,6 +223,7 @@ impl PyMoyoCollinearMagneticDataset {
         })
     }
 
+    /// Create an object from a dictionary.
     #[classmethod]
     pub fn from_dict(_cls: &Bound<'_, PyType>, obj: &Bound<'_, PyAny>) -> PyResult<Self> {
         Python::attach(|_| {
@@ -193,6 +234,7 @@ impl PyMoyoCollinearMagneticDataset {
     }
 }
 
+/// A dataset containing magnetic symmetry information of a non-collinear magnetic structure.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[pyclass(name = "MoyoNonCollinearMagneticDataset", frozen, from_py_object)]
 #[pyo3(module = "moyopy")]
@@ -200,6 +242,24 @@ pub struct PyMoyoNonCollinearMagneticDataset(MoyoMagneticDataset<NonCollinear>);
 
 #[pymethods]
 impl PyMoyoNonCollinearMagneticDataset {
+    /// Run magnetic symmetry analysis on a non-collinear magnetic structure.
+    ///
+    /// Parameters
+    /// ----------
+    /// magnetic_cell : NonCollinearMagneticCell
+    ///     Input non-collinear magnetic structure.
+    /// symprec : float
+    ///     Symmetry search tolerance in the unit of ``magnetic_cell.basis``.
+    /// angle_tolerance : float | None
+    ///     Symmetry search tolerance in radians.
+    /// mag_symprec : float | None
+    ///     Tolerance for matching magnetic moments. If ``None``, ``symprec`` is reused.
+    /// is_axial : bool
+    ///     If ``True``, magnetic moments transform as axial vectors. Defaults to ``True`` for
+    ///     non-collinear moments.
+    /// rotate_basis : bool
+    ///     Whether to rotate the basis vectors of the input cell to those of the standardized
+    ///     cell.
     #[new]
     #[pyo3(signature = (magnetic_cell, *, symprec=1e-4, angle_tolerance=None, mag_symprec=None, is_axial=true, rotate_basis=true))]
     pub fn new(
@@ -235,7 +295,7 @@ impl PyMoyoNonCollinearMagneticDataset {
     // ------------------------------------------------------------------------
     // Magnetic space-group type
     // ------------------------------------------------------------------------
-
+    /// Serial number of UNI (and BNS) symbols.
     #[getter]
     pub fn uni_number(&self) -> i32 {
         self.0.uni_number
@@ -244,7 +304,7 @@ impl PyMoyoNonCollinearMagneticDataset {
     // ------------------------------------------------------------------------
     // Magnetic symmetry operations in the input cell
     // ------------------------------------------------------------------------
-
+    /// Magnetic symmetry operations in the input cell.
     #[getter]
     pub fn magnetic_operations(&self) -> PyMagneticOperations {
         self.0.magnetic_operations.clone().into()
@@ -253,7 +313,7 @@ impl PyMoyoNonCollinearMagneticDataset {
     // ------------------------------------------------------------------------
     // Site symmetry
     // ------------------------------------------------------------------------
-
+    /// Spglib's ``crystallographic_orbits``, not ``equivalent_atoms``.
     #[getter]
     pub fn orbits(&self) -> Vec<usize> {
         self.0.orbits.clone()
@@ -262,22 +322,27 @@ impl PyMoyoNonCollinearMagneticDataset {
     // ------------------------------------------------------------------------
     // Standardized magnetic cell
     // ------------------------------------------------------------------------
-
+    /// Standardized magnetic cell.
     #[getter]
     pub fn std_mag_cell(&self) -> PyNonCollinearMagneticCell {
         self.0.std_mag_cell.clone().into()
     }
 
+    /// Linear part of the transformation from the input cell to the standardized magnetic
+    /// cell.
     #[getter]
     pub fn std_linear(&self) -> [[f64; 3]; 3] {
         self.0.std_linear_as_array()
     }
 
+    /// Origin shift of the transformation from the input cell to the standardized magnetic
+    /// cell.
     #[getter]
     pub fn std_origin_shift(&self) -> [f64; 3] {
         self.0.std_origin_shift_as_array()
     }
 
+    /// Rigid rotation (orthogonal matrix) applied to the lattice basis.
     #[getter]
     pub fn std_rotation_matrix(&self) -> [[f64; 3]; 3] {
         self.0.std_rotation_matrix_as_array()
@@ -286,22 +351,28 @@ impl PyMoyoNonCollinearMagneticDataset {
     // ------------------------------------------------------------------------
     // Primitive standardized magnetic cell
     // ------------------------------------------------------------------------
-
+    /// Primitive standardized magnetic cell.
     #[getter]
     pub fn prim_std_mag_cell(&self) -> PyNonCollinearMagneticCell {
         self.0.prim_std_mag_cell.clone().into()
     }
 
+    /// Linear part of the transformation from the input cell to the primitive standardized
+    /// magnetic cell.
     #[getter]
     pub fn prim_std_linear(&self) -> [[f64; 3]; 3] {
         self.0.prim_std_linear_as_array()
     }
 
+    /// Origin shift of the transformation from the input cell to the primitive standardized
+    /// magnetic cell.
     #[getter]
     pub fn prim_std_origin_shift(&self) -> [f64; 3] {
         self.0.prim_std_origin_shift_as_array()
     }
 
+    /// Mapping of sites in the input magnetic cell to those in the primitive standardized
+    /// magnetic cell.
     #[getter]
     pub fn mapping_std_prim(&self) -> Vec<usize> {
         self.0.mapping_std_prim.clone()
@@ -310,12 +381,13 @@ impl PyMoyoNonCollinearMagneticDataset {
     // ------------------------------------------------------------------------
     // Final parameters
     // ------------------------------------------------------------------------
-
+    /// Actual ``symprec`` used in iterative symmetry search.
     #[getter]
     pub fn symprec(&self) -> f64 {
         self.0.symprec
     }
 
+    /// Actual ``angle_tolerance`` used in iterative symmetry search.
     #[getter]
     pub fn angle_tolerance(&self) -> Option<f64> {
         if let AngleTolerance::Radian(angle_tolerance) = self.0.angle_tolerance {
@@ -325,6 +397,7 @@ impl PyMoyoNonCollinearMagneticDataset {
         }
     }
 
+    /// Actual ``mag_symprec`` used in iterative magnetic-moment matching.
     #[getter]
     pub fn mag_symprec(&self) -> f64 {
         self.0.mag_symprec
@@ -349,15 +422,18 @@ impl PyMoyoNonCollinearMagneticDataset {
     // ------------------------------------------------------------------------
     // Serialization
     // ------------------------------------------------------------------------
+    /// Serialize this object to a JSON string.
     pub fn serialize_json(&self) -> String {
         serde_json::to_string(&self.0).expect("Serialization should not fail")
     }
 
+    /// Deserialize an object from a JSON string.
     #[classmethod]
     pub fn deserialize_json(_cls: &Bound<'_, PyType>, s: &str) -> PyResult<Self> {
         serde_json::from_str(s).map_err(|e| PyValueError::new_err(e.to_string()))
     }
 
+    /// Convert this object to a dictionary.
     pub fn as_dict(&self) -> PyResult<Py<PyAny>> {
         Python::attach(|py| {
             let obj = pythonize(py, &self.0).expect("Python object conversion should not fail");
@@ -365,6 +441,7 @@ impl PyMoyoNonCollinearMagneticDataset {
         })
     }
 
+    /// Create an object from a dictionary.
     #[classmethod]
     pub fn from_dict(_cls: &Bound<'_, PyType>, obj: &Bound<'_, PyAny>) -> PyResult<Self> {
         Python::attach(|_| {

--- a/moyopy/src/dataset/space_group.rs
+++ b/moyopy/src/dataset/space_group.rs
@@ -11,6 +11,7 @@ use moyo::data::Setting;
 use crate::base::{PyMoyoError, PyOperations, PyStructure};
 use crate::data::PySetting;
 
+/// A dataset containing symmetry information of the input crystal structure.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[pyclass(name = "MoyoDataset", frozen, from_py_object)]
 #[pyo3(module = "moyopy")]
@@ -18,6 +19,21 @@ pub struct PyMoyoDataset(MoyoDataset);
 
 #[pymethods]
 impl PyMoyoDataset {
+    /// Run symmetry analysis on a crystal structure.
+    ///
+    /// Parameters
+    /// ----------
+    /// cell : Cell
+    ///     Input crystal structure.
+    /// symprec : float
+    ///     Symmetry search tolerance in the unit of ``cell.basis``.
+    /// angle_tolerance : float | None
+    ///     Symmetry search tolerance in radians.
+    /// setting : Setting | None
+    ///     Preference for the setting of the space group.
+    /// rotate_basis : bool
+    ///     Whether to rotate the basis vectors of the input cell to those of the standardized
+    ///     cell.
     #[new]
     #[pyo3(signature = (cell, *, symprec=1e-4, angle_tolerance=None, setting=None, rotate_basis=true))]
     pub fn new(
@@ -52,11 +68,13 @@ impl PyMoyoDataset {
     // ------------------------------------------------------------------------
     // Identification
     // ------------------------------------------------------------------------
+    /// Space group number.
     #[getter]
     pub fn number(&self) -> i32 {
         self.0.number
     }
 
+    /// Hall symbol number.
     #[getter]
     pub fn hall_number(&self) -> i32 {
         self.0.hall_number
@@ -65,6 +83,7 @@ impl PyMoyoDataset {
     // ------------------------------------------------------------------------
     // Symmetry operations in the input cell
     // ------------------------------------------------------------------------
+    /// Symmetry operations in the input cell.
     #[getter]
     pub fn operations(&self) -> PyOperations {
         self.0.operations.clone().into()
@@ -73,16 +92,25 @@ impl PyMoyoDataset {
     // ------------------------------------------------------------------------
     // Site symmetry
     // ------------------------------------------------------------------------
+    /// Spglib's ``crystallographic_orbits``, not ``equivalent_atoms``.
+    ///
+    /// The ``i`` th atom in the input cell is equivalent to the ``orbits[i]`` th atom in the
+    /// **input** cell. For example, ``orbits = [0, 0, 2, 2, 2, 2]`` means the first two atoms
+    /// are equivalent and the last four atoms are equivalent to each other.
     #[getter]
     pub fn orbits(&self) -> Vec<usize> {
         self.0.orbits.clone()
     }
 
+    /// Wyckoff letters for each site in the input cell.
     #[getter]
     pub fn wyckoffs(&self) -> Vec<char> {
         self.0.wyckoffs.clone()
     }
 
+    /// Site symmetry symbols for each site in the input cell.
+    ///
+    /// The orientation of the site symmetry is with respect to the standardized cell.
     #[getter]
     pub fn site_symmetry_symbols(&self) -> Vec<String> {
         self.0.site_symmetry_symbols.clone()
@@ -91,26 +119,42 @@ impl PyMoyoDataset {
     // ------------------------------------------------------------------------
     // Standardized cell
     // ------------------------------------------------------------------------
+    /// Standardized cell.
+    ///
+    /// The input cell is related to the standardized cell by ``(std_linear, std_origin_shift)``
+    /// and ``std_rotation_matrix``:
+    ///
+    /// ```text
+    /// std_cell.basis.T = std_rotation_matrix @ cell.basis.T @ std_linear
+    /// x_std = np.linalg.inv(std_linear) @ (x_input - std_origin_shift)
+    /// ```
+    ///
+    /// ``std_rotation_matrix`` is a rigid rotation (orthogonal matrix) applied only to the
+    /// Cartesian lattice basis. It does not affect fractional coordinates.
     #[getter]
     pub fn std_cell(&self) -> PyStructure {
         self.0.std_cell.clone().into()
     }
 
+    /// Linear part of the transformation from the input cell to the standardized cell.
     #[getter]
     pub fn std_linear(&self) -> [[f64; 3]; 3] {
         self.0.std_linear_as_array()
     }
 
+    /// Origin shift of the transformation from the input cell to the standardized cell.
     #[getter]
     pub fn std_origin_shift(&self) -> [f64; 3] {
         self.0.std_origin_shift_as_array()
     }
 
+    /// Rigid rotation (orthogonal matrix) applied to the lattice basis.
     #[getter]
     pub fn std_rotation_matrix(&self) -> [[f64; 3]; 3] {
         self.0.std_rotation_matrix_as_array()
     }
 
+    /// Pearson symbol for the standardized cell.
     #[getter]
     pub fn pearson_symbol(&self) -> String {
         self.0.pearson_symbol.clone()
@@ -119,21 +163,37 @@ impl PyMoyoDataset {
     // ------------------------------------------------------------------------
     // Primitive standardized cell
     // ------------------------------------------------------------------------
+    /// Primitive standardized cell.
+    ///
+    /// Same transformation convention as the standardized cell:
+    ///
+    /// ```text
+    /// prim_std_cell.basis.T = std_rotation_matrix @ cell.basis.T @ prim_std_linear
+    /// x_prim_std = np.linalg.inv(prim_std_linear) @ (x_input - prim_std_origin_shift)
+    /// ```
     #[getter]
     pub fn prim_std_cell(&self) -> PyStructure {
         self.0.prim_std_cell.clone().into()
     }
 
+    /// Linear part of the transformation from the input cell to the primitive standardized
+    /// cell.
     #[getter]
     pub fn prim_std_linear(&self) -> [[f64; 3]; 3] {
         self.0.prim_std_linear_as_array()
     }
 
+    /// Origin shift of the transformation from the input cell to the primitive standardized
+    /// cell.
     #[getter]
     pub fn prim_std_origin_shift(&self) -> [f64; 3] {
         self.0.prim_std_origin_shift_as_array()
     }
 
+    /// Mapping of sites in the input cell to those in the primitive standardized cell.
+    ///
+    /// The ``i`` th atom in the input cell is mapped to the ``mapping_std_prim[i]`` th atom in
+    /// the primitive standardized cell.
     #[getter]
     pub fn mapping_std_prim(&self) -> Vec<usize> {
         self.0.mapping_std_prim.clone()
@@ -142,11 +202,13 @@ impl PyMoyoDataset {
     // ------------------------------------------------------------------------
     // Final parameters
     // ------------------------------------------------------------------------
+    /// Actual ``symprec`` used in iterative symmetry search.
     #[getter]
     pub fn symprec(&self) -> f64 {
         self.0.symprec
     }
 
+    /// Actual ``angle_tolerance`` used in iterative symmetry search.
     #[getter]
     pub fn angle_tolerance(&self) -> Option<f64> {
         if let AngleTolerance::Radian(angle_tolerance) = self.0.angle_tolerance {
@@ -178,15 +240,18 @@ impl PyMoyoDataset {
     // ------------------------------------------------------------------------
     // Serialization
     // ------------------------------------------------------------------------
+    /// Serialize this object to a JSON string.
     pub fn serialize_json(&self) -> String {
         serde_json::to_string(&self.0).expect("Serialization should not fail")
     }
 
+    /// Deserialize an object from a JSON string.
     #[classmethod]
     pub fn deserialize_json(_cls: &Bound<'_, PyType>, s: &str) -> PyResult<Self> {
         serde_json::from_str(s).map_err(|e| PyValueError::new_err(e.to_string()))
     }
 
+    /// Convert this object to a dictionary.
     pub fn as_dict(&self) -> PyResult<Py<PyAny>> {
         Python::attach(|py| {
             let obj = pythonize(py, &self.0).expect("Python object conversion should not fail");
@@ -194,6 +259,7 @@ impl PyMoyoDataset {
         })
     }
 
+    /// Create an object from a dictionary.
     #[classmethod]
     pub fn from_dict(_cls: &Bound<'_, PyType>, obj: &Bound<'_, PyAny>) -> PyResult<Self> {
         Python::attach(|_| {

--- a/moyopy/src/identify.rs
+++ b/moyopy/src/identify.rs
@@ -78,6 +78,21 @@ fn derive_small_generators(prim_operations: &[Operation]) -> PyResult<Vec<Operat
     Ok(generators)
 }
 
+/// Compute the integral normalizer of a space group.
+///
+/// Returns the unimodular transformations that conjugate the given space group into itself.
+///
+/// Parameters
+/// ----------
+/// prim_rotations : list[list[list[int]]]
+///     Rotation matrices of the symmetry operations of the primitive cell.
+/// prim_translations : list[list[float]]
+///     Translation vectors of the symmetry operations of the primitive cell.
+/// prim_generators : list[int] | None
+///     Optional indices of operations to use as generators. If ``None``, a small generating
+///     set is derived automatically.
+/// epsilon : float
+///     Numerical tolerance for matching translations.
 #[pyfunction]
 #[pyo3(signature = (prim_rotations, prim_translations, *, prim_generators=None, epsilon=1e-4))]
 pub fn integral_normalizer(
@@ -124,6 +139,7 @@ pub fn integral_normalizer(
     )
 }
 
+/// Point group identified from a list of rotation matrices.
 #[derive(Debug, Clone, Serialize)]
 #[pyclass(name = "PointGroup", frozen, from_py_object)]
 #[pyo3(module = "moyopy")]
@@ -131,6 +147,15 @@ pub struct PyPointGroup(PointGroup);
 
 #[pymethods]
 impl PyPointGroup {
+    /// Identify the point group of the given primitive rotations.
+    ///
+    /// Parameters
+    /// ----------
+    /// prim_rotations : list[list[list[int]]]
+    ///     Rotation matrices in the primitive cell.
+    /// basis : list[list[float]] | None
+    ///     Row-wise basis vectors of the primitive lattice. If ``None``, an identity basis
+    ///     is assumed.
     #[new]
     #[pyo3(signature = (prim_rotations, *, basis=None))]
     pub fn new(
@@ -148,11 +173,13 @@ impl PyPointGroup {
         Ok(Self(point_group))
     }
 
+    /// Number for the arithmetic crystal class (1 - 73).
     #[getter]
     pub fn arithmetic_number(&self) -> ArithmeticNumber {
         self.0.arithmetic_number
     }
 
+    /// Transformation matrix from the input primitive basis to the standardized basis.
     #[getter]
     pub fn prim_trans_mat(&self) -> [[i32; 3]; 3] {
         to_3x3_slice(&self.0.prim_trans_mat)
@@ -172,10 +199,12 @@ impl PyPointGroup {
     // ------------------------------------------------------------------------
     // Serialization
     // ------------------------------------------------------------------------
+    /// Serialize this object to a JSON string.
     pub fn serialize_json(&self) -> String {
         serde_json::to_string(&self).expect("Serialization should not fail")
     }
 
+    /// Convert this object to a dictionary.
     pub fn as_dict(&self) -> PyResult<Py<PyAny>> {
         Python::attach(|py| {
             let obj = pythonize(py, &self).expect("Python object conversion should not fail");
@@ -196,6 +225,7 @@ impl From<PointGroup> for PyPointGroup {
     }
 }
 
+/// Space group identified from a list of primitive symmetry operations.
 #[derive(Debug, Clone, Serialize)]
 #[pyclass(name = "SpaceGroup", frozen, from_py_object)]
 #[pyo3(module = "moyopy")]
@@ -203,6 +233,21 @@ pub struct PySpaceGroup(SpaceGroup);
 
 #[pymethods]
 impl PySpaceGroup {
+    /// Identify the space group from primitive rotations and translations.
+    ///
+    /// Parameters
+    /// ----------
+    /// prim_rotations : list[list[list[int]]]
+    ///     Rotation matrices of the symmetry operations of the primitive cell.
+    /// prim_translations : list[list[float]]
+    ///     Translation vectors of the symmetry operations of the primitive cell.
+    /// basis : list[list[float]] | None
+    ///     Row-wise basis vectors of the primitive lattice. If ``None``, an identity basis
+    ///     is assumed.
+    /// setting : Setting | None
+    ///     Preference for the standardized setting of the detected space-group type.
+    /// epsilon : float
+    ///     Numerical tolerance for matching translations.
     #[new]
     #[pyo3(signature = (prim_rotations, prim_translations, *, basis=None, setting=None, epsilon=1e-4))]
     pub fn new(
@@ -233,21 +278,27 @@ impl PySpaceGroup {
         Ok(Self(space_group))
     }
 
+    /// ITA number for the identified space group (1 - 230).
     #[getter]
     pub fn number(&self) -> Number {
         self.0.number
     }
 
+    /// Hall symbol number (1 - 530) for the chosen setting.
     #[getter]
     pub fn hall_number(&self) -> HallNumber {
         self.0.hall_number
     }
 
+    /// Linear part of the transformation from the input primitive basis to the standardized
+    /// basis.
     #[getter]
     pub fn linear(&self) -> [[i32; 3]; 3] {
         self.0.transformation.linear_as_array()
     }
 
+    /// Origin shift of the transformation from the input primitive basis to the standardized
+    /// basis.
     #[getter]
     pub fn origin_shift(&self) -> [f64; 3] {
         self.0.transformation.origin_shift_as_array()
@@ -267,10 +318,12 @@ impl PySpaceGroup {
     // ------------------------------------------------------------------------
     // Serialization
     // ------------------------------------------------------------------------
+    /// Serialize this object to a JSON string.
     pub fn serialize_json(&self) -> String {
         serde_json::to_string(&self).expect("Serialization should not fail")
     }
 
+    /// Convert this object to a dictionary.
     pub fn as_dict(&self) -> PyResult<Py<PyAny>> {
         Python::attach(|py| {
             let obj = pythonize(py, &self).expect("Python object conversion should not fail");
@@ -291,6 +344,7 @@ impl From<SpaceGroup> for PySpaceGroup {
     }
 }
 
+/// Magnetic space group identified from a list of primitive magnetic operations.
 #[derive(Debug, Clone, Serialize)]
 #[pyclass(name = "MagneticSpaceGroup", frozen, from_py_object)]
 #[pyo3(module = "moyopy")]
@@ -298,6 +352,21 @@ pub struct PyMagneticSpaceGroup(MagneticSpaceGroup);
 
 #[pymethods]
 impl PyMagneticSpaceGroup {
+    /// Identify the magnetic space group from primitive magnetic operations.
+    ///
+    /// Parameters
+    /// ----------
+    /// prim_rotations : list[list[list[int]]]
+    ///     Rotation matrices of the magnetic operations of the primitive cell.
+    /// prim_translations : list[list[float]]
+    ///     Translation vectors of the magnetic operations of the primitive cell.
+    /// prim_time_reversals : list[bool]
+    ///     Time-reversal flag for each magnetic operation of the primitive cell.
+    /// basis : list[list[float]] | None
+    ///     Row-wise basis vectors of the primitive lattice. If ``None``, an identity basis
+    ///     is assumed.
+    /// epsilon : float
+    ///     Numerical tolerance for matching translations.
     #[new]
     #[pyo3(signature = (prim_rotations, prim_translations, prim_time_reversals, *, basis=None, epsilon=1e-4))]
     pub fn new(
@@ -325,16 +394,21 @@ impl PyMagneticSpaceGroup {
         Ok(Self(magnetic_space_group))
     }
 
+    /// Serial number of UNI (and BNS) symbols.
     #[getter]
     pub fn uni_number(&self) -> UNINumber {
         self.0.uni_number
     }
 
+    /// Linear part of the transformation from the input primitive basis to the standardized
+    /// basis.
     #[getter]
     pub fn linear(&self) -> [[i32; 3]; 3] {
         self.0.transformation.linear_as_array()
     }
 
+    /// Origin shift of the transformation from the input primitive basis to the standardized
+    /// basis.
     #[getter]
     pub fn origin_shift(&self) -> [f64; 3] {
         self.0.transformation.origin_shift_as_array()
@@ -354,10 +428,12 @@ impl PyMagneticSpaceGroup {
     // ------------------------------------------------------------------------
     // Serialization
     // ------------------------------------------------------------------------
+    /// Serialize this object to a JSON string.
     pub fn serialize_json(&self) -> String {
         serde_json::to_string(&self).expect("Serialization should not fail")
     }
 
+    /// Convert this object to a dictionary.
     pub fn as_dict(&self) -> PyResult<Py<PyAny>> {
         Python::attach(|py| {
             let obj = pythonize(py, &self).expect("Python object conversion should not fail");


### PR DESCRIPTION
## Summary

- Adds `///` doc comments to every PyO3-exposed class, method, getter, and free function in `moyopy/src/`. PyO3 forwards them to Python `__doc__`, so `help(MoyoDataset)`, `MoyoDataset.std_cell.__doc__`, and IDE hover now show real documentation instead of being empty. Also enriches `_identify.pyi` and `_base.pyi` so static type-checker tooltips match.
- Replaces the star import in `moyopy/__init__.py` with explicit imports + `__all__`, and adds the previously-missing `MagneticOperations` to `_moyopy.pyi`. Lets static-analysis tools (autoapi, mypy, Pyright) resolve `moyopy.X` cleanly.
- Groups the rendered API Reference into five thematic sections (Crystal structures, Symmetry datasets, Crystallographic data, Group identification, Adapters) mirroring the Rust crate layout. Drops `private-members` from autoapi options so leading-underscore helpers (`_species_from_numbers` etc.) stay out of the reference.
- Tunes the right-hand page TOC to a sensible default depth so the API Reference is scannable.
- Adds a `.claude/skills/port-rust-docs-to-pyi/` skill capturing the convention for keeping Rust `///` and `.pyi` stubs in sync.

## Why

Before this PR there were two unsynchronized documentation surfaces:

- The PyO3 binding layer in `moyopy/src/` had **no** `///` doc comments, so `MoyoDataset.__doc__`, `Cell.__doc__`, etc. were empty in `help()` and IDE hover.
- The hand-written `.pyi` stubs were uneven in quality (`_dataset.pyi` was great; `_identify.pyi` was almost empty).
- The rich docs that already existed in the core `moyo` crate were not visible from Python at all.
- The API Reference page dumped everything alphabetically, mixing `Cell`, `Centering`, and `CollinearMagneticCell` next to each other.

This PR ports the docs onto the bindings (so they flow through PyO3 to `__doc__`), keeps the `.pyi` files in sync, and reorganizes the rendered API Reference around the natural module boundaries.

## Notable decisions

- Preserves `#[pyo3(module = "moyopy")]` on every class. An earlier draft adopted `pyo3-stub-gen` for auto-generated stubs, but it forces `module = "<pkg>._<sub>"` which leaks `_moyopy` into `__module__` and `repr()`. Reviewer rejected; reverted that approach. The `///` docs stay; the `.pyi` stays hand-written.
- Sphinx-autoapi continues to do the static-analysis parsing of `.pyi`. The new `api.md` page uses `.. autoapisummary::` and `.. autoapiclass::` directives over five `## Group` sections; autoapi's auto-generated alphabetical module page is suppressed via `autoapi_generate_api_docs = False` and `autoapi_add_toctree_entry = False`.

## Commit layout

1. `docs(moyopy): port docstrings from Rust to PyO3 bindings` — `///` adds + `.pyi` enrichment.
2. `chore(moyopy): make moyopy.__init__ imports explicit` — drop star import; add `MagneticOperations` to `_moyopy.pyi`.
3. `docs(moyopy): group API reference into thematic sections` — `api.md`, autoapi config, toctree.
4. `chore(claude): add port-rust-docs-to-pyi skill` — repo-local skill.
5. `docs(moyopy): reduce default TOC depth to one level` — page-TOC tweak.
6. `docs(moyopy): bump default TOC depth back to two levels` — settles on `show_toc_level = 2` (group + class names visible by default).

## Test plan

- [x] `cargo test --manifest-path moyopy/Cargo.toml` -- 5 unit tests pass
- [x] `pytest moyopy/python/tests` -- 28 tests pass
- [x] Smoke test: `MoyoDataset.__doc__`, `MoyoDataset.std_cell.__doc__`, `Cell.__doc__`, `PointGroup.__doc__`, `integral_normalizer.__doc__` all populated at runtime
- [x] `sphinx-build moyopy/docs /tmp/out` succeeds with only 2 pre-existing warnings (unrelated README/intersphinx); generated `api.html` shows 5 grouped sections with summary tables and per-class detail
- [x] `prek run --all-files` passes

[Claude Code] Generated with [Claude Code](https://claude.com/claude-code)
