### PR TITLE
feat(moyo): layer-group M1 - data and math foundations

### DIFF
--- a/moyo/src/base.rs
+++ b/moyo/src/base.rs
@@ -18,7 +18,7 @@ pub use operation::{
     TimeReversal, Translation,
 };
 pub use permutation::Permutation;
-pub use tolerance::AngleTolerance;
+pub use tolerance::{AngleTolerance, is_angle_within_tolerance};
 pub use transformation::{Linear, OriginShift, Transformation, UnimodularTransformation};
 
 pub(super) use cell::orbits_from_permutations;

--- a/moyo/src/base.rs
+++ b/moyo/src/base.rs
@@ -9,7 +9,7 @@ mod tolerance;
 mod transformation;
 
 pub use action::RotationMagneticMomentAction;
-pub use cell::{AtomicSpecie, Cell, Position};
+pub use cell::{AtomicSpecie, Cell, Position, validate_aperiodic_axis};
 pub use error::MoyoError;
 pub use lattice::Lattice;
 pub use magnetic_cell::{Collinear, MagneticCell, MagneticMoment, NonCollinear};

--- a/moyo/src/base/cell.rs
+++ b/moyo/src/base/cell.rs
@@ -11,7 +11,7 @@ use union_find::{QuickFindUf, UnionByRank, UnionFind};
 use super::error::MoyoError;
 use super::lattice::Lattice;
 use super::permutation::Permutation;
-use super::tolerance::AngleTolerance;
+use super::tolerance::{AngleTolerance, is_angle_within_tolerance};
 
 /// Fractional coordinates
 pub type Position = Vector3<f64>;
