### PR TITLE
refactor(moyo): extract orbit / Wyckoff helpers in standardize

### DIFF
--- a/moyo/src/symmetrize/standardize.rs
+++ b/moyo/src/symmetrize/standardize.rs
@@ -145,20 +145,18 @@ impl StandardizedCell {
 
         let prim_std_cell_tmp = prim_transformation.transform_cell(prim_cell);
 
-        // Symmetrize positions of prim_std_cell by refined symmetry operations
-        // Reorder permutations because prim_std_operations may have different order from symmetry_search.operations!
-        let mut permutation_mapping = HashMap::new();
-        let prim_rotations =
-            project_rotations(&prim_transformation.transform_operations(prim_operations));
-        for (prim_rotation, permutation) in prim_rotations.iter().zip(prim_permutations.iter()) {
-            permutation_mapping.insert(*prim_rotation, permutation.clone());
-        }
-        let prim_std_permutations = prim_std_operations
-            .iter()
-            .map(|ops| permutation_mapping.get(&ops.rotation).unwrap().clone())
-            .collect::<Vec<_>>();
+        // Symmetrize positions of prim_std_cell by refined symmetry operations.
+        // Reorder permutations because prim_std_operations (from the Hall-symbol
+        // traversal) is in a different order than `prim_operations` (from the
+        // symmetry search).
+        let prim_std_permutations = align_primitive_permutations(
+            &prim_transformation,
+            prim_operations,
+            prim_permutations,
+            &prim_std_operations,
+        )?;
         let new_prim_std_positions = symmetrize_positions(
-            &prim_std_cell_tmp,
+            &prim_std_cell_tmp.positions,
             &prim_std_operations,
             &prim_std_permutations,
             epsilon,
@@ -214,66 +212,19 @@ impl StandardizedCell {
         hall_number: HallNumber,
         symprec: f64,
     ) -> Result<Vec<WyckoffPosition>, MoyoError> {
-        // Group sites in std_cell by crystallographic orbits
-        let orbits = orbits_in_cell(
+        let group = group_sites_by_orbit(
             prim_std_cell.num_atoms(),
             prim_std_permutations,
             site_mapping,
+            std_cell.num_atoms(),
         );
-        let mut num_orbits = 0;
-        let mut mapping = vec![0; std_cell.num_atoms()]; // [std_cell.num_atoms()] -> [num_orbits]
-        let mut remapping = vec![]; // [num_orbits] -> [std_cell.num_atoms()]
-        for i in 0..std_cell.num_atoms() {
-            if orbits[i] == i {
-                mapping[i] = num_orbits;
-                remapping.push(i);
-                num_orbits += 1;
-            } else {
-                mapping[i] = mapping[orbits[i]];
-            }
-        }
-
-        // multiplicities: orbit -> multiplicity
-        let mut multiplicities = vec![0; num_orbits];
-        for i in 0..std_cell.num_atoms() {
-            multiplicities[mapping[i]] += 1;
-        }
-        // Assign Wyckoff positions to representative sites: orbit -> WyckoffPosition
-        let mut representative_wyckoffs = vec![None; num_orbits];
-        for (i, position) in std_cell.positions.iter().enumerate() {
-            let orbit = mapping[i];
-            if representative_wyckoffs[orbit].is_some() {
-                continue;
-            }
-
-            if let Ok(wyckoff) = assign_wyckoff_position(
-                position,
-                multiplicities[orbit],
-                hall_number,
-                &std_cell.lattice,
-                symprec,
-            ) {
-                representative_wyckoffs[orbit] = Some(wyckoff);
-            }
-        }
-
-        for (i, wyckoff) in representative_wyckoffs.iter().enumerate() {
-            if wyckoff.is_none() {
-                debug!(
-                    "Failed to assign Wyckoff positions with multiplicity {}: {:?}",
-                    multiplicities[i], std_cell.positions[i]
-                );
-            }
-        }
-        let representative_wyckoffs = representative_wyckoffs
-            .into_iter()
-            .map(|wyckoff| wyckoff.ok_or(MoyoError::WyckoffPositionAssignmentError))
-            .collect::<Result<Vec<_>, _>>()?;
-
-        let wyckoffs = (0..std_cell.num_atoms())
-            .map(|i| representative_wyckoffs[mapping[orbits[i]]].clone())
-            .collect::<Vec<_>>();
-        Ok(wyckoffs)
+        assign_wyckoffs_by_orbit(&group, &std_cell.positions, |position, multiplicity| {
+            iter_wyckoff_positions(hall_number, multiplicity)
+                .find(|w| {
+                    match_wyckoff_coordinates(position, w.coordinates, &std_cell.lattice, symprec)
+                })
+                .cloned()
+        })
     }
 }
 
@@ -298,6 +249,130 @@ pub fn orbits_in_cell(
         orbits.push(*map.get(&key).unwrap());
     }
     orbits
+}
+
+/// Group sites of a conventional cell by crystallographic orbit. Shared
+/// between the bulk and layer pipelines.
+pub(super) struct OrbitGrouping {
+    /// `[std_num_atoms] -> [num_orbits]`: orbit index for each site.
+    pub mapping: Vec<usize>,
+    /// `[num_orbits] -> [std_num_atoms]`: representative site for each orbit
+    /// (the lowest-index site in the orbit). Used only for diagnostics.
+    pub remapping: Vec<usize>,
+    /// Number of sites per orbit, indexed by orbit. `multiplicities.len()` is
+    /// the orbit count.
+    pub multiplicities: Vec<usize>,
+}
+
+pub(super) fn group_sites_by_orbit(
+    prim_num_atoms: usize,
+    prim_permutations: &[Permutation],
+    site_mapping: &[usize],
+    std_num_atoms: usize,
+) -> OrbitGrouping {
+    let orbits = orbits_in_cell(prim_num_atoms, prim_permutations, site_mapping);
+
+    let mut num_orbits = 0;
+    let mut mapping = vec![0; std_num_atoms];
+    let mut remapping = vec![];
+    for i in 0..std_num_atoms {
+        if orbits[i] == i {
+            mapping[i] = num_orbits;
+            remapping.push(i);
+            num_orbits += 1;
+        } else {
+            mapping[i] = mapping[orbits[i]];
+        }
+    }
+
+    let mut multiplicities = vec![0; num_orbits];
+    for i in 0..std_num_atoms {
+        multiplicities[mapping[i]] += 1;
+    }
+
+    OrbitGrouping {
+        mapping,
+        remapping,
+        multiplicities,
+    }
+}
+
+/// Align a set of primitive-cell permutations (as produced by the symmetry
+/// search) with a target operation list (as produced by traversing a Hall
+/// symbol) by matching rotation matrices. Both pipelines need this because
+/// the search and the database traversal generate operations in different
+/// orders. Errors with `StandardizationError` if any target rotation is
+/// missing from the input — i.e. the input set is not closed under the
+/// transformation, which would indicate a primitive-cell or
+/// hall-symbol-database bug rather than a user error.
+pub(super) fn align_primitive_permutations(
+    prim_transformation: &UnimodularTransformation,
+    prim_operations: &Operations,
+    prim_permutations: &[Permutation],
+    target_operations: &Operations,
+) -> Result<Vec<Permutation>, MoyoError> {
+    let mut permutation_mapping = HashMap::new();
+    let prim_rotations =
+        project_rotations(&prim_transformation.transform_operations(prim_operations));
+    for (rot, perm) in prim_rotations.iter().zip(prim_permutations.iter()) {
+        permutation_mapping.insert(*rot, perm.clone());
+    }
+    target_operations
+        .iter()
+        .map(|ops| {
+            permutation_mapping
+                .get(&ops.rotation)
+                .cloned()
+                .ok_or(MoyoError::StandardizationError)
+        })
+        .collect()
+}
+
+/// Run the per-orbit Wyckoff-assignment loop over a precomputed
+/// `OrbitGrouping`. The closure produces the database-specific Wyckoff
+/// representative for an `(orbit_position, multiplicity)` pair (returning
+/// `None` if no orbit in the database matches that multiplicity at that
+/// position). Shared between bulk and layer pipelines: the only thing that
+/// differs is the database lookup, which the caller passes in as the
+/// closure.
+pub(super) fn assign_wyckoffs_by_orbit<W, F>(
+    group: &OrbitGrouping,
+    positions: &[Position],
+    mut find_for_orbit: F,
+) -> Result<Vec<W>, MoyoError>
+where
+    W: Clone,
+    F: FnMut(&Position, usize) -> Option<W>,
+{
+    let mut representative_wyckoffs: Vec<Option<W>> = vec![None; group.multiplicities.len()];
+    for (i, position) in positions.iter().enumerate() {
+        let orbit = group.mapping[i];
+        if representative_wyckoffs[orbit].is_some() {
+            continue;
+        }
+        if let Some(w) = find_for_orbit(position, group.multiplicities[orbit]) {
+            representative_wyckoffs[orbit] = Some(w);
+        }
+    }
+
+    for (orbit, wyckoff) in representative_wyckoffs.iter().enumerate() {
+        if wyckoff.is_none() {
+            debug!(
+                "Failed to assign Wyckoff position with multiplicity {} at representative site {}",
+                group.multiplicities[orbit], group.remapping[orbit]
+            );
+        }
+    }
+    let representative_wyckoffs = representative_wyckoffs
+        .into_iter()
+        .map(|w| w.ok_or(MoyoError::WyckoffPositionAssignmentError))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(group
+        .mapping
+        .iter()
+        .map(|&orbit| representative_wyckoffs[orbit].clone())
+        .collect())
 }
 
 /// Niggli reduction for distorted triclinic lattice systems is numerically so challenging.
@@ -391,60 +466,56 @@ fn standardize_monoclinic_conv_cell(
         .1
 }
 
-/// Assign a Wyckoff position by solving for a compatible integer offset.
+/// Test whether `position` matches a Wyckoff orbit described by `coordinates`
+/// (the parsed-coordinates string from a Wyckoff entry, e.g. `"x,1/2,z"`)
+/// modulo a bounded integer offset. Shared between the bulk and layer
+/// pipelines: both Wyckoff databases store their representative coordinate as
+/// the same `&str` shape, so the SNF-based offset search is identical.
 ///
-/// This function first tries offsets in `[-1, 1]^3` and then the remaining
-/// shell in `[-2, 2]^3`. This bounded integer search is heuristic. If no
-/// compatible offset is found in the bounded window,
-/// `MoyoError::WyckoffPositionAssignmentError` is returned.
-fn assign_wyckoff_position(
+/// The search probes offsets in `[-1, 1]^3` first, then the remaining shell
+/// in `[-2, 2]^3`. The math (suppressing tolerances): we want `y, offset` so
+/// that `lattice * (space.linear * y + space.origin - position - offset)` is
+/// near zero. Decomposing `space.linear` as `D = L * space.linear * R` (SNF)
+/// reduces the integer search to picking `D^{-1} L (offset + position -
+/// space.origin)` and reading off whether the residual is small in Cartesian
+/// distance.
+pub(super) fn match_wyckoff_coordinates(
     position: &Position,
-    multiplicity: usize,
-    hall_number: HallNumber,
+    coordinates: &str,
     lattice: &Lattice,
     symprec: f64,
-) -> Result<WyckoffPosition, MoyoError> {
-    for wyckoff in iter_wyckoff_positions(hall_number, multiplicity) {
-        // Find variable `y` and integers offset `offset` such that
-        //    | lattice * (space.linear * y + space.origin - position - offset) | < symprec.
-        // Let SNF decomposition of space.linear be
-        //    D = L * space.linear * R.
-        // lattice * (space.linear * y + space.origin - position - offset)
-        //    = lattice * (L^-1 * D * R^-1 * y + space.origin - position - offset)
-        //    = lattice * L^-1 * (D * R^-1 * y + L * (space.origin - position - offset))
+) -> bool {
+    let space = WyckoffPositionSpace::new(coordinates);
+    let snf = SNF::new(&space.linear);
 
-        //    = lattice * (D * R^-1 * y - L * (offset + position - space.origin)
-        let space = WyckoffPositionSpace::new(wyckoff.coordinates);
-        let snf = SNF::new(&space.linear);
+    let iter_multi_1 = iproduct!(-1..=1, -1..=1, -1..=1);
+    let iter_multi_2 = iproduct!(-2_i32..=2_i32, -2_i32..=2_i32, -2_i32..=2_i32)
+        .filter(|&(n1, n2, n3)| n1.abs() == 2 || n2.abs() == 2 || n3.abs() == 2);
 
-        // Try the bounded `[-2, 2]^3` window heuristically.
-        let iter_multi_1 = iproduct!(-1..=1, -1..=1, -1..=1);
-        let iter_multi_2 = iproduct!(-2_i32..=2_i32, -2_i32..=2_i32, -2_i32..=2_i32)
-            .filter(|&(n1, n2, n3)| n1.abs() == 2 || n2.abs() == 2 || n3.abs() == 2);
-
-        for offset in iter_multi_1.chain(iter_multi_2) {
-            let offset = Vector3::new(offset.0 as f64, offset.1 as f64, offset.2 as f64);
-            let b = snf.l.map(|e| e as f64) * (offset + position - space.origin);
-            let mut rinvy = Vector3::zeros();
-            for i in 0..3 {
-                if snf.d[(i, i)] != 0 {
-                    rinvy[i] = b[i] / snf.d[(i, i)] as f64;
-                }
-            }
-
-            let y = snf.r.map(|e| e as f64) * rinvy;
-            let diff = space.linear.map(|e| e as f64) * y + space.origin - position - offset;
-            if lattice.cartesian_coords(&diff).norm() < symprec {
-                return Ok(wyckoff.clone());
+    for offset in iter_multi_1.chain(iter_multi_2) {
+        let offset = Vector3::new(offset.0 as f64, offset.1 as f64, offset.2 as f64);
+        let b = snf.l.map(|e| e as f64) * (offset + position - space.origin);
+        let mut rinvy = Vector3::zeros();
+        for i in 0..3 {
+            if snf.d[(i, i)] != 0 {
+                rinvy[i] = b[i] / snf.d[(i, i)] as f64;
             }
         }
+
+        let y = snf.r.map(|e| e as f64) * rinvy;
+        let diff = space.linear.map(|e| e as f64) * y + space.origin - position - offset;
+        if lattice.cartesian_coords(&diff).norm() < symprec {
+            return true;
+        }
     }
-    Err(MoyoError::WyckoffPositionAssignmentError)
+    false
 }
 
-/// Symmetrize positions by site symmetry groups
-fn symmetrize_positions(
-    cell: &Cell,
+/// Symmetrize positions by site symmetry groups. Operates on a slice rather
+/// than `&Cell` so the layer pipeline (which threads `LayerCell::positions()`)
+/// can reuse it.
+pub(super) fn symmetrize_positions(
+    positions: &[Position],
     operations: &Operations,
     permutations: &[Permutation],
     epsilon: f64,
@@ -456,14 +527,14 @@ fn symmetrize_positions(
         .map(|permutation| permutation.inverse())
         .collect::<Vec<_>>();
 
-    (0..cell.num_atoms())
+    (0..positions.len())
         .map(|i| {
             let mut acc = Vector3::zeros();
             for (inv_perm, operation) in inverse_permutations.iter().zip(operations.iter()) {
                 let mut frac_displacements = operation.rotation.map(|e| e as f64)
-                    * cell.positions[inv_perm.apply(i)]
+                    * positions[inv_perm.apply(i)]
                     + operation.translation
-                    - cell.positions[i];
+                    - positions[i];
                 frac_displacements -= frac_displacements.map(|e| e.round()); // in [-0.5, 0.5]
                 acc += frac_displacements;
             }
@@ -474,7 +545,7 @@ fn symmetrize_positions(
                     acc, i
                 )
             }
-            cell.positions[i] + acc
+            positions[i] + acc
         })
         .collect::<Vec<_>>()
 }


### PR DESCRIPTION
## Summary

Refactor `moyo/src/symmetrize/standardize.rs` to factor out the reusable pieces of the standardization pipeline. No behaviour change; bulk space-group / magnetic results are bit-identical.

This is a **precursor PR for #306 (layer-group M4 standardization)**: the layer pipeline ends up needing the same orbit bookkeeping, permutation alignment, and Wyckoff-matching machinery, so extracting it here lets that PR land as a much smaller, layer-only diff.

New `pub(super)` items in `standardize.rs`:

- **`OrbitGrouping`** + **`group_sites_by_orbit`** — the conventional-cell → orbit-index bundle (`mapping`, `remapping`, `multiplicities`). Replaces three hand-rolled loops in `assign_wyckoffs`.
- **`align_primitive_permutations`** — matches search-order permutations to database-order operations by rotation key. Replaces the inline `HashMap<Rotation, Permutation>` block in `standardize_and_symmetrize_cell`.
- **`assign_wyckoffs_by_orbit<W, F>`** — generic per-orbit assignment loop, parameterised by a closure that does the database lookup. Bulk `assign_wyckoffs` collapses to a `group_sites_by_orbit` + `assign_wyckoffs_by_orbit` call.
- **`match_wyckoff_coordinates`** — the SNF + bounded integer-offset matcher, factored out of the old `assign_wyckoff_position`.
- **`symmetrize_positions`** — now takes `&[Position]` instead of `&Cell`, so callers that only have a position slice can reuse it.

Net diff on `standardize.rs`: +188 / −117 lines.

The factored helpers also fix a pre-existing index-conflation in the failure debug log inside `assign_wyckoffs` — `std_cell.positions[orbit_index]` was indexing a positions vector with an orbit index; now it logs `OrbitGrouping::remapping[orbit]` (the representative site index for that orbit).

## Test plan

- [x] `cargo test -p moyo` — 126 lib + 22 dataset + 4 magnetic + 3 layer-symmetry integration tests all pass.
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p moyo` — no new warnings.

[Claude Code] Generated with [Claude Code](https://claude.com/claude-code)
