### PR TITLE
chore(moyopy): mark Development Status as Beta

### DIFF
--- a/moyopy/pyproject.toml
+++ b/moyopy/pyproject.toml
@@ -15,7 +15,7 @@ dynamic = [
     'version',
 ]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: Apache Software License",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
## Summary
- Update the PyPI Trove classifier in `moyopy/pyproject.toml` from `Development Status :: 3 - Alpha` to `Development Status :: 4 - Beta` to reflect the project's current maturity.

Refs #301.

## Test plan
- [x] `prek run --files moyopy/pyproject.toml`
- [ ] CI green

[Claude Code] Generated with [Claude Code](https://claude.com/claude-code)