@@ -70,10 +70,8 @@ impl Cell {
 /// Validate the layer-group convention that the third basis vector `c` is
 /// perpendicular to the in-plane axes `a` and `b` (paper Fu et al. 2024 eq. 5).
 ///
-/// When `angle_tolerance` is `AngleTolerance::Default`, `symprec` drives the
-/// check via the same `sin^2(dtheta) * |u| * |v| < symprec^2` form moyo uses
-/// elsewhere (see `compare_nondiagonal_matrix_tensor_element`); explicit
-/// `Radian(_)` compares the deviation directly.
+/// Defers to `is_angle_within_tolerance` so the `(symprec, angle_tolerance)`
+/// pair is interpreted exactly as in the rest of the symmetry pipeline.
 pub fn validate_aperiodic_axis(
     cell: &Cell,
     symprec: f64,
@@ -83,36 +81,21 @@ pub fn validate_aperiodic_axis(
     let b = cell.lattice.basis.column(1);
     let c = cell.lattice.basis.column(2);
 
-    let na = a.norm();
-    let nb = b.norm();
-    let nc = c.norm();
+    let dev_ca = c.angle(&a) - PI / 2.0;
+    let dev_cb = c.angle(&b) - PI / 2.0;
 
-    let cos_ca = (c.dot(&a) / (nc * na)).clamp(-1.0, 1.0);
-    let cos_cb = (c.dot(&b) / (nc * nb)).clamp(-1.0, 1.0);
-    let dev_ca = (PI / 2.0 - cos_ca.acos()).abs();
-    let dev_cb = (PI / 2.0 - cos_cb.acos()).abs();
-
-    let ok_ca = match angle_tolerance {
-        AngleTolerance::Radian(r) => dev_ca <= r,
-        AngleTolerance::Default => {
-            let dot = c.dot(&a);
-            dot * dot <= symprec * symprec * nc * na
-        }
-    };
-    let ok_cb = match angle_tolerance {
-        AngleTolerance::Radian(r) => dev_cb <= r,
-        AngleTolerance::Default => {
-            let dot = c.dot(&b);
-            dot * dot <= symprec * symprec * nc * nb
-        }
-    };
+    let ok_ca = is_angle_within_tolerance(dev_ca, c.norm(), a.norm(), symprec, angle_tolerance);
+    let ok_cb = is_angle_within_tolerance(dev_cb, c.norm(), b.norm(), symprec, angle_tolerance);
 
     if !ok_ca || !ok_cb {
         debug!(
             "Aperiodic axis is not orthogonal: dev(c,a)={:.6} rad, dev(c,b)={:.6} rad",
             dev_ca, dev_cb
         );
-        return Err(MoyoError::AperiodicAxisNotOrthogonal { dev_ca, dev_cb });
+        return Err(MoyoError::AperiodicAxisNotOrthogonal {
+            dev_ca: dev_ca.abs(),
+            dev_cb: dev_cb.abs(),
+        });
     }
     Ok(())
 }

--- a/moyo/src/base/cell.rs
+++ b/moyo/src/base/cell.rs
@@ -1,13 +1,17 @@
 use std::collections::BTreeMap;
+use std::f64::consts::PI;
 
+use log::debug;
 use nalgebra::{Matrix3, Vector3};
 
 use crate::utils::to_3_slice;
 use serde::{Deserialize, Serialize};
 use union_find::{QuickFindUf, UnionByRank, UnionFind};
 
+use super::error::MoyoError;
 use super::lattice::Lattice;
 use super::permutation::Permutation;
+use super::tolerance::AngleTolerance;
 
 /// Fractional coordinates
 pub type Position = Vector3<f64>;
@@ -63,6 +67,53 @@ impl Cell {
     }
 }
 
+/// Default tolerance for the layer-group aperiodic-axis perpendicularity check
+/// when `AngleTolerance::Default` is supplied. Matches spglib's default
+/// `angle_tolerance` of 5 degrees.
+const DEFAULT_LAYER_ANGLE_TOLERANCE_RAD: f64 = 5.0 * PI / 180.0;
+
+/// Validate the layer-group convention that the third basis vector `c` is
+/// perpendicular to the in-plane axes `a` and `b` (paper Fu et al. 2024 eq. 5).
+///
+/// Returns `Err(MoyoError::AperiodicAxisNotOrthogonal)` if either angle deviates
+/// from 90 degrees by more than `angle_tolerance`. The deviation in radians is
+/// emitted via `log::debug!` so failures can be diagnosed without changing the
+/// error type's payload (which stays `Copy`).
+pub fn validate_aperiodic_axis(
+    cell: &Cell,
+    angle_tolerance: AngleTolerance,
+) -> Result<(), MoyoError> {
+    let tol = match angle_tolerance {
+        AngleTolerance::Radian(r) => r,
+        AngleTolerance::Default => DEFAULT_LAYER_ANGLE_TOLERANCE_RAD,
+    };
+
+    let a = cell.lattice.basis.column(0);
+    let b = cell.lattice.basis.column(1);
+    let c = cell.lattice.basis.column(2);
+
+    let na = a.norm();
+    let nb = b.norm();
+    let nc = c.norm();
+    if na == 0.0 || nb == 0.0 || nc == 0.0 {
+        return Err(MoyoError::AperiodicAxisNotOrthogonal);
+    }
+
+    let cos_ca = (c.dot(&a) / (nc * na)).clamp(-1.0, 1.0);
+    let cos_cb = (c.dot(&b) / (nc * nb)).clamp(-1.0, 1.0);
+    let dev_ca = (PI / 2.0 - cos_ca.acos()).abs();
+    let dev_cb = (PI / 2.0 - cos_cb.acos()).abs();
+
+    if dev_ca > tol || dev_cb > tol {
+        debug!(
+            "Aperiodic axis is not orthogonal: dev(c,a)={:.6} rad, dev(c,b)={:.6} rad, tol={:.6} rad",
+            dev_ca, dev_cb, tol
+        );
+        return Err(MoyoError::AperiodicAxisNotOrthogonal);
+    }
+    Ok(())
+}
+
 /// If and only if the `i`th and `j`th atoms are equivalent, `orbits[i] == orbits[j]`.
 /// For each orbit, only one of them satisfies `orbits[i] == i`.
 pub fn orbits_from_permutations(num_atoms: usize, permutations: &[Permutation]) -> Vec<usize> {
@@ -86,11 +137,13 @@ pub fn orbits_from_permutations(num_atoms: usize, permutations: &[Permutation]) 
 mod tests {
     use std::panic;
 
-    use nalgebra::{Matrix3, vector};
+    use nalgebra::{Matrix3, matrix, vector};
 
-    use super::{Cell, orbits_from_permutations};
+    use super::{Cell, orbits_from_permutations, validate_aperiodic_axis};
+    use crate::base::error::MoyoError;
     use crate::base::lattice::Lattice;
     use crate::base::permutation::Permutation;
+    use crate::base::tolerance::AngleTolerance;
 
     #[test]
     fn test_orbits_from_permutations() {
@@ -120,5 +173,62 @@ mod tests {
 
         let result = panic::catch_unwind(|| Cell::new(lattice, positions, numbers));
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_aperiodic_axis_orthogonal() {
+        let lattice = Lattice::new(matrix![
+            1.0, 0.0, 0.0;
+            0.0, 1.0, 0.0;
+            0.0, 0.0, 5.0;
+        ]);
+        let cell = Cell::new(lattice, vec![vector![0.0, 0.0, 0.0]], vec![1]);
+        assert!(validate_aperiodic_axis(&cell, AngleTolerance::Default).is_ok());
+    }
+
+    #[test]
+    fn test_validate_aperiodic_axis_oblique_in_plane_ok() {
+        // Hexagonal-style oblique in-plane (a,b) with c perpendicular:
+        // a, b in xy-plane; c along z. Validator must pass.
+        let lattice = Lattice::new(matrix![
+            1.0, 0.0, 0.0;
+            -0.5, (3.0_f64).sqrt() / 2.0, 0.0;
+            0.0, 0.0, 5.0;
+        ]);
+        let cell = Cell::new(lattice, vec![vector![0.0, 0.0, 0.0]], vec![1]);
+        assert!(validate_aperiodic_axis(&cell, AngleTolerance::Default).is_ok());
+    }
+
+    #[test]
+    fn test_validate_aperiodic_axis_tilted_c_rejected() {
+        // c has a non-trivial in-plane component; should be rejected with default tol.
+        let lattice = Lattice::new(matrix![
+            1.0, 0.0, 0.0;
+            0.0, 1.0, 0.0;
+            0.5, 0.0, 5.0;
+        ]);
+        let cell = Cell::new(lattice, vec![vector![0.0, 0.0, 0.0]], vec![1]);
+        assert_eq!(
+            validate_aperiodic_axis(&cell, AngleTolerance::Default),
+            Err(MoyoError::AperiodicAxisNotOrthogonal)
+        );
+    }
+
+    #[test]
+    fn test_validate_aperiodic_axis_explicit_radian() {
+        // Small tilt (~1.7 degrees) accepted with a 5-degree tolerance, rejected with a 1-degree one.
+        let lattice = Lattice::new(matrix![
+            1.0, 0.0, 0.0;
+            0.0, 1.0, 0.0;
+            0.15, 0.0, 5.0;
+        ]);
+        let cell = Cell::new(lattice, vec![vector![0.0, 0.0, 0.0]], vec![1]);
+        assert!(
+            validate_aperiodic_axis(&cell, AngleTolerance::Radian(5.0_f64.to_radians())).is_ok()
+        );
+        assert_eq!(
+            validate_aperiodic_axis(&cell, AngleTolerance::Radian(1.0_f64.to_radians())),
+            Err(MoyoError::AperiodicAxisNotOrthogonal)
+        );
     }
 }

--- a/moyo/src/base/cell.rs
+++ b/moyo/src/base/cell.rs
@@ -67,27 +67,18 @@ impl Cell {
     }
 }
 
-/// Default tolerance for the layer-group aperiodic-axis perpendicularity check
-/// when `AngleTolerance::Default` is supplied. Matches spglib's default
-/// `angle_tolerance` of 5 degrees.
-const DEFAULT_LAYER_ANGLE_TOLERANCE_RAD: f64 = 5.0 * PI / 180.0;
-
 /// Validate the layer-group convention that the third basis vector `c` is
 /// perpendicular to the in-plane axes `a` and `b` (paper Fu et al. 2024 eq. 5).
 ///
-/// Returns `Err(MoyoError::AperiodicAxisNotOrthogonal)` if either angle deviates
-/// from 90 degrees by more than `angle_tolerance`. The deviation in radians is
-/// emitted via `log::debug!` so failures can be diagnosed without changing the
-/// error type's payload (which stays `Copy`).
+/// When `angle_tolerance` is `AngleTolerance::Default`, `symprec` drives the
+/// check via the same `sin^2(dtheta) * |u| * |v| < symprec^2` form moyo uses
+/// elsewhere (see `compare_nondiagonal_matrix_tensor_element`); explicit
+/// `Radian(_)` compares the deviation directly.
 pub fn validate_aperiodic_axis(
     cell: &Cell,
+    symprec: f64,
     angle_tolerance: AngleTolerance,
 ) -> Result<(), MoyoError> {
-    let tol = match angle_tolerance {
-        AngleTolerance::Radian(r) => r,
-        AngleTolerance::Default => DEFAULT_LAYER_ANGLE_TOLERANCE_RAD,
-    };
-
     let a = cell.lattice.basis.column(0);
     let b = cell.lattice.basis.column(1);
     let c = cell.lattice.basis.column(2);
@@ -95,21 +86,33 @@ pub fn validate_aperiodic_axis(
     let na = a.norm();
     let nb = b.norm();
     let nc = c.norm();
-    if na == 0.0 || nb == 0.0 || nc == 0.0 {
-        return Err(MoyoError::AperiodicAxisNotOrthogonal);
-    }
 
     let cos_ca = (c.dot(&a) / (nc * na)).clamp(-1.0, 1.0);
     let cos_cb = (c.dot(&b) / (nc * nb)).clamp(-1.0, 1.0);
     let dev_ca = (PI / 2.0 - cos_ca.acos()).abs();
     let dev_cb = (PI / 2.0 - cos_cb.acos()).abs();
 
-    if dev_ca > tol || dev_cb > tol {
+    let ok_ca = match angle_tolerance {
+        AngleTolerance::Radian(r) => dev_ca <= r,
+        AngleTolerance::Default => {
+            let dot = c.dot(&a);
+            dot * dot <= symprec * symprec * nc * na
+        }
+    };
+    let ok_cb = match angle_tolerance {
+        AngleTolerance::Radian(r) => dev_cb <= r,
+        AngleTolerance::Default => {
+            let dot = c.dot(&b);
+            dot * dot <= symprec * symprec * nc * nb
+        }
+    };
+
+    if !ok_ca || !ok_cb {
         debug!(
-            "Aperiodic axis is not orthogonal: dev(c,a)={:.6} rad, dev(c,b)={:.6} rad, tol={:.6} rad",
-            dev_ca, dev_cb, tol
+            "Aperiodic axis is not orthogonal: dev(c,a)={:.6} rad, dev(c,b)={:.6} rad",
+            dev_ca, dev_cb
         );
-        return Err(MoyoError::AperiodicAxisNotOrthogonal);
+        return Err(MoyoError::AperiodicAxisNotOrthogonal { dev_ca, dev_cb });
     }
     Ok(())
 }
@@ -175,6 +178,8 @@ mod tests {
         assert!(result.is_err());
     }
 
+    const TEST_SYMPREC: f64 = 1e-4;
+
     #[test]
     fn test_validate_aperiodic_axis_orthogonal() {
         let lattice = Lattice::new(matrix![
@@ -183,7 +188,7 @@ mod tests {
             0.0, 0.0, 5.0;
         ]);
         let cell = Cell::new(lattice, vec![vector![0.0, 0.0, 0.0]], vec![1]);
-        assert!(validate_aperiodic_axis(&cell, AngleTolerance::Default).is_ok());
+        assert!(validate_aperiodic_axis(&cell, TEST_SYMPREC, AngleTolerance::Default).is_ok());
     }
 
     #[test]
@@ -196,7 +201,7 @@ mod tests {
             0.0, 0.0, 5.0;
         ]);
         let cell = Cell::new(lattice, vec![vector![0.0, 0.0, 0.0]], vec![1]);
-        assert!(validate_aperiodic_axis(&cell, AngleTolerance::Default).is_ok());
+        assert!(validate_aperiodic_axis(&cell, TEST_SYMPREC, AngleTolerance::Default).is_ok());
     }
 
     #[test]
@@ -208,10 +213,10 @@ mod tests {
             0.5, 0.0, 5.0;
         ]);
         let cell = Cell::new(lattice, vec![vector![0.0, 0.0, 0.0]], vec![1]);
-        assert_eq!(
-            validate_aperiodic_axis(&cell, AngleTolerance::Default),
-            Err(MoyoError::AperiodicAxisNotOrthogonal)
-        );
+        assert!(matches!(
+            validate_aperiodic_axis(&cell, TEST_SYMPREC, AngleTolerance::Default),
+            Err(MoyoError::AperiodicAxisNotOrthogonal { .. })
+        ));
     }
 
     #[test]
@@ -224,11 +229,20 @@ mod tests {
         ]);
         let cell = Cell::new(lattice, vec![vector![0.0, 0.0, 0.0]], vec![1]);
         assert!(
-            validate_aperiodic_axis(&cell, AngleTolerance::Radian(5.0_f64.to_radians())).is_ok()
+            validate_aperiodic_axis(
+                &cell,
+                TEST_SYMPREC,
+                AngleTolerance::Radian(5.0_f64.to_radians())
+            )
+            .is_ok()
         );
-        assert_eq!(
-            validate_aperiodic_axis(&cell, AngleTolerance::Radian(1.0_f64.to_radians())),
-            Err(MoyoError::AperiodicAxisNotOrthogonal)
-        );
+        assert!(matches!(
+            validate_aperiodic_axis(
+                &cell,
+                TEST_SYMPREC,
+                AngleTolerance::Radian(1.0_f64.to_radians())
+            ),
+            Err(MoyoError::AperiodicAxisNotOrthogonal { .. })
+        ));
     }
 }

