### PR TITLE
feat(moyo): MoyoLayerDataset public API (M5 step 1)

### DIFF
--- a/moyo/src/data/layer_wyckoff.rs
+++ b/moyo/src/data/layer_wyckoff.rs
@@ -9,7 +9,6 @@ use super::layer_hall_symbol_database::LayerHallNumber;
 /// caller (`assign_layer_wyckoff_position`) recovers the orbit by an integer
 /// offset search, so the secondary coordinates are not needed.
 #[derive(Debug, Clone)]
-#[allow(dead_code)] // `letter` and `site_symmetry` are read by `MoyoLayerDataset` (not yet wired up).
 pub struct LayerWyckoffPosition {
     pub hall_number: LayerHallNumber,
     /// Multiplicity in the conventional layer cell.

--- a/moyo/src/lib.rs
+++ b/moyo/src/lib.rs
@@ -491,7 +491,6 @@ impl MoyoLayerDataset {
         let prim_std_origin_shift =
             prim_cell_linear_inv * std_layer.prim_transformation.origin_shift;
 
-        // Pearson symbol: 2D Bravais type + standardized atom count.
         let entry = layer_hall_symbol_entry(layer_group.hall_number).unwrap();
         let layer_arith = layer_arithmetic_crystal_class_entry(entry.arithmetic_number).unwrap();
         let pearson_symbol = format!(

--- a/moyo/src/lib.rs
+++ b/moyo/src/lib.rs
@@ -93,19 +93,23 @@ mod symmetrize;
 pub use base::MoyoError as Error;
 
 use crate::base::{
-    AngleTolerance, Cell, MagneticCell, MagneticMoment, MagneticOperations, MoyoError, Operations,
-    OriginShift, RotationMagneticMomentAction,
+    AngleTolerance, Cell, LayerCell, MagneticCell, MagneticMoment, MagneticOperations, MoyoError,
+    Operation, Operations, OriginShift, RotationMagneticMomentAction, Transformation,
 };
 use crate::data::{
-    ArithmeticCrystalClassEntry, HallNumber, HallSymbolEntry, Number, Setting, UNINumber,
-    arithmetic_crystal_class_entry, hall_symbol_entry,
+    ArithmeticCrystalClassEntry, HallNumber, HallSymbolEntry, LayerArithmeticCrystalClassEntry,
+    LayerHallNumber, LayerHallSymbolEntry, LayerNumber, LayerSetting, Number, Setting, UNINumber,
+    arithmetic_crystal_class_entry, hall_symbol_entry, layer_arithmetic_crystal_class_entry,
+    layer_hall_symbol_entry,
 };
-use crate::identify::{MagneticSpaceGroup, SpaceGroup};
+use crate::identify::{LayerGroup, MagneticSpaceGroup, SpaceGroup};
 use crate::search::{
-    iterative_magnetic_symmetry_search, iterative_symmetry_search,
-    magnetic_operations_in_magnetic_cell, operations_in_cell,
+    LayerPrimitiveCell, LayerPrimitiveSymmetrySearch, iterative_magnetic_symmetry_search,
+    iterative_symmetry_search, magnetic_operations_in_magnetic_cell, operations_in_cell,
 };
-use crate::symmetrize::{StandardizedCell, StandardizedMagneticCell, orbits_in_cell};
+use crate::symmetrize::{
+    StandardizedCell, StandardizedLayerCell, StandardizedMagneticCell, orbits_in_cell,
+};
 use crate::utils::{to_3_slice, to_3x3_slice};
 
 use nalgebra::Matrix3;
@@ -348,6 +352,248 @@ impl MoyoDataset {
     pub fn arithmetic_crystal_class(&self) -> ArithmeticCrystalClassEntry {
         arithmetic_crystal_class_entry(self.hall_symbol().arithmetic_number).unwrap()
     }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+/// A dataset containing layer-group symmetry information of the input crystal
+/// structure (a 2D-periodic system whose third basis vector is the aperiodic
+/// stacking direction; paper Fu et al. 2024 §2).
+///
+/// Mirrors [`MoyoDataset`] for the bulk space-group case, but the input must
+/// satisfy the layer-group periodicity contract (`c` perpendicular to `a, b`)
+/// enforced by [`LayerCell::new`].
+pub struct MoyoLayerDataset {
+    // ------------------------------------------------------------------------
+    // Identification
+    // ------------------------------------------------------------------------
+    /// Layer group number (1 - 80, paper Fu et al. 2024 Table 5).
+    pub number: LayerNumber,
+    /// Layer Hall symbol number (1 - 116).
+    pub hall_number: LayerHallNumber,
+    /// Hermann-Mauguin symbol in short notation.
+    pub hm_symbol: String,
+    // ------------------------------------------------------------------------
+    // Symmetry operations in the input cell
+    // ------------------------------------------------------------------------
+    /// Layer-group operations in the input cell.
+    pub operations: Operations,
+    // ------------------------------------------------------------------------
+    // Site symmetry
+    // ------------------------------------------------------------------------
+    /// The `i`th atom in the input cell is equivalent to the `orbits[i]`th atom
+    /// in the input cell. Convention matches [`MoyoDataset::orbits`].
+    pub orbits: Vec<usize>,
+    /// Wyckoff letters for each site in the input cell.
+    pub wyckoffs: Vec<char>,
+    /// Site symmetry symbols for each site in the input cell, oriented w.r.t.
+    /// the standardized cell.
+    pub site_symmetry_symbols: Vec<String>,
+    // ------------------------------------------------------------------------
+    // Standardized layer cell
+    // ------------------------------------------------------------------------
+    /// Conventional standardized layer cell. See
+    /// [`moyopy/docs/layer_standardization.md`] for the output convention.
+    pub std_cell: LayerCell,
+    /// Linear part of the transformation from the input cell to `std_cell`.
+    pub std_linear: Matrix3<f64>,
+    /// Origin shift of the transformation from the input cell to `std_cell`.
+    pub std_origin_shift: OriginShift,
+    /// Rigid rotation applied to the lattice basis when `rotate_basis = true`,
+    /// identity otherwise.
+    pub std_rotation_matrix: Matrix3<f64>,
+    /// Pearson symbol for the standardized layer cell. The first two characters
+    /// are the 2D Bravais type (`mp`, `op`, `oc`, `tp`, or `hp`).
+    pub pearson_symbol: String,
+    // ------------------------------------------------------------------------
+    // Primitive standardized layer cell
+    // ------------------------------------------------------------------------
+    /// Primitive standardized layer cell.
+    pub prim_std_cell: LayerCell,
+    /// Linear part of the transformation from the input cell to `prim_std_cell`.
+    pub prim_std_linear: Matrix3<f64>,
+    /// Origin shift of the transformation from the input cell to `prim_std_cell`.
+    pub prim_std_origin_shift: OriginShift,
+    /// Mapping sites in the input cell to those in `prim_std_cell`.
+    pub mapping_std_prim: Vec<usize>,
+    // ------------------------------------------------------------------------
+    // Final parameters
+    // ------------------------------------------------------------------------
+    /// `symprec` used for the symmetry search.
+    pub symprec: f64,
+    /// `angle_tolerance` used for the symmetry search.
+    pub angle_tolerance: AngleTolerance,
+}
+
+impl MoyoLayerDataset {
+    /// Identify the layer group of `cell` and produce a [`MoyoLayerDataset`].
+    ///
+    /// `cell` must satisfy the layer-group periodicity contract (`c`
+    /// perpendicular to `a, b`); inputs that violate it are rejected with
+    /// [`MoyoError::AperiodicAxisNotOrthogonal`].
+    pub fn new(
+        cell: &Cell,
+        symprec: f64,
+        angle_tolerance: AngleTolerance,
+        setting: LayerSetting,
+        rotate_basis: bool,
+    ) -> Result<Self, MoyoError> {
+        let layer_cell = LayerCell::new(cell.clone(), symprec, angle_tolerance)?;
+        let prim_layer = LayerPrimitiveCell::new(&layer_cell, symprec)?;
+        let symmetry_search =
+            LayerPrimitiveSymmetrySearch::new(&prim_layer.layer_cell, symprec, angle_tolerance)?;
+
+        let prim_volume = prim_layer.layer_cell.lattice().basis().determinant().abs();
+        let epsilon = symprec / prim_volume.powf(1.0 / 3.0);
+
+        let layer_group = LayerGroup::new(&symmetry_search.operations, setting, epsilon)?;
+
+        let std_layer = StandardizedLayerCell::new(
+            &prim_layer.layer_cell,
+            &symmetry_search.operations,
+            &symmetry_search.permutations,
+            &layer_group,
+            symprec,
+            epsilon,
+            rotate_basis,
+        )?;
+
+        let operations = layer_operations_in_cell(&prim_layer, &symmetry_search.operations);
+
+        // Site symmetry. `StandardizedLayerCell.prim_layer_cell` and
+        // `prim_layer.layer_cell` share the same site order (mirrors the bulk
+        // pipeline), so the prim-cell Wyckoffs are looked up via `site_mapping`.
+        let mapping_std_prim = prim_layer.site_mapping.clone();
+        let orbits = orbits_in_cell(
+            prim_layer.layer_cell.num_atoms(),
+            &symmetry_search.permutations,
+            &prim_layer.site_mapping,
+        );
+        let mut std_prim_wyckoffs = vec![None; prim_layer.layer_cell.num_atoms()];
+        for (i, wyckoff) in std_layer.wyckoffs.iter().enumerate() {
+            let j = std_layer.site_mapping[i];
+            if std_prim_wyckoffs[j].is_none() {
+                std_prim_wyckoffs[j] = Some(wyckoff.clone());
+            }
+        }
+        let wyckoffs: Option<Vec<_>> = mapping_std_prim
+            .iter()
+            .map(|&i| std_prim_wyckoffs[i].clone())
+            .collect();
+        let wyckoffs = wyckoffs.ok_or(MoyoError::WyckoffPositionAssignmentError)?;
+
+        // Compose linear maps:
+        //   cell <-(prim_layer.linear, 0)- prim_layer.layer_cell -(std_layer.transformation)-> std_layer.layer_cell
+        // (std_linear, std_origin_shift) = (prim_layer.linear^-1, 0) * std_layer.transformation
+        let prim_cell_linear_inv = prim_layer.linear.map(|e| e as f64).try_inverse().unwrap();
+        let std_linear = prim_cell_linear_inv * std_layer.transformation.linear_as_f64();
+        let std_origin_shift = prim_cell_linear_inv * std_layer.transformation.origin_shift;
+        let prim_std_linear = prim_cell_linear_inv * std_layer.prim_transformation.linear_as_f64();
+        let prim_std_origin_shift =
+            prim_cell_linear_inv * std_layer.prim_transformation.origin_shift;
+
+        // Pearson symbol: 2D Bravais type + standardized atom count.
+        let entry = layer_hall_symbol_entry(layer_group.hall_number).unwrap();
+        let layer_arith = layer_arithmetic_crystal_class_entry(entry.arithmetic_number).unwrap();
+        let pearson_symbol = format!(
+            "{}{}",
+            layer_arith.layer_bravais_class.to_string(),
+            std_layer.layer_cell.num_atoms()
+        );
+
+        Ok(Self {
+            number: layer_group.number,
+            hall_number: layer_group.hall_number,
+            hm_symbol: entry.hm_short.to_string(),
+            operations,
+            orbits,
+            wyckoffs: wyckoffs.iter().map(|w| w.letter).collect(),
+            site_symmetry_symbols: wyckoffs
+                .iter()
+                .map(|w| w.site_symmetry.to_string())
+                .collect(),
+            std_cell: std_layer.layer_cell,
+            std_linear,
+            std_origin_shift,
+            std_rotation_matrix: std_layer.rotation_matrix,
+            pearson_symbol,
+            prim_std_cell: std_layer.prim_layer_cell,
+            prim_std_linear,
+            prim_std_origin_shift,
+            mapping_std_prim,
+            symprec,
+            angle_tolerance,
+        })
+    }
+
+    /// Identify the layer group of `cell` with default parameters
+    /// ([`AngleTolerance::Default`], [`LayerSetting::Standard`],
+    /// `rotate_basis = true`).
+    pub fn with_default(cell: &Cell, symprec: f64) -> Result<Self, MoyoError> {
+        Self::new(
+            cell,
+            symprec,
+            AngleTolerance::default(),
+            LayerSetting::default(),
+            true,
+        )
+    }
+
+    /// Number of layer-group operations in the input cell.
+    pub fn num_operations(&self) -> usize {
+        self.operations.len()
+    }
+
+    /// `std_linear` as a 3x3 array.
+    pub fn std_linear_as_array(&self) -> [[f64; 3]; 3] {
+        to_3x3_slice(&self.std_linear)
+    }
+
+    /// `std_origin_shift` as a 3-array.
+    pub fn std_origin_shift_as_array(&self) -> [f64; 3] {
+        to_3_slice(&self.std_origin_shift)
+    }
+
+    /// `std_rotation_matrix` as a 3x3 array.
+    pub fn std_rotation_matrix_as_array(&self) -> [[f64; 3]; 3] {
+        to_3x3_slice(&self.std_rotation_matrix)
+    }
+
+    /// `prim_std_linear` as a 3x3 array.
+    pub fn prim_std_linear_as_array(&self) -> [[f64; 3]; 3] {
+        to_3x3_slice(&self.prim_std_linear)
+    }
+
+    /// `prim_std_origin_shift` as a 3-array.
+    pub fn prim_std_origin_shift_as_array(&self) -> [f64; 3] {
+        to_3_slice(&self.prim_std_origin_shift)
+    }
+
+    /// Hall symbol entry for the identified layer group.
+    pub fn hall_symbol(&self) -> LayerHallSymbolEntry {
+        layer_hall_symbol_entry(self.hall_number).unwrap().clone()
+    }
+
+    /// Arithmetic crystal class entry for the identified layer group.
+    pub fn arithmetic_crystal_class(&self) -> LayerArithmeticCrystalClassEntry {
+        layer_arithmetic_crystal_class_entry(self.hall_symbol().arithmetic_number).unwrap()
+    }
+}
+
+/// Lift primitive-layer-cell operations to operations in the input cell.
+/// Mirrors [`crate::search::operations_in_cell`] but consumes
+/// [`LayerPrimitiveCell`] (whose pure-translation set is in-plane only).
+fn layer_operations_in_cell(prim: &LayerPrimitiveCell, prim_operations: &Operations) -> Operations {
+    let input_operations =
+        Transformation::from_linear(prim.linear).transform_operations(prim_operations);
+    let mut operations = vec![];
+    for t1 in prim.translations.iter() {
+        for op2 in input_operations.iter() {
+            // (E, t1) (rotation, t2) = (rotation, t1 + t2)
+            let t12 = (t1 + op2.translation).map(|e| e % 1.);
+            operations.push(Operation::new(op2.rotation, t12));
+        }
+    }
+    operations
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/moyo/src/search.rs
+++ b/moyo/src/search.rs
@@ -10,9 +10,7 @@ pub use solve::{
     PeriodicKdTree, PeriodicNeighbor, solve_correspondence, solve_correspondence_naive,
 };
 
-#[allow(unused_imports)]
 pub(crate) use layer_primitive_cell::LayerPrimitiveCell;
-#[allow(unused_imports)]
 pub use layer_symmetry_search::LayerPrimitiveSymmetrySearch;
 pub(super) use primitive_cell::{PrimitiveCell, PrimitiveMagneticCell};
 pub(super) use primitive_symmetry_search::{

--- a/moyo/src/search/layer_primitive_cell.rs
+++ b/moyo/src/search/layer_primitive_cell.rs
@@ -23,7 +23,6 @@ fn minkowski_reduce_inplane(cell: &Cell) -> Result<(Cell, Linear), MoyoError> {
 /// Mirrors `PrimitiveCell` but the discovered translations are constrained to
 /// the in-plane sublattice (no `c`-direction translations).
 #[derive(Debug)]
-#[allow(dead_code)] // consumed by later layer-group milestones
 pub(crate) struct LayerPrimitiveCell {
     /// Primitive layer cell whose third basis vector equals the input `c`.
     pub layer_cell: LayerCell,
@@ -33,11 +32,13 @@ pub(crate) struct LayerPrimitiveCell {
     pub site_mapping: Vec<usize>,
     /// Pure translations in the **input** cell (all have zero `c`-component).
     pub translations: Vec<Translation>,
-    /// Permutations induced by the translations.
+    /// Permutations induced by the translations. Mirrors `PrimitiveCell` for
+    /// API parity; the layer pipeline uses `LayerPrimitiveSymmetrySearch`'s
+    /// own permutations downstream rather than this field.
+    #[allow(dead_code)]
     pub permutations: Vec<Permutation>,
 }
 
-#[allow(dead_code)] // consumed by later layer-group milestones
 impl LayerPrimitiveCell {
     /// Find the primitive cell of a 2D-periodic (layer) system.
     ///

--- a/moyo/src/search/layer_symmetry_search.rs
+++ b/moyo/src/search/layer_symmetry_search.rs
@@ -13,14 +13,12 @@ use crate::base::{
 /// resulting subset is a subgroup of the bulk space group, hence still
 /// closed; no separate closure check is needed here.
 #[derive(Debug)]
-#[allow(dead_code)] // wired up by later layer-group milestones
 pub struct LayerPrimitiveSymmetrySearch {
     /// Layer-group operations in the given primitive layer cell.
     pub operations: Operations,
     pub permutations: Vec<Permutation>,
 }
 
-#[allow(dead_code)] // wired up by later layer-group milestones
 impl LayerPrimitiveSymmetrySearch {
     /// Search layer-group coset representatives for a primitive layer cell.
     ///

--- a/moyo/src/symmetrize.rs
+++ b/moyo/src/symmetrize.rs
@@ -2,7 +2,6 @@ mod layer_standardize;
 mod magnetic_standardize;
 mod standardize;
 
-#[allow(unused_imports)]
 pub(super) use layer_standardize::StandardizedLayerCell;
 pub(super) use magnetic_standardize::StandardizedMagneticCell;
 pub(super) use standardize::{StandardizedCell, orbits_in_cell};

--- a/moyo/src/symmetrize/layer_standardize.rs
+++ b/moyo/src/symmetrize/layer_standardize.rs
@@ -23,7 +23,6 @@ use crate::identify::LayerGroup;
 /// in the xy-plane, `|c_s| = |c|` is preserved from the input, and the
 /// in-plane `(a_s, b_s)` block obeys the LG crystal system's metric
 /// conditions (paper Fu et al. 2024 Figure 1 / Appendix C).
-#[allow(dead_code)] // consumed by `MoyoLayerDataset` (not yet wired up)
 pub(crate) struct StandardizedLayerCell {
     /// Primitive standardized layer cell.
     pub prim_layer_cell: LayerCell,
@@ -44,7 +43,6 @@ pub(crate) struct StandardizedLayerCell {
     pub site_mapping: Vec<usize>,
 }
 
-#[allow(dead_code)] // consumed by `MoyoLayerDataset` (not yet wired up)
 impl StandardizedLayerCell {
     /// Standardize the input **primitive** layer cell.
     ///

--- a/moyo/tests/test_layer_dataset.rs
+++ b/moyo/tests/test_layer_dataset.rs
@@ -1,0 +1,129 @@
+#[macro_use]
+extern crate approx;
+
+use nalgebra::{Vector3, matrix};
+use test_log::test;
+
+use moyo::MoyoLayerDataset;
+use moyo::base::{AngleTolerance, Cell, Lattice};
+use moyo::data::LayerSetting;
+
+const SYMPREC: f64 = 1e-4;
+
+/// LG 1 (p1): triclinic-oblique with two unrelated atoms. Verify identification
+/// and standardized-cell convention end-to-end through the public dataset.
+#[test]
+fn test_layer_dataset_p1() {
+    let gamma = 80.0_f64.to_radians();
+    let a = 1.0;
+    let b = 1.5;
+    let cell = Cell::new(
+        Lattice::new(matrix![
+            a, b * gamma.cos(), 0.0;
+            0.0, b * gamma.sin(), 0.0;
+            0.0, 0.0, 5.0;
+        ]),
+        vec![Vector3::new(0.1, 0.2, 0.1), Vector3::new(0.3, 0.5, 0.2)],
+        vec![1, 1],
+    );
+
+    let dataset = MoyoLayerDataset::with_default(&cell, SYMPREC).unwrap();
+
+    assert_eq!(dataset.number, 1);
+    assert_eq!(dataset.hall_number, 1);
+    assert_eq!(dataset.hm_symbol, "p 1");
+    // Order of LG 1 is 1; in the input cell that's still 1.
+    assert_eq!(dataset.num_operations(), 1);
+    assert_eq!(dataset.orbits, vec![0, 1]);
+    assert_eq!(dataset.wyckoffs, vec!['a', 'a']);
+    // Standardized output: |c| preserved, c along z, a along x.
+    let std_basis = dataset.std_cell.lattice().basis();
+    assert_relative_eq!(std_basis.column(2).norm(), 5.0, epsilon = 1e-10);
+    assert_relative_eq!(std_basis[(2, 2)], 5.0, epsilon = 1e-10);
+    assert_relative_eq!(std_basis[(0, 2)], 0.0, epsilon = 1e-10);
+    assert_relative_eq!(std_basis[(1, 2)], 0.0, epsilon = 1e-10);
+    assert_relative_eq!(std_basis[(1, 0)], 0.0, epsilon = 1e-10);
+    // mp Bravais + 2 atoms.
+    assert_eq!(dataset.pearson_symbol, "mp2");
+}
+
+/// LG 3 (p112): primitive monoclinic-oblique, two atoms in one orbit.
+/// Verifies that the orbit collapses and the wyckoff multiplicity is honoured.
+#[test]
+fn test_layer_dataset_p112_orbit_collapse() {
+    let cell = Cell::new(
+        Lattice::new(matrix![
+            1.0, 0.2, 0.0;
+            0.0, 1.3, 0.0;
+            0.0, 0.0, 5.0;
+        ]),
+        vec![
+            Vector3::new(0.31, 0.42, 0.07),
+            Vector3::new(-0.31, -0.42, 0.07),
+        ],
+        vec![1, 1],
+    );
+
+    let dataset = MoyoLayerDataset::with_default(&cell, SYMPREC).unwrap();
+
+    assert_eq!(dataset.number, 3);
+    // Two atoms related by the 2-fold along c -> one orbit.
+    assert_eq!(dataset.orbits, vec![0, 0]);
+    assert_eq!(dataset.wyckoffs[0], dataset.wyckoffs[1]);
+    // mp + 2 atoms in the conventional cell.
+    assert_eq!(dataset.pearson_symbol, "mp2");
+}
+
+/// LG 55 (p4mm): square in-plane, atom on the high-symmetry site. Verifies
+/// `std_cell` snaps to a square (a = b) and the site symmetry contains "4mm".
+#[test]
+fn test_layer_dataset_p4mm() {
+    let cell = Cell::new(
+        Lattice::new(matrix![
+            1.0, 0.0, 0.0;
+            0.0, 1.0, 0.0;
+            0.0, 0.0, 5.0;
+        ]),
+        vec![Vector3::new(0.0, 0.0, 0.1)],
+        vec![1],
+    );
+
+    let dataset = MoyoLayerDataset::new(
+        &cell,
+        SYMPREC,
+        AngleTolerance::default(),
+        LayerSetting::Standard,
+        true,
+    )
+    .unwrap();
+
+    assert_eq!(dataset.number, 55);
+    assert_eq!(dataset.num_operations(), 8);
+    // Standardized cell is square with c along z.
+    let basis = dataset.std_cell.lattice().basis();
+    let a = basis.column(0).norm();
+    let b = basis.column(1).norm();
+    assert_relative_eq!(a, b, epsilon = 1e-10);
+    assert_relative_eq!(basis.column(2).norm(), 5.0, epsilon = 1e-10);
+    // Single high-symmetry orbit (Wyckoff 'a', site symmetry contains 4mm).
+    assert_eq!(dataset.wyckoffs, vec!['a']);
+    assert!(dataset.site_symmetry_symbols[0].contains("4mm"));
+    // tp Bravais + 1 atom.
+    assert_eq!(dataset.pearson_symbol, "tp1");
+}
+
+/// Tilted-c input must be rejected by the layer-cell constructor.
+#[test]
+fn test_layer_dataset_rejects_tilted_c() {
+    let cell = Cell::new(
+        Lattice::new(matrix![
+            1.0, 0.0, 0.0;
+            0.0, 1.0, 0.0;
+            0.5, 0.0, 5.0;
+        ]),
+        vec![Vector3::new(0.0, 0.0, 0.0)],
+        vec![1],
+    );
+    let result = MoyoLayerDataset::with_default(&cell, SYMPREC);
+    assert!(result.is_err());
+}


### PR DESCRIPTION
## Summary

First slice of M5 (`.claude/plans/layer-group-support.md`): exposes a top-level `MoyoLayerDataset` that mirrors `MoyoDataset` for layer groups, wiring the M1-M4 internals (`LayerPrimitiveCell`, `LayerPrimitiveSymmetrySearch`, `LayerGroup`, `StandardizedLayerCell`) into one entry point.

- `MoyoLayerDataset::new(cell, symprec, angle_tolerance, setting, rotate_basis)` and `with_default(cell, symprec)`.
- Fields per the architecture doc (`docs/layer_architecture.md` "Public surface"): identification (`number`, `hall_number`, `hm_symbol`), input-cell `operations`, per-site `orbits` / `wyckoffs` / `site_symmetry_symbols`, conventional + primitive standardized `LayerCell` with their transformation maps, layer Pearson symbol (2D Bravais type + atom count), and the resolved tolerances.
- Drops the now-stale `#[allow(dead_code)]` hedges on `LayerPrimitiveCell`, `LayerPrimitiveSymmetrySearch`, `StandardizedLayerCell`, and `LayerWyckoffPosition` since the dataset consumes them.

Out of scope (follow-ups within M5): moyopy / moyoc bindings, README update, `detect_layer_group` free function (the dataset constructor is enough on its own for now), iterative tolerance retry.

## Test plan

- [x] `cargo test -p moyo` -- 137 unit + 4 new layer-dataset integration + 3 layer-symmetry + 22 bulk dataset + 4 magnetic + doc tests, all green
- [x] `cargo build --workspace` clean
- [x] `prek run --files <changed>` (cargo-fmt + typos + EOF/whitespace) passes
- [x] New integration tests in `moyo/tests/test_layer_dataset.rs`:
  - LG 1 (p1) end-to-end: number, hall, HM symbol, op count, orbits, Wyckoffs, std-cell convention, Pearson `mp2`
  - LG 3 (p112) two-atom orbit collapse + shared Wyckoff
  - LG 55 (p4mm) order-8 ops, square std cell (a = b), site symmetry `4mm`, Pearson `tp1`
  - tilted-`c` input rejected by `LayerCell::new`

[Claude Code] Generated with [Claude Code](https://claude.com/claude-code)
