### PR TITLE
fix(search): avoid panic in magnetic operation closure check (#295)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Unlisted patch versions (e.g. v0.7.1, v0.7.3, v0.7.6, v0.7.7) contain only depen
 ### moyo
 
 - Add `hall_symbol()` and `arithmetic_crystal_class()` to `MoyoDataset` (#272)
+- Fix panic in `MoyoMagneticDataset::new` when the magnetic operation set is not closed; return `MoyoError::TooLargeToleranceError` instead (#295)
 
 ### moyopy
 

--- a/moyo/src/search/primitive_symmetry_search.rs
+++ b/moyo/src/search/primitive_symmetry_search.rs
@@ -273,9 +273,13 @@ impl PrimitiveMagneticSymmetrySearch {
         for mops1 in magnetic_operations.iter() {
             for mops2 in magnetic_operations.iter() {
                 let mops12 = mops1.clone() * mops2.clone();
-                let diff = (translations_map[&(mops12.operation.rotation, mops12.time_reversal)]
-                    - mops12.operation.translation)
-                    .map(|e| e - e.round());
+                let Some(expected_translation) =
+                    translations_map.get(&(mops12.operation.rotation, mops12.time_reversal))
+                else {
+                    return false;
+                };
+                let diff =
+                    (expected_translation - mops12.operation.translation).map(|e| e - e.round());
                 if lattice.cartesian_coords(&diff).norm() > symprec {
                     return false;
                 }

--- a/moyo/tests/test_moyo_magnetic_dataset.rs
+++ b/moyo/tests/test_moyo_magnetic_dataset.rs
@@ -242,3 +242,31 @@ fn test_with_pyrochlore() {
 
     let _dataset = assert_magnetic_dataset_with_default(&magnetic_cell, symprec, action);
 }
+
+#[test]
+fn test_with_large_mag_symprec() {
+    // https://github.com/spglib/moyo/issues/295
+    // With these borderline tolerances the magnetic operation set may not be closed.
+    // The requirement is only that `MoyoMagneticDataset::new` does not panic; it may
+    // either succeed or return a `MoyoError` such as `TooLargeToleranceError`.
+    let magnetic_cell = MagneticCell::new(
+        Lattice::from_basis([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]),
+        vec![[0.0, 0.0, 0.0].into(), [0.25, 0.25, 0.25].into()],
+        vec![1, 1],
+        vec![Collinear(0.003), Collinear(0.005)],
+    );
+    let symprec = 1e-2;
+    let angle_tolerance = AngleTolerance::default();
+    let mag_symprec = 1e-2;
+    let action = RotationMagneticMomentAction::Axial;
+    let rotate_basis = false;
+
+    let _ = MoyoMagneticDataset::new(
+        &magnetic_cell,
+        symprec,
+        angle_tolerance,
+        Some(mag_symprec),
+        action,
+        rotate_basis,
+    );
+}


### PR DESCRIPTION
## Summary

- `PrimitiveMagneticSymmetrySearch::check_closure` indexed a `(rotation, time_reversal)` -> `translation` `HashMap` with `[]`, panicking with `no entry found for key` when composing two candidate magnetic operations produced a combo absent from the candidate set. Switched to `.get()`; a missing key is treated as a closure failure and the caller propagates `MoyoError::TooLargeToleranceError`, matching the behaviour requested in #295.
- Added a regression test (`test_with_large_mag_symprec`) using the minimal repro from the issue. The expectation is only that the call does not panic; it may return either `Ok` or an `Err(MoyoError)`.

Closes #295

## Test plan

- [x] `cargo test --test test_moyo_magnetic_dataset` (4 passing)
- [x] `cargo test -p moyo` (full suite passes: 71 unit + 22 + 4 integration tests)
- [x] `prek` hooks pass on touched files

[Claude Code] Generated with [Claude Code](https://claude.com/claude-code)