--- a/moyo/src/base/error.rs
+++ b/moyo/src/base/error.rs
@@ -55,4 +55,9 @@ pub enum MoyoError {
     UnknownArithmeticNumberError,
     #[error("Unknown uni_number")]
     UnknownUNINumberError,
+    // Layer-group input validation errors
+    #[error(
+        "Aperiodic axis c is not perpendicular to the in-plane axes within the angle tolerance"
+    )]
+    AperiodicAxisNotOrthogonal,
 }

--- a/moyo/src/base/error.rs
+++ b/moyo/src/base/error.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-#[derive(Error, Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Error, Debug, PartialEq, Clone, Copy)]
 /// Error types for the **moyo** library
 pub enum MoyoError {
     // Lattice reduction errors
@@ -57,7 +57,7 @@ pub enum MoyoError {
     UnknownUNINumberError,
     // Layer-group input validation errors
     #[error(
-        "Aperiodic axis c is not perpendicular to the in-plane axes within the angle tolerance"
+        "Aperiodic axis c is not perpendicular to the in-plane axes within tolerance: dev(c,a)={dev_ca:.6} rad, dev(c,b)={dev_cb:.6} rad"
     )]
-    AperiodicAxisNotOrthogonal,
+    AperiodicAxisNotOrthogonal { dev_ca: f64, dev_cb: f64 },
 }

--- a/moyo/src/base/tolerance.rs
+++ b/moyo/src/base/tolerance.rs
@@ -23,6 +23,28 @@ impl Default for AngleTolerance {
     }
 }
 
+/// Returns true iff the angle deviation `dtheta` (in radians) is within
+/// tolerance, given the lengths of the two vectors involved.
+///
+/// For `AngleTolerance::Radian(r)`, returns `|dtheta| <= r`.
+/// For `AngleTolerance::Default`, applies the symprec-driven criterion
+/// `sin^2(dtheta) * len_u * len_v < symprec^2` (Eq.(7) of arXiv:1808.01590).
+pub fn is_angle_within_tolerance(
+    dtheta: f64,
+    len_u: f64,
+    len_v: f64,
+    symprec: f64,
+    angle_tolerance: AngleTolerance,
+) -> bool {
+    match angle_tolerance {
+        AngleTolerance::Radian(r) => dtheta.abs() <= r,
+        AngleTolerance::Default => {
+            let sin2 = dtheta.sin().powi(2);
+            sin2 * len_u * len_v < symprec * symprec
+        }
+    }
+}
+
 pub trait Tolerances {
     fn increase_tolerances(&self, stride: f64) -> Self;
     fn reduce_tolerances(&self, stride: f64) -> Self;

--- a/moyo/src/data.rs
+++ b/moyo/src/data.rs
@@ -3,6 +3,9 @@ mod centering;
 mod classification;
 mod hall_symbol;
 mod hall_symbol_database;
+mod layer_arithmetic_crystal_class;
+mod layer_centering;
+mod layer_classification;
 mod magnetic_hall_symbol_database;
 mod magnetic_space_group;
 mod point_group;
@@ -18,6 +21,12 @@ pub use classification::{
 };
 pub use hall_symbol::{HallSymbol, MagneticHallSymbol};
 pub use hall_symbol_database::{HallNumber, HallSymbolEntry, Number, hall_symbol_entry};
+pub use layer_arithmetic_crystal_class::{
+    LayerArithmeticCrystalClassEntry, LayerArithmeticNumber, iter_layer_arithmetic_crystal_entry,
+    layer_arithmetic_crystal_class_entry,
+};
+pub use layer_centering::LayerCentering;
+pub use layer_classification::{LayerBravaisClass, LayerCrystalSystem, LayerLatticeSystem};
 pub use magnetic_hall_symbol_database::{MagneticHallSymbolEntry, magnetic_hall_symbol_entry};
 pub use magnetic_space_group::{
     ConstructType, MagneticSpaceGroupType, NUM_MAGNETIC_SPACE_GROUP_TYPES, UNINumber,

--- a/moyo/src/data/layer_arithmetic_crystal_class.rs
+++ b/moyo/src/data/layer_arithmetic_crystal_class.rs
@@ -1,0 +1,370 @@
+use super::classification::GeometricCrystalClass;
+use super::layer_classification::{LayerBravaisClass, LayerLatticeSystem};
+
+pub type LayerArithmeticNumber = i32;
+
+#[derive(Debug, Clone)]
+pub struct LayerArithmeticCrystalClassEntry {
+    /// Sequential number for layer arithmetic crystal classes (1-based, ordered as in paper Table 4).
+    pub arithmetic_number: LayerArithmeticNumber,
+    /// Symbol for the arithmetic crystal class (e.g. "p1", "c2/m11").
+    pub symbol: &'static str,
+    /// Geometric crystal class (subset of the 32 used for space groups; cubic classes do not occur).
+    pub geometric_crystal_class: GeometricCrystalClass,
+    /// Bravais class for the layer group's 2D lattice.
+    pub layer_bravais_class: LayerBravaisClass,
+}
+
+impl LayerArithmeticCrystalClassEntry {
+    const fn new(
+        arithmetic_number: LayerArithmeticNumber,
+        symbol: &'static str,
+        geometric_crystal_class: GeometricCrystalClass,
+        layer_bravais_class: LayerBravaisClass,
+    ) -> Self {
+        Self {
+            arithmetic_number,
+            symbol,
+            geometric_crystal_class,
+            layer_bravais_class,
+        }
+    }
+
+    pub fn layer_lattice_system(&self) -> LayerLatticeSystem {
+        LayerLatticeSystem::from_layer_bravais_class(self.layer_bravais_class)
+    }
+}
+
+pub fn layer_arithmetic_crystal_class_entry(
+    arithmetic_number: LayerArithmeticNumber,
+) -> Option<LayerArithmeticCrystalClassEntry> {
+    if arithmetic_number < 1 {
+        return None;
+    }
+    LAYER_ARITHMETIC_CRYSTAL_CLASS_DATABASE
+        .get((arithmetic_number - 1) as usize)
+        .cloned()
+}
+
+pub fn iter_layer_arithmetic_crystal_entry()
+-> impl Iterator<Item = &'static LayerArithmeticCrystalClassEntry> {
+    LAYER_ARITHMETIC_CRYSTAL_CLASS_DATABASE.iter()
+}
+
+// Layer arithmetic-geometric crystal classes from Fu et al. 2024, Table 4.
+// Each row of Table 4 is one arithmetic class (orientation-distinct rows like
+// "(m2m)" vs "mm2" are listed separately, mirroring how the existing 3D
+// `ArithmeticCrystalClassEntry` distinguishes e.g. `mm2C` and `2mmC`).
+// The integer in parentheses after each symbol below is the smallest layer-group
+// number (LG number) belonging to the class, as listed in Table 4.
+const LAYER_ARITHMETIC_CRYSTAL_CLASS_DATABASE: [LayerArithmeticCrystalClassEntry; 43] = [
+    // Triclinic / oblique
+    LayerArithmeticCrystalClassEntry::new(
+        1,
+        "p1",
+        GeometricCrystalClass::C1,
+        LayerBravaisClass::mp,
+    ), // LG 1
+    LayerArithmeticCrystalClassEntry::new(
+        2,
+        "p-1",
+        GeometricCrystalClass::Ci,
+        LayerBravaisClass::mp,
+    ), // LG 2
+    // Monoclinic / oblique
+    LayerArithmeticCrystalClassEntry::new(
+        3,
+        "p112",
+        GeometricCrystalClass::C2,
+        LayerBravaisClass::mp,
+    ), // LG 3
+    LayerArithmeticCrystalClassEntry::new(
+        4,
+        "p11m",
+        GeometricCrystalClass::C1h,
+        LayerBravaisClass::mp,
+    ), // LG 4
+    LayerArithmeticCrystalClassEntry::new(
+        5,
+        "p112/m",
+        GeometricCrystalClass::C2h,
+        LayerBravaisClass::mp,
+    ), // LG 6
+    // Monoclinic / rectangular
+    LayerArithmeticCrystalClassEntry::new(
+        6,
+        "p211",
+        GeometricCrystalClass::C2,
+        LayerBravaisClass::op,
+    ), // LG 8
+    LayerArithmeticCrystalClassEntry::new(
+        7,
+        "c211",
+        GeometricCrystalClass::C2,
+        LayerBravaisClass::oc,
+    ), // LG 10
+    LayerArithmeticCrystalClassEntry::new(
+        8,
+        "pm11",
+        GeometricCrystalClass::C1h,
+        LayerBravaisClass::op,
+    ), // LG 11
+    LayerArithmeticCrystalClassEntry::new(
+        9,
+        "cm11",
+        GeometricCrystalClass::C1h,
+        LayerBravaisClass::oc,
+    ), // LG 13
+    LayerArithmeticCrystalClassEntry::new(
+        10,
+        "p2/m11",
+        GeometricCrystalClass::C2h,
+        LayerBravaisClass::op,
+    ), // LG 14
+    LayerArithmeticCrystalClassEntry::new(
+        11,
+        "c2/m11",
+        GeometricCrystalClass::C2h,
+        LayerBravaisClass::oc,
+    ), // LG 18
+    // Orthorhombic / rectangular
+    LayerArithmeticCrystalClassEntry::new(
+        12,
+        "p222",
+        GeometricCrystalClass::D2,
+        LayerBravaisClass::op,
+    ), // LG 19
+    LayerArithmeticCrystalClassEntry::new(
+        13,
+        "c222",
+        GeometricCrystalClass::D2,
+        LayerBravaisClass::oc,
+    ), // LG 22
+    LayerArithmeticCrystalClassEntry::new(
+        14,
+        "pmm2",
+        GeometricCrystalClass::C2v,
+        LayerBravaisClass::op,
+    ), // LG 23
+    LayerArithmeticCrystalClassEntry::new(
+        15,
+        "cmm2",
+        GeometricCrystalClass::C2v,
+        LayerBravaisClass::oc,
+    ), // LG 26
+    LayerArithmeticCrystalClassEntry::new(
+        16,
+        "pm2m",
+        GeometricCrystalClass::C2v,
+        LayerBravaisClass::op,
+    ), // LG 27
+    LayerArithmeticCrystalClassEntry::new(
+        17,
+        "cm2m",
+        GeometricCrystalClass::C2v,
+        LayerBravaisClass::oc,
+    ), // LG 35
+    LayerArithmeticCrystalClassEntry::new(
+        18,
+        "pmmm",
+        GeometricCrystalClass::D2h,
+        LayerBravaisClass::op,
+    ), // LG 37
+    LayerArithmeticCrystalClassEntry::new(
+        19,
+        "cmmm",
+        GeometricCrystalClass::D2h,
+        LayerBravaisClass::oc,
+    ), // LG 47
+    // Tetragonal / square
+    LayerArithmeticCrystalClassEntry::new(
+        20,
+        "p4",
+        GeometricCrystalClass::C4,
+        LayerBravaisClass::tp,
+    ), // LG 49
+    LayerArithmeticCrystalClassEntry::new(
+        21,
+        "p-4",
+        GeometricCrystalClass::S4,
+        LayerBravaisClass::tp,
+    ), // LG 50
+    LayerArithmeticCrystalClassEntry::new(
+        22,
+        "p4/m",
+        GeometricCrystalClass::C4h,
+        LayerBravaisClass::tp,
+    ), // LG 51
+    LayerArithmeticCrystalClassEntry::new(
+        23,
+        "p422",
+        GeometricCrystalClass::D4,
+        LayerBravaisClass::tp,
+    ), // LG 53
+    LayerArithmeticCrystalClassEntry::new(
+        24,
+        "p4mm",
+        GeometricCrystalClass::C4v,
+        LayerBravaisClass::tp,
+    ), // LG 55
+    LayerArithmeticCrystalClassEntry::new(
+        25,
+        "p-42m",
+        GeometricCrystalClass::D2d,
+        LayerBravaisClass::tp,
+    ), // LG 57
+    LayerArithmeticCrystalClassEntry::new(
+        26,
+        "p-4m2",
+        GeometricCrystalClass::D2d,
+        LayerBravaisClass::tp,
+    ), // LG 59
+    LayerArithmeticCrystalClassEntry::new(
+        27,
+        "p4/mmm",
+        GeometricCrystalClass::D4h,
+        LayerBravaisClass::tp,
+    ), // LG 61
+    // Trigonal / hexagonal
+    LayerArithmeticCrystalClassEntry::new(
+        28,
+        "p3",
+        GeometricCrystalClass::C3,
+        LayerBravaisClass::hp,
+    ), // LG 65
+    LayerArithmeticCrystalClassEntry::new(
+        29,
+        "p-3",
+        GeometricCrystalClass::C3i,
+        LayerBravaisClass::hp,
+    ), // LG 66
+    LayerArithmeticCrystalClassEntry::new(
+        30,
+        "p312",
+        GeometricCrystalClass::D3,
+        LayerBravaisClass::hp,
+    ), // LG 67
+    LayerArithmeticCrystalClassEntry::new(
+        31,
+        "p321",
+        GeometricCrystalClass::D3,
+        LayerBravaisClass::hp,
+    ), // LG 68
+    LayerArithmeticCrystalClassEntry::new(
+        32,
+        "p3m1",
+        GeometricCrystalClass::C3v,
+        LayerBravaisClass::hp,
+    ), // LG 69
+    LayerArithmeticCrystalClassEntry::new(
+        33,
+        "p31m",
+        GeometricCrystalClass::C3v,
+        LayerBravaisClass::hp,
+    ), // LG 70
+    LayerArithmeticCrystalClassEntry::new(
+        34,
+        "p-31m",
+        GeometricCrystalClass::D3d,
+        LayerBravaisClass::hp,
+    ), // LG 71
+    LayerArithmeticCrystalClassEntry::new(
+        35,
+        "p-3m1",
+        GeometricCrystalClass::D3d,
+        LayerBravaisClass::hp,
+    ), // LG 72
+    // Hexagonal / hexagonal
+    LayerArithmeticCrystalClassEntry::new(
+        36,
+        "p6",
+        GeometricCrystalClass::C6,
+        LayerBravaisClass::hp,
+    ), // LG 73
+    LayerArithmeticCrystalClassEntry::new(
+        37,
+        "p-6",
+        GeometricCrystalClass::C3h,
+        LayerBravaisClass::hp,
+    ), // LG 74
+    LayerArithmeticCrystalClassEntry::new(
+        38,
+        "p6/m",
+        GeometricCrystalClass::C6h,
+        LayerBravaisClass::hp,
+    ), // LG 75
+    LayerArithmeticCrystalClassEntry::new(
+        39,
+        "p622",
+        GeometricCrystalClass::D6,
+        LayerBravaisClass::hp,
+    ), // LG 76
+    LayerArithmeticCrystalClassEntry::new(
+        40,
+        "p6mm",
+        GeometricCrystalClass::C6v,
+        LayerBravaisClass::hp,
+    ), // LG 77
+    LayerArithmeticCrystalClassEntry::new(
+        41,
+        "p-6m2",
+        GeometricCrystalClass::D3h,
+        LayerBravaisClass::hp,
+    ), // LG 78
+    LayerArithmeticCrystalClassEntry::new(
+        42,
+        "p-62m",
+        GeometricCrystalClass::D3h,
+        LayerBravaisClass::hp,
+    ), // LG 79
+    LayerArithmeticCrystalClassEntry::new(
+        43,
+        "p6/mmm",
+        GeometricCrystalClass::D6h,
+        LayerBravaisClass::hp,
+    ), // LG 80
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_database_size_and_numbering() {
+        assert_eq!(LAYER_ARITHMETIC_CRYSTAL_CLASS_DATABASE.len(), 43);
+        for (i, entry) in iter_layer_arithmetic_crystal_entry().enumerate() {
+            assert_eq!(entry.arithmetic_number as usize, i + 1);
+        }
+    }
+
+    #[test]
+    fn test_lookup() {
+        let entry = layer_arithmetic_crystal_class_entry(1).unwrap();
+        assert_eq!(entry.symbol, "p1");
+        assert_eq!(entry.geometric_crystal_class, GeometricCrystalClass::C1);
+        assert_eq!(entry.layer_bravais_class, LayerBravaisClass::mp);
+        assert_eq!(entry.layer_lattice_system(), LayerLatticeSystem::Oblique);
+
+        let entry = layer_arithmetic_crystal_class_entry(43).unwrap();
+        assert_eq!(entry.symbol, "p6/mmm");
+        assert_eq!(entry.geometric_crystal_class, GeometricCrystalClass::D6h);
+        assert_eq!(entry.layer_bravais_class, LayerBravaisClass::hp);
+
+        assert!(layer_arithmetic_crystal_class_entry(0).is_none());
+        assert!(layer_arithmetic_crystal_class_entry(44).is_none());
+    }
+
+    #[test]
+    fn test_no_cubic() {
+        for entry in iter_layer_arithmetic_crystal_entry() {
+            assert!(!matches!(
+                entry.geometric_crystal_class,
+                GeometricCrystalClass::T
+                    | GeometricCrystalClass::Th
+                    | GeometricCrystalClass::O
+                    | GeometricCrystalClass::Td
+                    | GeometricCrystalClass::Oh
+            ));
+        }
+    }
+}

--- a/moyo/src/data/layer_centering.rs
+++ b/moyo/src/data/layer_centering.rs
@@ -1,0 +1,84 @@
+use nalgebra::{Matrix3, Vector3};
+use serde::Serialize;
+use strum_macros::EnumIter;
+
+use crate::base::{Linear, Translation};
+
+/// Centering type for layer groups (only oblique-/rectangular-primitive and
+/// rectangular-centered exist in 2D).
+#[derive(Debug, Copy, Clone, PartialEq, EnumIter, Serialize)]
+pub enum LayerCentering {
+    P, // Primitive
+    C, // C-face centered (in-plane only)
+}
+
+impl LayerCentering {
+    pub fn order(&self) -> usize {
+        match self {
+            LayerCentering::P => 1,
+            LayerCentering::C => 2,
+        }
+    }
+
+    /// Transformation matrix from primitive to conventional cell.
+    /// The c (aperiodic) axis is left untouched.
+    pub fn linear(&self) -> Linear {
+        match self {
+            LayerCentering::P => Linear::identity(),
+            LayerCentering::C => Linear::new(
+                1, -1, 0, //
+                1, 1, 0, //
+                0, 0, 1, //
+            ),
+        }
+    }
+
+    /// Transformation matrix from conventional to primitive cell.
+    pub fn inverse(&self) -> Matrix3<f64> {
+        self.linear().map(|e| e as f64).try_inverse().unwrap()
+    }
+
+    /// Lattice points of the conventional cell expressed in the conventional basis.
+    /// Centerings are 2D-only: the c-component is always zero.
+    pub fn lattice_points(&self) -> Vec<Vector3<f64>> {
+        match self {
+            LayerCentering::P => {
+                vec![Translation::new(0.0, 0.0, 0.0)]
+            }
+            LayerCentering::C => {
+                vec![
+                    Translation::new(0.0, 0.0, 0.0),
+                    Translation::new(0.5, 0.5, 0.0),
+                ]
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use strum::IntoEnumIterator;
+
+    use super::*;
+    use crate::base::Transformation;
+
+    #[test]
+    fn test_conventional_transformation_matrix() {
+        for centering in LayerCentering::iter() {
+            assert_eq!(
+                Transformation::from_linear(centering.linear()).size,
+                centering.order()
+            );
+        }
+    }
+
+    #[test]
+    fn test_lattice_points_in_plane() {
+        for centering in LayerCentering::iter() {
+            for p in centering.lattice_points() {
+                assert_eq!(p[2], 0.0);
+            }
+            assert_eq!(centering.lattice_points().len(), centering.order());
+        }
+    }
+}

--- a/moyo/src/data/layer_classification.rs
+++ b/moyo/src/data/layer_classification.rs
@@ -73,13 +73,13 @@ impl LayerCentering {
 }
 
 /// Crystal systems applicable to layer groups.
-/// The monoclinic system is split into oblique and rectangular subcases because
-/// they differ in which axis carries the unique 2-fold (paper Figure 1).
+/// Reference: Fu et al. 2024, Table 2 (point-group classification of layer groups).
+/// The oblique-vs-rectangular distinction for monoclinic is a *lattice-system*
+/// distinction (Table 3), not a crystal-system one.
 #[derive(Debug, Clone, Copy, PartialEq, EnumIter)]
 pub enum LayerCrystalSystem {
     Triclinic,
-    MonoclinicOblique,
-    MonoclinicRectangular,
+    Monoclinic,
     Orthorhombic,
     Tetragonal,
     Trigonal,
@@ -91,8 +91,7 @@ impl ToString for LayerCrystalSystem {
     fn to_string(&self) -> String {
         match self {
             LayerCrystalSystem::Triclinic => "Triclinic".to_string(),
-            LayerCrystalSystem::MonoclinicOblique => "MonoclinicOblique".to_string(),
-            LayerCrystalSystem::MonoclinicRectangular => "MonoclinicRectangular".to_string(),
+            LayerCrystalSystem::Monoclinic => "Monoclinic".to_string(),
             LayerCrystalSystem::Orthorhombic => "Orthorhombic".to_string(),
             LayerCrystalSystem::Tetragonal => "Tetragonal".to_string(),
             LayerCrystalSystem::Trigonal => "Trigonal".to_string(),

--- a/moyo/src/data/layer_classification.rs
+++ b/moyo/src/data/layer_classification.rs
@@ -1,0 +1,165 @@
+use strum_macros::EnumIter;
+
+use super::layer_centering::LayerCentering;
+
+/// 2D lattice systems applicable to layer groups.
+/// Reference: Fu et al. 2024, Table 3.
+#[derive(Debug, Clone, Copy, PartialEq, EnumIter)]
+pub enum LayerLatticeSystem {
+    Oblique,     // 2/m
+    Rectangular, // mmm
+    Square,      // 4/mmm
+    Hexagonal,   // 6/mmm
+}
+
+#[allow(clippy::to_string_trait_impl)]
+impl ToString for LayerLatticeSystem {
+    fn to_string(&self) -> String {
+        match self {
+            LayerLatticeSystem::Oblique => "Oblique".to_string(),
+            LayerLatticeSystem::Rectangular => "Rectangular".to_string(),
+            LayerLatticeSystem::Square => "Square".to_string(),
+            LayerLatticeSystem::Hexagonal => "Hexagonal".to_string(),
+        }
+    }
+}
+
+/// Bravais types of 2D lattices for layer groups.
+/// Reference: Fu et al. 2024, Table 3.
+#[allow(non_camel_case_types)]
+#[derive(Debug, Clone, Copy, PartialEq, EnumIter)]
+pub enum LayerBravaisClass {
+    mp, // Oblique primitive
+    op, // Rectangular primitive
+    oc, // Rectangular centered
+    tp, // Square primitive
+    hp, // Hexagonal primitive
+}
+
+#[allow(clippy::to_string_trait_impl)]
+impl ToString for LayerBravaisClass {
+    fn to_string(&self) -> String {
+        match self {
+            LayerBravaisClass::mp => "mp".to_string(),
+            LayerBravaisClass::op => "op".to_string(),
+            LayerBravaisClass::oc => "oc".to_string(),
+            LayerBravaisClass::tp => "tp".to_string(),
+            LayerBravaisClass::hp => "hp".to_string(),
+        }
+    }
+}
+
+impl LayerLatticeSystem {
+    pub fn from_layer_bravais_class(layer_bravais_class: LayerBravaisClass) -> Self {
+        match layer_bravais_class {
+            LayerBravaisClass::mp => LayerLatticeSystem::Oblique,
+            LayerBravaisClass::op | LayerBravaisClass::oc => LayerLatticeSystem::Rectangular,
+            LayerBravaisClass::tp => LayerLatticeSystem::Square,
+            LayerBravaisClass::hp => LayerLatticeSystem::Hexagonal,
+        }
+    }
+}
+
+impl LayerCentering {
+    pub fn from_layer_bravais_class(layer_bravais_class: LayerBravaisClass) -> Self {
+        match layer_bravais_class {
+            LayerBravaisClass::mp
+            | LayerBravaisClass::op
+            | LayerBravaisClass::tp
+            | LayerBravaisClass::hp => LayerCentering::P,
+            LayerBravaisClass::oc => LayerCentering::C,
+        }
+    }
+}
+
+/// Crystal systems applicable to layer groups.
+/// The monoclinic system is split into oblique and rectangular subcases because
+/// they differ in which axis carries the unique 2-fold (paper Figure 1).
+#[derive(Debug, Clone, Copy, PartialEq, EnumIter)]
+pub enum LayerCrystalSystem {
+    Triclinic,
+    MonoclinicOblique,
+    MonoclinicRectangular,
+    Orthorhombic,
+    Tetragonal,
+    Trigonal,
+    Hexagonal,
+}
+
+#[allow(clippy::to_string_trait_impl)]
+impl ToString for LayerCrystalSystem {
+    fn to_string(&self) -> String {
+        match self {
+            LayerCrystalSystem::Triclinic => "Triclinic".to_string(),
+            LayerCrystalSystem::MonoclinicOblique => "MonoclinicOblique".to_string(),
+            LayerCrystalSystem::MonoclinicRectangular => "MonoclinicRectangular".to_string(),
+            LayerCrystalSystem::Orthorhombic => "Orthorhombic".to_string(),
+            LayerCrystalSystem::Tetragonal => "Tetragonal".to_string(),
+            LayerCrystalSystem::Trigonal => "Trigonal".to_string(),
+            LayerCrystalSystem::Hexagonal => "Hexagonal".to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use strum::IntoEnumIterator;
+
+    use super::*;
+
+    #[test]
+    fn test_lattice_system_from_bravais() {
+        assert_eq!(
+            LayerLatticeSystem::from_layer_bravais_class(LayerBravaisClass::mp),
+            LayerLatticeSystem::Oblique
+        );
+        assert_eq!(
+            LayerLatticeSystem::from_layer_bravais_class(LayerBravaisClass::op),
+            LayerLatticeSystem::Rectangular
+        );
+        assert_eq!(
+            LayerLatticeSystem::from_layer_bravais_class(LayerBravaisClass::oc),
+            LayerLatticeSystem::Rectangular
+        );
+        assert_eq!(
+            LayerLatticeSystem::from_layer_bravais_class(LayerBravaisClass::tp),
+            LayerLatticeSystem::Square
+        );
+        assert_eq!(
+            LayerLatticeSystem::from_layer_bravais_class(LayerBravaisClass::hp),
+            LayerLatticeSystem::Hexagonal
+        );
+    }
+
+    #[test]
+    fn test_centering_from_bravais() {
+        assert_eq!(
+            LayerCentering::from_layer_bravais_class(LayerBravaisClass::oc),
+            LayerCentering::C
+        );
+        for bc in [
+            LayerBravaisClass::mp,
+            LayerBravaisClass::op,
+            LayerBravaisClass::tp,
+            LayerBravaisClass::hp,
+        ] {
+            assert_eq!(
+                LayerCentering::from_layer_bravais_class(bc),
+                LayerCentering::P
+            );
+        }
+    }
+
+    #[test]
+    fn test_to_string_round_trip() {
+        for ls in LayerLatticeSystem::iter() {
+            assert!(!ls.to_string().is_empty());
+        }
+        for bc in LayerBravaisClass::iter() {
+            assert!(!bc.to_string().is_empty());
+        }
+        for cs in LayerCrystalSystem::iter() {
+            assert!(!cs.to_string().is_empty());
+        }
+    }
+}

--- a/moyo/src/math.rs
+++ b/moyo/src/math.rs
@@ -13,4 +13,6 @@ pub use snf::SNF;
 pub(super) use delaunay::delaunay_reduce;
 pub(super) use integer_system::sylvester3;
 pub(super) use minkowski::{is_minkowski_reduced, minkowski_reduce};
+#[allow(unused_imports)]
+pub(super) use minkowski::{is_minkowski_reduced_2d, lift_2d_to_3d, minkowski_reduce_2d};
 pub(super) use niggli::{is_niggli_reduced, niggli_reduce};

--- a/moyo/src/math/minkowski.rs
+++ b/moyo/src/math/minkowski.rs
@@ -1,7 +1,8 @@
 use itertools::Itertools;
 use nalgebra::allocator::Allocator;
 use nalgebra::{
-    DMatrix, DVector, DefaultAllocator, Dim, DimName, Matrix3, OMatrix, OVector, U3, Vector3,
+    DMatrix, DVector, DefaultAllocator, Dim, DimName, Matrix2, Matrix3, OMatrix, OVector, U3,
+    Vector3,
 };
 
 use super::cycle_checker::CycleChecker;
@@ -154,14 +155,84 @@ pub fn is_minkowski_reduced(basis: &Matrix3<f64>) -> bool {
     true
 }
 
+/// Lagrange-Gauss reduction of a 2D basis (column-vector convention).
+/// Returns the reduced basis and the unimodular transformation `T` such that
+/// `basis * T == reduced` (exact under integer linear combinations of input columns).
+/// Parity is preserved (det(T) > 0).
+#[allow(dead_code)]
+pub fn minkowski_reduce_2d(basis: &Matrix2<f64>) -> (Matrix2<f64>, Matrix2<i32>) {
+    let mut b = *basis;
+    let mut t = Matrix2::<i32>::identity();
+
+    // Lagrange-Gauss: provably terminates in O(log(max norm)) steps; no cycle
+    // check needed. We bound iterations defensively to avoid infinite loops on
+    // pathological f64 inputs.
+    for _ in 0..1024 {
+        if b.column(0).norm() > b.column(1).norm() + EPS {
+            b.swap_columns(0, 1);
+            t = t * Matrix2::new(0, 1, 1, 0);
+        }
+
+        let denom = b.column(0).norm_squared();
+        if denom < EPS {
+            break;
+        }
+        let m = (b.column(0).dot(&b.column(1)) / denom).round() as i32;
+        if m == 0 {
+            break;
+        }
+
+        let new_b2 = b.column(1) - (m as f64) * b.column(0);
+        b.set_column(1, &new_b2);
+        t = t * Matrix2::new(1, -m, 0, 1);
+    }
+
+    // Preserve parity: det(T) > 0. In 2D, negating both columns leaves det unchanged,
+    // so flip a single column instead (negate b2 / second column of T).
+    if t.map(|e| e as f64).determinant() < 0. {
+        let new_b2 = -b.column(1);
+        b.set_column(1, &new_b2);
+        t = t * Matrix2::new(1, 0, 0, -1);
+    }
+
+    (b, t)
+}
+
+/// Lift a 2x2 unimodular transformation (acting on the in-plane axes) to a 3x3
+/// transformation that leaves the third axis untouched. Used to compose the
+/// in-plane reduction with the layer-group block form W_33 = +/- 1 (paper eq. 4).
+#[allow(dead_code)]
+pub fn lift_2d_to_3d(t: &Matrix2<i32>) -> Matrix3<i32> {
+    Matrix3::new(t[(0, 0)], t[(0, 1)], 0, t[(1, 0)], t[(1, 1)], 0, 0, 0, 1)
+}
+
+/// Returns true iff the 2D basis is Minkowski reduced
+/// (`|b1| <= |b2|` and `|2 b1 . b2| <= |b1|^2`).
+#[allow(dead_code)]
+pub fn is_minkowski_reduced_2d(basis: &Matrix2<f64>) -> bool {
+    let n1 = basis.column(0).norm();
+    let n2 = basis.column(1).norm();
+    if n1 > n2 + EPS {
+        return false;
+    }
+    let dot12 = basis.column(0).dot(&basis.column(1));
+    if 2.0 * dot12.abs() > basis.column(0).norm_squared() + EPS {
+        return false;
+    }
+    true
+}
+
 #[cfg(test)]
 mod tests {
-    use nalgebra::{Matrix3, Vector3};
+    use nalgebra::{Matrix2, Matrix3, Vector2, Vector3};
     use rand::SeedableRng;
     use rand::prelude::*;
     use rand::rngs::StdRng;
 
-    use super::{is_minkowski_reduced, minkowski_reduce};
+    use super::{
+        is_minkowski_reduced, is_minkowski_reduced_2d, lift_2d_to_3d, minkowski_reduce,
+        minkowski_reduce_2d,
+    };
 
     #[test]
     fn test_is_minkowski_reduced() {
@@ -268,5 +339,78 @@ mod tests {
 
         let (reduced_basis, _) = minkowski_reduce(&basis);
         assert_relative_eq!(reduced_basis, basis);
+    }
+
+    #[test]
+    fn test_minkowski_2d_basic() {
+        let basis = Matrix2::<f64>::from_columns(&[Vector2::new(1.0, 0.0), Vector2::new(0.0, 1.0)]);
+        let (reduced, t) = minkowski_reduce_2d(&basis);
+        assert!(is_minkowski_reduced_2d(&reduced));
+        assert_relative_eq!(reduced, basis);
+        assert_eq!(t, Matrix2::<i32>::identity());
+
+        let basis = Matrix2::<f64>::from_columns(&[Vector2::new(1.0, 0.0), Vector2::new(5.0, 1.0)]);
+        let (reduced, t) = minkowski_reduce_2d(&basis);
+        assert!(is_minkowski_reduced_2d(&reduced));
+        assert_relative_eq!(reduced, basis * t.map(|e| e as f64));
+    }
+
+    #[test]
+    fn test_minkowski_2d_random() {
+        let mut rng: StdRng = SeedableRng::from_seed([1; 32]);
+
+        for _ in 0..512 {
+            let basis = Matrix2::<f64>::new(
+                rng.random::<i8>() as f64,
+                rng.random::<i8>() as f64,
+                rng.random::<i8>() as f64,
+                rng.random::<i8>() as f64,
+            );
+            // Skip degenerate (rank-deficient) cases where reduction is undefined.
+            if basis.determinant().abs() < 1e-6 {
+                continue;
+            }
+            let (reduced, t) = minkowski_reduce_2d(&basis);
+            assert!(is_minkowski_reduced_2d(&reduced));
+            assert_relative_eq!(basis * t.map(|e| e as f64), reduced);
+            // Idempotence.
+            let (reduced2, t2) = minkowski_reduce_2d(&reduced);
+            assert_relative_eq!(reduced2, reduced);
+            assert_eq!(t2, Matrix2::<i32>::identity());
+            // Parity.
+            assert!(t.map(|e| e as f64).determinant() > 0.0);
+        }
+    }
+
+    #[test]
+    fn test_minkowski_2d_swap_invariance() {
+        let basis = Matrix2::<f64>::from_columns(&[Vector2::new(3.0, 0.0), Vector2::new(1.0, 2.0)]);
+        let (r1, _) = minkowski_reduce_2d(&basis);
+
+        let mut swapped = basis;
+        swapped.swap_columns(0, 1);
+        let (r2, _) = minkowski_reduce_2d(&swapped);
+        // Reduced bases agree up to column swap and column sign flip.
+        let mut equal_pair = false;
+        for s0 in [-1.0_f64, 1.0] {
+            for s1 in [-1.0_f64, 1.0] {
+                let cand = Matrix2::from_columns(&[s0 * r2.column(0), s1 * r2.column(1)]);
+                if (cand - r1).norm() < 1e-6 {
+                    equal_pair = true;
+                }
+                let cand_swap = Matrix2::from_columns(&[s0 * r2.column(1), s1 * r2.column(0)]);
+                if (cand_swap - r1).norm() < 1e-6 {
+                    equal_pair = true;
+                }
+            }
+        }
+        assert!(equal_pair);
+    }
+
+    #[test]
+    fn test_lift_2d_to_3d() {
+        let t = Matrix2::<i32>::new(2, -1, 1, 0);
+        let lifted = lift_2d_to_3d(&t);
+        assert_eq!(lifted, Matrix3::<i32>::new(2, -1, 0, 1, 0, 0, 0, 0, 1));
     }
 }

--- a/moyo/src/math/minkowski.rs
+++ b/moyo/src/math/minkowski.rs
@@ -155,19 +155,25 @@ pub fn is_minkowski_reduced(basis: &Matrix3<f64>) -> bool {
     true
 }
 
+// Lagrange-Gauss provably terminates in O(log(max norm)) steps; the bound is
+// only a defensive guard against pathological f64 inputs.
+const MINKOWSKI_2D_MAX_ITERATIONS: usize = 1024;
+
 /// Lagrange-Gauss reduction of a 2D basis (column-vector convention).
 /// Returns the reduced basis and the unimodular transformation `T` such that
 /// `basis * T == reduced` (exact under integer linear combinations of input columns).
-/// Parity is preserved (det(T) > 0).
+/// Parity is preserved (det(T) > 0). If the input is already reduced, returns
+/// `(basis, identity)`.
 #[allow(dead_code)]
 pub fn minkowski_reduce_2d(basis: &Matrix2<f64>) -> (Matrix2<f64>, Matrix2<i32>) {
+    if is_minkowski_reduced_2d(basis) {
+        return (*basis, Matrix2::<i32>::identity());
+    }
+
     let mut b = *basis;
     let mut t = Matrix2::<i32>::identity();
 
-    // Lagrange-Gauss: provably terminates in O(log(max norm)) steps; no cycle
-    // check needed. We bound iterations defensively to avoid infinite loops on
-    // pathological f64 inputs.
-    for _ in 0..1024 {
+    for _ in 0..MINKOWSKI_2D_MAX_ITERATIONS {
         if b.column(0).norm() > b.column(1).norm() + EPS {
             b.swap_columns(0, 1);
             t = t * Matrix2::new(0, 1, 1, 0);

--- a/moyo/src/search/primitive_symmetry_search.rs
+++ b/moyo/src/search/primitive_symmetry_search.rs
@@ -15,7 +15,7 @@ use super::{
 use crate::base::{
     AngleTolerance, Cell, EPS, Lattice, MagneticCell, MagneticMoment, MagneticOperation,
     MagneticOperations, MoyoError, Operation, Operations, Permutation, Rotation,
-    RotationMagneticMomentAction, Rotations, Transformation, traverse,
+    RotationMagneticMomentAction, Rotations, Transformation, is_angle_within_tolerance, traverse,
 };
 
 #[derive(Debug)]
@@ -451,19 +451,15 @@ fn compare_nondiagonal_matrix_tensor_element(
 ) -> bool {
     let theta_org = basis.column(col1).angle(&basis.column(col2));
     let theta_new = b1.angle(b2);
-    let cos_dtheta = theta_org.cos() * theta_new.cos() + theta_org.sin() * theta_new.sin();
-
-    match angle_tolerance {
-        AngleTolerance::Radian(angle_tolerance) => cos_dtheta.acos().abs() < angle_tolerance,
-        AngleTolerance::Default => {
-            // Eq.(7) of https://arxiv.org/pdf/1808.01590.pdf
-            let sin_dtheta2 = 1.0 - cos_dtheta.powi(2);
-            let length_ave2 = (basis.column(col1).norm() + b1.norm())
-                * (basis.column(col2).norm() + b2.norm())
-                / 4.0;
-            sin_dtheta2 * length_ave2 < symprec * symprec
-        }
-    }
+    let len_u = (basis.column(col1).norm() + b1.norm()) / 2.0;
+    let len_v = (basis.column(col2).norm() + b2.norm()) / 2.0;
+    is_angle_within_tolerance(
+        theta_new - theta_org,
+        len_u,
+        len_v,
+        symprec,
+        angle_tolerance,
+    )
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

**Scope (after split):** data and math foundations for layer-group support. Search, `LayerCell` newtype, and integration tests are deferred to the follow-up PR (`feat/layer-group-search`) per reviewer request — review this one first.

This PR delivers M1 from the [layer-group plan](.claude/plans/layer-group-support.md) §8: the static type/data layer plus the math primitives the search pipeline will consume.

### Data layer (`moyo/src/data/`)
- `LayerCentering` enum (`p`, `c`) with `linear` / `inverse` / `lattice_points` (mirrors `Centering`).
- `LayerLatticeSystem` (4), `LayerBravaisClass` (`mp`, `op`, `oc`, `tp`, `hp`), `LayerCrystalSystem` (6 -- single Monoclinic per paper Table 2) enums.
- `LayerArithmeticCrystalClassEntry` table -- 43 entries transcribed from Fu et al. 2024 Table 4. The plan said 27 originally; we verified independently (IUCr Dictionary + paper Table 4) that 43 is the canonical count under the orientation-splitting convention moyo already uses for its 73-row 3D table. Plan §5.1 was updated.

### Math (`moyo/src/math/minkowski.rs`)
- `minkowski_reduce_2d` (Lagrange-Gauss), `is_minkowski_reduced_2d`, `lift_2d_to_3d`. Short-circuit to identity transform when input is already reduced (mirrors the 3D path).
- The existing 3D `minkowski_reduce_greedy` is typed-generic but has hardcoded 3D arithmetic, so a dedicated 2D routine is simpler than retrofitting.

### Validator + error variant (`moyo/src/base/`)
- `validate_aperiodic_axis(cell, symprec, angle_tolerance)` enforcing `c perp a, b` per plan §3.2.
- `MoyoError::AperiodicAxisNotOrthogonal { dev_ca, dev_cb }` variant carrying the measured deviations. Dropped `Eq` from `MoyoError` derives (f64 isn't Eq); `Copy` is preserved.

### Tolerance helper (`moyo/src/base/tolerance.rs`)
- `is_angle_within_tolerance(dtheta, len_u, len_v, symprec, angle_tolerance)` -- single point of truth for resolving `AngleTolerance::Default` (Eq.(7) of arXiv:1808.01590). Both `validate_aperiodic_axis` and the existing `compare_nondiagonal_matrix_tensor_element` delegate to it.

## What's intentionally NOT in this PR

The follow-up PR (`feat/layer-group-search`) will add:
- `LayerCell` newtype (one-way `Cell -> LayerCell` conversion).
- `LayerPrimitiveCell` (2D primitive-cell finder with c-component filter, `MoyoError::SpuriousAperiodicTranslation`).
- LG-restricted Bravais filter (`search_layer_bravais_group`).
- `LayerPrimitiveSymmetrySearch` and `p1` / `p112` / `p4mm` round-trip integration tests.

## Test plan
- [x] `cargo test -p moyo` -- 114 tests pass (87 lib unit + 22 dataset + 4 magnetic + 1 doc).
- [x] `prek run --all-files` clean.
- [ ] Reviewer: spot-check the 43 entries in `data/layer_arithmetic_crystal_class.rs` against Fu Table 4 (PDF in `.claude/resources/`).

[Claude Code] Generated with [Claude Code](https://claude.com/claude-code)
