### PR TITLE
refactor(moyo): exact c-translation in layer search, remove wyckoff retry

### DIFF
--- a/bench/2d/analyze.py
+++ b/bench/2d/analyze.py
@@ -1,0 +1,305 @@
+"""Categorize moyopy `MoyoLayerDataset` failures on JARVIS dft_2d.
+
+Companion to ``layer.py``. The benchmark itself swallows exceptions (one
+``Abort: jid=... symprec=...`` line per drop) so it can finish the sweep
+quickly. This script re-runs the same per-(material, symprec) loop with
+full error capture, buckets failures by exception kind + message, and
+joins each bucket against the bulk-parent space-group label JARVIS
+provides so we can spot systematic groups (e.g. "all bulk-SG-164 failures
+have the same root cause").
+
+Outputs:
+
+* A printed report broken down by error-kind, per-symprec totals, and
+  per-jid failure pattern (always-fail / partial / always-OK).
+* ``stats_moyopy_errors.json`` next to the other bench artifacts, with
+  one entry per (jid, symprec) failure carrying the exception message
+  and the bulk-parent space group, for follow-up drilling.
+
+Subcommands:
+
+  * ``run``      -- full re-run of the dataset + write JSON.
+  * ``report``   -- read an existing JSON and print the summary only.
+  * ``probe``    -- drill into one jid: print spglib + moyopy answers at
+                    every symprec and the per-symprec error message.
+
+Single material smoke check::
+
+    python analyze.py probe JVASP-76516
+
+Full sweep::
+
+    python analyze.py run                 # writes stats_moyopy_errors.json
+    python analyze.py report              # re-print summary from the JSON
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Iterable
+
+import click
+from jarvis.core.atoms import Atoms as JarvisAtoms
+from jarvis.db.figshare import data as jarvis_data
+from spglib import get_symmetry_layerdataset
+from tqdm.auto import tqdm
+
+import moyopy
+from moyopy import LayerSetting
+from moyopy.interface import MoyoAdapter
+
+SYMPREC_LIST = [1e-4, 3e-4, 1e-3, 3e-3, 1e-2, 3e-2, 1e-1]
+APERIODIC_DIR = 2
+DEFAULT_OUT = Path(__file__).resolve().parent / "stats_moyopy_errors.json"
+
+
+@click.group()
+def cli() -> None:
+    """Error-classification companion for ``layer.py``."""
+
+
+@cli.command()
+@click.option(
+    "--out",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=DEFAULT_OUT,
+    show_default=True,
+    help="Where to write the per-(jid, symprec) failure JSON.",
+)
+@click.option(
+    "--setting",
+    type=click.Choice(["spglib", "standard"]),
+    default="spglib",
+    show_default=True,
+    help="LayerSetting to use for MoyoLayerDataset.",
+)
+def run(out: Path, setting: str) -> None:
+    """Re-run the JARVIS dft_2d sweep with full error capture."""
+    layer_setting = (
+        LayerSetting.spglib() if setting == "spglib" else LayerSetting.standard()
+    )
+    entries = jarvis_data("dft_2d")
+
+    cell_build_fails: list[dict] = []
+    failures: list[dict] = []
+    successes = 0
+    per_jid_status: dict[str, dict[float, str]] = {}
+
+    for entry in tqdm(entries):
+        jid = entry["jid"]
+        spg_num = entry.get("spg_number", "?")
+        formula = entry.get("formula", "?")
+        atoms = JarvisAtoms.from_dict(entry["atoms"])
+        structure = atoms.pymatgen_converter()
+        try:
+            cell = MoyoAdapter.from_structure(structure)
+        except Exception as e:
+            cell_build_fails.append(
+                {
+                    "jid": jid,
+                    "exception": type(e).__name__,
+                    "msg": str(e).strip() or "<empty>",
+                    "bulk_spg": spg_num,
+                    "formula": formula,
+                }
+            )
+            continue
+
+        per_jid_status[jid] = {}
+        for symprec in SYMPREC_LIST:
+            try:
+                moyopy.MoyoLayerDataset(cell, symprec=symprec, setting=layer_setting)
+                successes += 1
+                per_jid_status[jid][symprec] = "OK"
+            except Exception as e:
+                kind = type(e).__name__
+                msg = str(e).strip() or "<empty>"
+                key = f"{kind}: {msg}"
+                failures.append(
+                    {
+                        "jid": jid,
+                        "symprec": symprec,
+                        "exception": kind,
+                        "msg": msg,
+                        "bulk_spg": spg_num,
+                        "formula": formula,
+                    }
+                )
+                per_jid_status[jid][symprec] = key
+
+    payload = {
+        "n_entries": len(entries),
+        "n_symprec": len(SYMPREC_LIST),
+        "symprec_list": SYMPREC_LIST,
+        "setting": setting,
+        "successes": successes,
+        "cell_build_fails": cell_build_fails,
+        "failures": failures,
+    }
+    out.write_text(json.dumps(payload, indent=2))
+    click.echo(f"Wrote {out}")
+    _print_report(payload)
+
+
+@cli.command()
+@click.option(
+    "--src",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=DEFAULT_OUT,
+    show_default=True,
+)
+def report(src: Path) -> None:
+    """Re-print the summary from an existing JSON without re-running."""
+    payload = json.loads(src.read_text())
+    _print_report(payload)
+
+
+@cli.command()
+@click.argument("jid")
+@click.option(
+    "--setting",
+    type=click.Choice(["spglib", "standard"]),
+    default="spglib",
+    show_default=True,
+)
+def probe(jid: str, setting: str) -> None:
+    """Drill into a single material: spglib vs moyopy at every symprec."""
+    layer_setting = (
+        LayerSetting.spglib() if setting == "spglib" else LayerSetting.standard()
+    )
+    entries = jarvis_data("dft_2d")
+    entry = next((e for e in entries if e["jid"] == jid), None)
+    if entry is None:
+        raise click.ClickException(f"jid {jid!r} not found in JARVIS dft_2d")
+    atoms = JarvisAtoms.from_dict(entry["atoms"])
+    click.echo(f"jid      : {jid}")
+    click.echo(f"formula  : {entry['formula']}")
+    click.echo(f"nat      : {entry['nat']}")
+    click.echo(f"bulk SG  : {entry['spg_number']} {entry['spg_symbol']}")
+    click.echo(f"crys     : {entry.get('crys', '?')}")
+    click.echo("lattice (rows = basis vectors):")
+    for row in atoms.lattice_mat:
+        click.echo(f"  {[float(x) for x in row]}")
+    click.echo("frac_coords:")
+    for sym, p in zip(atoms.elements, atoms.frac_coords):
+        click.echo(f"  {sym}  {[float(x) for x in p]}")
+
+    spg_cell = (atoms.lattice_mat, atoms.frac_coords, atoms.atomic_numbers)
+    click.echo("\nspglib:")
+    for sp in SYMPREC_LIST:
+        try:
+            ds = get_symmetry_layerdataset(spg_cell, aperiodic_dir=APERIODIC_DIR, symprec=sp)
+            click.echo(
+                f"  symprec={sp}: LG={ds.number} hall={ds.hall_number} "
+                f"n_ops={len(ds.rotations)}"
+            )
+        except Exception as e:
+            click.echo(f"  symprec={sp}: ERR {type(e).__name__}: {e}")
+
+    structure = atoms.pymatgen_converter()
+    try:
+        cell = MoyoAdapter.from_structure(structure)
+    except Exception as e:
+        click.echo(f"\nmoyopy cell build failed: {type(e).__name__}: {e}")
+        return
+    click.echo(f"\nmoyopy (setting={setting}):")
+    for sp in SYMPREC_LIST:
+        try:
+            ds = moyopy.MoyoLayerDataset(cell, symprec=sp, setting=layer_setting)
+            click.echo(
+                f"  symprec={sp}: LG={ds.number} hall={ds.hall_number} "
+                f"n_ops={len(ds.operations.rotations)}"
+            )
+        except Exception as e:
+            click.echo(f"  symprec={sp}: ERR {type(e).__name__}: {e}")
+
+
+def _print_report(payload: dict) -> None:
+    failures = payload["failures"]
+    cell_build_fails = payload["cell_build_fails"]
+    n_entries = payload["n_entries"]
+    n_symprec = payload["n_symprec"]
+    successes = payload["successes"]
+    total_attempts = n_entries * n_symprec - len(cell_build_fails) * n_symprec
+
+    click.secho(
+        f"\n=== Cell-build failures (MoyoAdapter.from_structure): {len(cell_build_fails)} ===",
+        bold=True,
+    )
+    if cell_build_fails:
+        c = Counter(f["exception"] for f in cell_build_fails)
+        for kind, n in c.most_common():
+            click.echo(f"  {kind}: {n}")
+
+    click.secho(
+        f"\n=== Compute failures: {len(failures)} / {total_attempts} "
+        f"({len(failures) / total_attempts * 100:.1f}%); successes: {successes} ===",
+        bold=True,
+    )
+
+    by_kind: dict[str, list[dict]] = defaultdict(list)
+    for f in failures:
+        by_kind[f"{f['exception']}: {f['msg']}"].append(f)
+    ranked = sorted(by_kind.items(), key=lambda kv: -len(kv[1]))
+
+    click.echo("\nTop 15 error kinds (by total count):")
+    for key, occs in ranked[:15]:
+        n = len(occs)
+        n_jids = len({f["jid"] for f in occs})
+        bulk_spg_top = Counter(f["bulk_spg"] for f in occs).most_common(3)
+        bulk_str = ", ".join(f"SG{sp}={k}" for sp, k in bulk_spg_top)
+        click.echo(
+            f"  [{n:>4}] in {n_jids:>3} unique jids  bulk-SG: {bulk_str}"
+        )
+        click.echo(f"          msg: {key}")
+        for sample in occs[:2]:
+            click.echo(
+                f"          ex: {sample['jid']} symprec={sample['symprec']} "
+                f"bulk_spg={sample['bulk_spg']} {sample['formula']}"
+            )
+
+    click.echo("\nPer-symprec failure counts:")
+    by_sp: dict[float, int] = defaultdict(int)
+    for f in failures:
+        by_sp[f["symprec"]] += 1
+    for sp in payload["symprec_list"]:
+        click.echo(f"  symprec={sp}: {by_sp.get(sp, 0)} failures")
+
+    # Per-jid pattern: count materials by always-fail / partial / always-OK.
+    by_jid: dict[str, set[float]] = defaultdict(set)
+    all_jids: set[str] = set()
+    for f in failures:
+        by_jid[f["jid"]].add(f["symprec"])
+        all_jids.add(f["jid"])
+    n_symprec_set = set(payload["symprec_list"])
+    full_fail = sum(1 for j, sps in by_jid.items() if sps == n_symprec_set)
+    partial_fail = sum(1 for j, sps in by_jid.items() if sps != n_symprec_set)
+
+    n_seen = n_entries - len(cell_build_fails)
+    click.echo("\nPer-jid failure pattern:")
+    click.echo(f"  {n_seen - len(by_jid)} jids: OK at every symprec")
+    click.echo(f"  {partial_fail} jids: OK at some, fail at others")
+    click.echo(f"  {full_fail} jids: fail at every symprec")
+
+    # Per-error-kind, per-bulk-SG cross-tab (top kind only).
+    if ranked:
+        top_key, top_occs = ranked[0]
+        sg_counts = Counter(f["bulk_spg"] for f in top_occs)
+        click.secho(f"\nBulk-SG breakdown of dominant error ({top_key}):", bold=True)
+        for sg, n in sg_counts.most_common(10):
+            n_jids = len({f["jid"] for f in top_occs if f["bulk_spg"] == sg})
+            click.echo(f"  bulk SG {sg}: {n} (in {n_jids} jids)")
+
+
+def _iter_failure_jids(failures: Iterable[dict]) -> Iterable[str]:
+    seen: set[str] = set()
+    for f in failures:
+        if f["jid"] not in seen:
+            seen.add(f["jid"])
+            yield f["jid"]
+
+
+if __name__ == "__main__":
+    cli()

--- a/moyo/src/identify/layer_group.rs
+++ b/moyo/src/identify/layer_group.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use log::debug;
 use serde::Serialize;
 
@@ -91,12 +93,40 @@ impl LayerGroup {
             let db_prim_generators = lh_symbol.primitive_generators();
 
             for trans_mat in &LAYER_CORRECTION_MATRICES {
-                if let Some(origin_shift) = match_origin_shift(
+                if let Some(mut origin_shift) = match_origin_shift(
                     prim_layer_operations,
                     trans_mat,
                     &db_prim_generators,
                     epsilon,
                 ) {
+                    // The c-axis is aperiodic, but `match_origin_shift` solves
+                    // its modular system in all three components. For LGs
+                    // with c-flipping generators (`W[2,2] = -1`) the c-row
+                    // reduces to `-2 s_z = b_z (mod 1)` and admits two valid
+                    // branches differing by 1/2; the modular solver returns
+                    // either, but only one places the layer's special-z
+                    // atoms onto the LG Wyckoff database orbits (stored at
+                    // `z = 0` -- there is no `z = 1/2` counterpart for
+                    // layer groups). The layer search step now produces
+                    // operations whose `t_z` is exact (no mod-1 reduction),
+                    // so we can recover `s_z` directly from the c-row of any
+                    // c-flipping generator without going through `% 1`.
+                    //
+                    // For any layer-block W with `W[2,2] = -1`, `(W - E)`
+                    // has c-row `(0, 0, -2)`, so `-2 s_z = t_db_z - t_target_z`
+                    // and `s_z = (t_target_z - t_db_z) / 2` exactly.
+                    // `LAYER_CORRECTION_MATRICES` are block-diagonal in c
+                    // (`trans_mat[2,0] = trans_mat[2,1] = 0`,
+                    // `trans_mat[2,2] in {+1, -1}`) so the c-component of
+                    // `trans_mat * s` is `trans_mat[2,2] * s_z`.
+                    if let Some(exact_s_z) = layer_exact_s_z(
+                        prim_layer_operations,
+                        trans_mat,
+                        &db_prim_generators,
+                        epsilon,
+                    ) {
+                        origin_shift[2] = trans_mat[(2, 2)] as f64 * exact_s_z;
+                    }
                     debug!(
                         "Matched layer Hall number {} (LG {}) via correction {:?}",
                         hall_number, entry.number, trans_mat
@@ -111,6 +141,55 @@ impl LayerGroup {
         }
         Err(MoyoError::LayerGroupTypeIdentificationError)
     }
+}
+
+/// Recover the exact `s_z` (origin-shift c-component) by reading any
+/// c-flipping generator's c-row of the matching equation.
+///
+/// Returns `None` when no c-flipping generator exists in the input ops or
+/// the database (e.g. LG 1-5 oblique without inversion / horizontal
+/// mirror), in which case `s_z` is genuinely unconstrained and the modular
+/// solver's `s_z = 0` answer is correct.
+///
+/// When multiple c-flipping generators exist a debug-assert checks that
+/// they yield the same `s_z` (a group-consistency invariant).
+fn layer_exact_s_z(
+    prim_layer_operations: &Operations,
+    trans_mat: &UnimodularLinear,
+    db_prim_generators: &Operations,
+    epsilon: f64,
+) -> Option<f64> {
+    // Mirror the front of `match_origin_shift`: apply `trans_mat` to the
+    // input ops and index by rotation so we can look up `t_target` per
+    // generator.
+    let new_prim_operations = UnimodularTransformation::from_linear(*trans_mat)
+        .transform_operations(prim_layer_operations);
+    let mut hm_translations = HashMap::new();
+    for op in new_prim_operations.iter() {
+        hm_translations.insert(op.rotation, op.translation);
+    }
+
+    let mut chosen: Option<f64> = None;
+    for db_op in db_prim_generators.iter() {
+        if db_op.rotation[(2, 2)] != -1 {
+            continue;
+        }
+        let target_t = hm_translations.get(&db_op.rotation)?;
+        // (W - E) c-row for any layer-block W with W[2,2] = -1 is
+        // (0, 0, -2); so -2 s_z = t_db_z - t_target_z, i.e.
+        // s_z = (t_target_z - t_db_z) / 2.
+        let s_z = (target_t[2] - db_op.translation[2]) / 2.0;
+        match chosen {
+            None => chosen = Some(s_z),
+            Some(prev) => debug_assert!(
+                (prev - s_z - (prev - s_z).round()).abs() < epsilon.max(1e-6),
+                "c-flipping generators disagree on s_z (prev={}, new={})",
+                prev,
+                s_z
+            ),
+        }
+    }
+    chosen
 }
 
 #[cfg(test)]

--- a/moyo/src/search/layer_symmetry_search.rs
+++ b/moyo/src/search/layer_symmetry_search.rs
@@ -2,6 +2,7 @@ use super::layer_bravais_group::is_layer_block_form;
 use super::primitive_symmetry_search::PrimitiveSymmetrySearch;
 use crate::base::{
     AngleTolerance, Cell, Lattice, LayerCell, MoyoError, Operation, Operations, Permutation,
+    Rotation,
 };
 
 /// Coset representatives of the layer group of a primitive layer cell.
@@ -60,18 +61,31 @@ impl LayerPrimitiveSymmetrySearch {
             if !is_layer_block_form(&op.rotation) {
                 continue;
             }
+            // Recover the exact c-component of the translation from atom
+            // images: the bulk search returns `t` reduced mod 1 in all three
+            // axes, but for layer cells `c` is aperiodic and the inversion-
+            // center / mirror-plane location encoded in `t_z` is lost when
+            // mod-1 reduction collapses centers at z and z + 1/2 into the
+            // same translation. For layer-block W (`W[2,*] = (0, 0, +/-1)`),
+            // `(W r)_z = W[2,2] * r_z`, so the exact t_z is the orbit-mean
+            // `r_image_z - W[2,2] * r_z`.
+            let exact_tz = exact_tz(primitive_layer_cell, &op.rotation, perm);
             // Reject c-axis screws: when W[2,2] = +1 the intrinsic z-translation
             // is t_3 itself and must vanish. For W[2,2] = -1 the intrinsic part
             // is automatically zero, so t_3 is just the location of the
-            // symmetry center along the aperiodic c direction.
+            // symmetry center along the aperiodic c direction. The screw check
+            // operates on `exact_tz` modulo lattice (an exact `t_z = 1.0` is a
+            // unit-cell translation, not a screw), so the `tz - tz.round()`
+            // reduction is still correct after the lift.
             if op.rotation[(2, 2)] == 1 {
-                let mut tz = op.translation[2];
-                tz -= tz.round();
+                let tz = exact_tz - exact_tz.round();
                 if tz.abs() > z_tol {
                     continue;
                 }
             }
-            operations.push(Operation::new(op.rotation, op.translation));
+            let mut translation = op.translation;
+            translation[2] = exact_tz;
+            operations.push(Operation::new(op.rotation, translation));
             permutations.push(perm.clone());
         }
 
@@ -83,4 +97,32 @@ impl LayerPrimitiveSymmetrySearch {
             permutations,
         })
     }
+}
+
+/// Recover the exact c-component of an operation's translation in a
+/// `LayerCell`. For layer-block `W` (`W[2,*] = (0, 0, W[2,2])`,
+/// `W[2,2] = +/- 1`), `(W r)_z = W[2,2] * r_z`, so the displacement
+/// `r_image_z - W[2,2] * r_z` is the orbit-invariant exact c-translation.
+/// Unlike the in-plane components, no `mod 1` reduction is applied: `c`
+/// is aperiodic and the raw value carries the inversion-center /
+/// mirror-plane location.
+///
+/// Atom positions are stored in `[0, 1)` even for the aperiodic c-axis,
+/// so an atom at "real" `z = -0.04` is stored at `z = 0.96`. This wrap
+/// inflates the per-atom contribution by an integer for atoms whose
+/// image crosses a cell boundary. We anchor to atom 0 and round each
+/// subsequent atom's contribution to atom 0's reference, then average.
+fn exact_tz(cell: &LayerCell, rotation: &Rotation, permutation: &Permutation) -> f64 {
+    let n = cell.num_atoms();
+    debug_assert!(n > 0);
+    let w22 = rotation[(2, 2)] as f64;
+    let positions = cell.positions();
+    let raw_tz = |i: usize| positions[permutation.apply(i)][2] - w22 * positions[i][2];
+    let reference = raw_tz(0);
+    let mut sum = reference;
+    for i in 1..n {
+        let candidate = raw_tz(i);
+        sum += candidate - (candidate - reference).round();
+    }
+    sum / n as f64
 }

--- a/moyo/src/symmetrize/layer_standardize.rs
+++ b/moyo/src/symmetrize/layer_standardize.rs
@@ -1,5 +1,6 @@
-use nalgebra::Matrix3;
+use log::debug;
 use nalgebra::linalg::QR;
+use nalgebra::{Matrix3, Vector3};
 
 use super::standardize::{
     align_primitive_permutations, assign_wyckoffs_by_orbit, group_sites_by_orbit,
@@ -54,6 +55,59 @@ impl StandardizedLayerCell {
     /// symmetrization (Cholesky on the layer-block metric tensor) so the
     /// output's third axis stays the aperiodic stacking direction.
     pub fn new(
+        prim_layer_cell: &LayerCell,
+        prim_layer_operations: &Operations,
+        prim_layer_permutations: &[Permutation],
+        layer_group: &LayerGroup,
+        symprec: f64,
+        epsilon: f64,
+        rotate_basis: bool,
+    ) -> Result<Self, MoyoError> {
+        // Try the LG identifier's reported origin shift first.
+        match Self::try_with_layer_group(
+            prim_layer_cell,
+            prim_layer_operations,
+            prim_layer_permutations,
+            layer_group,
+            symprec,
+            epsilon,
+            rotate_basis,
+        ) {
+            Ok(result) => Ok(result),
+            // The bulk-style symmetry search reduces all translation
+            // components mod 1, including the aperiodic c. For LGs with
+            // c-flipping generators (W[2,2] = -1) the origin-shift equation
+            // in s_z, `-2 s_z = b_z (mod 1)`, has two solutions differing
+            // by 1/2; both satisfy the operation match, but only one places
+            // the layer's special-z atoms onto the LG Wyckoff database
+            // entries (which are stored at z = 0). When the first attempt
+            // landed on the wrong branch we retry with `s_z += 1/2` and the
+            // assignment then succeeds.
+            Err(MoyoError::WyckoffPositionAssignmentError) => {
+                debug!(
+                    "Wyckoff assignment failed at LG origin shift {:?}; retrying with +1/2 c-shift",
+                    layer_group.transformation.origin_shift
+                );
+                let mut retried = layer_group.clone();
+                retried.transformation = UnimodularTransformation::new(
+                    layer_group.transformation.linear,
+                    layer_group.transformation.origin_shift + Vector3::new(0.0, 0.0, 0.5),
+                );
+                Self::try_with_layer_group(
+                    prim_layer_cell,
+                    prim_layer_operations,
+                    prim_layer_permutations,
+                    &retried,
+                    symprec,
+                    epsilon,
+                    rotate_basis,
+                )
+            }
+            Err(other) => Err(other),
+        }
+    }
+
+    fn try_with_layer_group(
         prim_layer_cell: &LayerCell,
         prim_layer_operations: &Operations,
         prim_layer_permutations: &[Permutation],

--- a/moyo/src/symmetrize/layer_standardize.rs
+++ b/moyo/src/symmetrize/layer_standardize.rs
@@ -1,6 +1,5 @@
-use log::debug;
+use nalgebra::Matrix3;
 use nalgebra::linalg::QR;
-use nalgebra::{Matrix3, Vector3};
 
 use super::standardize::{
     align_primitive_permutations, assign_wyckoffs_by_orbit, group_sites_by_orbit,
@@ -55,59 +54,6 @@ impl StandardizedLayerCell {
     /// symmetrization (Cholesky on the layer-block metric tensor) so the
     /// output's third axis stays the aperiodic stacking direction.
     pub fn new(
-        prim_layer_cell: &LayerCell,
-        prim_layer_operations: &Operations,
-        prim_layer_permutations: &[Permutation],
-        layer_group: &LayerGroup,
-        symprec: f64,
-        epsilon: f64,
-        rotate_basis: bool,
-    ) -> Result<Self, MoyoError> {
-        // Try the LG identifier's reported origin shift first.
-        match Self::try_with_layer_group(
-            prim_layer_cell,
-            prim_layer_operations,
-            prim_layer_permutations,
-            layer_group,
-            symprec,
-            epsilon,
-            rotate_basis,
-        ) {
-            Ok(result) => Ok(result),
-            // The bulk-style symmetry search reduces all translation
-            // components mod 1, including the aperiodic c. For LGs with
-            // c-flipping generators (W[2,2] = -1) the origin-shift equation
-            // in s_z, `-2 s_z = b_z (mod 1)`, has two solutions differing
-            // by 1/2; both satisfy the operation match, but only one places
-            // the layer's special-z atoms onto the LG Wyckoff database
-            // entries (which are stored at z = 0). When the first attempt
-            // landed on the wrong branch we retry with `s_z += 1/2` and the
-            // assignment then succeeds.
-            Err(MoyoError::WyckoffPositionAssignmentError) => {
-                debug!(
-                    "Wyckoff assignment failed at LG origin shift {:?}; retrying with +1/2 c-shift",
-                    layer_group.transformation.origin_shift
-                );
-                let mut retried = layer_group.clone();
-                retried.transformation = UnimodularTransformation::new(
-                    layer_group.transformation.linear,
-                    layer_group.transformation.origin_shift + Vector3::new(0.0, 0.0, 0.5),
-                );
-                Self::try_with_layer_group(
-                    prim_layer_cell,
-                    prim_layer_operations,
-                    prim_layer_permutations,
-                    &retried,
-                    symprec,
-                    epsilon,
-                    rotate_basis,
-                )
-            }
-            Err(other) => Err(other),
-        }
-    }
-
-    fn try_with_layer_group(
         prim_layer_cell: &LayerCell,
         prim_layer_operations: &Operations,
         prim_layer_permutations: &[Permutation],

--- a/moyo/tests/test_layer_dataset.rs
+++ b/moyo/tests/test_layer_dataset.rs
@@ -140,6 +140,59 @@ fn test_layer_dataset_coo2_jvasp_14441() {
     assert_eq!(dataset.number, 72);
 }
 
+/// RhO2 monolayer (JARVIS jid=JVASP-77581), bulk parent space group P-3m1
+/// (no. 164). The layer is centrosymmetric (D_3d): inversion through the
+/// origin maps Rh -> Rh and the two O atoms onto each other. moyo
+/// correctly recovers the full LG 72 (p-3m1) of order 12; spglib's
+/// `get_symmetry_layerdataset` returns only the c-fixing C_3v subset for
+/// this structure (number=69, 6 ops), missing the inversion. This test
+/// pins moyo to the centrosymmetric answer.
+#[test]
+fn test_layer_dataset_rho2_jvasp_77581() {
+    let cell = Cell::new(
+        Lattice::new(matrix![
+            3.077561866713373,   -5.5895361638e-06,  0.0;
+            -1.538785277570888,  2.665244603795193,  0.0;
+            0.0,                 0.0,                21.887078;
+        ]),
+        vec![
+            Vector3::new(3.98962103e-08, -1.0507825500000001e-08, 2.690075935e-07),
+            Vector3::new(0.33333345542078574, 0.6666665498487259, 0.0424523285784089),
+            Vector3::new(0.6666665046829969, 0.33333346065909963, 0.9575474024139978),
+        ],
+        vec![45, 8, 8],
+    );
+
+    let dataset = MoyoLayerDataset::with_default(&cell, SYMPREC).unwrap();
+    assert_eq!(dataset.number, 72);
+    assert_eq!(dataset.num_operations(), 12);
+}
+
+/// Repro for the moyopy "Wyckoff position assignment failed" crash on a
+/// centrosymmetric LG 72 (p-3m1) layer with the inversion center placed at
+/// z = 0.3 (rather than z = 0). The structure is the same as RhO2 above
+/// modulo an origin shift of z by 0.3; the layer group is unchanged.
+#[test]
+fn test_layer_dataset_rho2_off_origin() {
+    let a = 3.077561866713373;
+    let cell = Cell::new(
+        Lattice::new(matrix![
+            a,        0.0,                              0.0;
+            -0.5 * a, a * 0.866025403784438646763_f64,  0.0;
+            0.0,      0.0,                              21.887078;
+        ]),
+        vec![
+            Vector3::new(0.0, 0.0, 0.3),
+            Vector3::new(2.0 / 3.0, 1.0 / 3.0, 0.3 + 0.0425),
+            Vector3::new(1.0 / 3.0, 2.0 / 3.0, 0.3 - 0.0425),
+        ],
+        vec![45, 8, 8],
+    );
+
+    let dataset = MoyoLayerDataset::with_default(&cell, SYMPREC).unwrap();
+    assert_eq!(dataset.number, 72);
+}
+
 /// Tilted-c input must be rejected by the layer-cell constructor.
 #[test]
 fn test_layer_dataset_rejects_tilted_c() {


### PR DESCRIPTION
## Summary

Root-cause fix for `MoyoLayerDataset::new` raising `WyckoffPositionAssignmentError` on centrosymmetric layers whose inversion center sat at z != 0 (e.g. C2DB-style relaxed monolayers centered at z = 0.5).

The bulk symmetry search reduces operation translations mod 1 in **all three** axes, including the aperiodic c. For LGs with c-flipping generators (`W[2,2] = -1`) this collapses two physically distinct inversion centers (at z = zr and z = zr + 1/2) into the same operation, so `match_origin_shift`'s c-row equation `-2 s_z = b_z (mod 1)` admits two valid s_z branches; `solve_mod1` returned either, but only one places the layer's special-z atoms onto the LG Wyckoff database orbits (stored at z = 0, no z = 1/2 counterpart for layer groups).

This branch evolved through two commits:

1. `1eb8a5b` — first-pass workaround: `StandardizedLayerCell::new` retried with `origin_shift_z + 1/2` after the assignment failure.
2. `b16767e` — root-cause fix: produce ops with exact `t_z` at the search step, then derive exact `s_z` directly from the c-row of any c-flipping generator. Reverts the retry.

## Changes (final state)

- **`moyo/src/search/layer_symmetry_search.rs`** — after the layer-block / c-screw filter, recompute `op.translation[2]` from atom positions and the permutation. For layer-block W, `(W r)_z = W[2,2] * r_z`, so `r_image_z - W[2,2] * r_z` is the orbit-invariant exact c-translation. Anchor to atom 0 and unwrap each other atom's contribution to the same lattice representative before averaging, so atoms whose images wrap across the cell boundary don't bias the mean.

- **`moyo/src/identify/layer_group.rs`** — after `match_origin_shift` returns, override `origin_shift[2]` using the exact c-row of any c-flipping db generator: `(W - E)[2,*] = (0, 0, -2)` for any layer-block W with `W[2,2] = -1`, so `s_z = (t_target_z - t_db_z) / 2` exactly. `LAYER_CORRECTION_MATRICES` are block-diagonal in c (`trans_mat[2,2] in {+/-1}`, `trans_mat[2,0] = trans_mat[2,1] = 0`), so the c-component of `trans_mat * s` is just `trans_mat[2,2] * s_z`. Skip `% 1` for the c-component (exact, aperiodic). Debug-assert that all c-flipping generators yield the same s_z (group-consistency invariant).

- **`moyo/src/symmetrize/layer_standardize.rs`** — revert the `WyckoffPositionAssignmentError` retry and the `try_with_layer_group` indirection. The off-origin RhO2 regression test (`test_layer_dataset_rho2_off_origin`) now exercises the direct path; if a future regression breaks the search-side or identify-side fix it fails directly rather than silently fall through to a retry.

- **`moyo/tests/test_layer_dataset.rs`** — two regression tests pinning real RhO2 monolayer behavior end-to-end:
  - `test_layer_dataset_rho2_jvasp_77581` — JARVIS RhO2 (Rh near z=0).
  - `test_layer_dataset_rho2_off_origin` — same structure with the inversion center at z = 0.3 (off-origin, exercises the search-side exact-tz unwrap and the identify-side c-row override).

## Effect on bench (JARVIS dft_2d, 1103 monolayers x 7 symprec)

| | Before fix | After fix |
|--|--|--|
| moyopy classified rows | 3751 | **4925** (+1174) |
| Agreement with spglib (overall) | 93.7% | **94.9%** |
| Agreement at symprec=1e-4 | 95.7% | 95.9% |

The newly-classified rows are materials whose Wyckoff assignment previously aborted because the search-side `t_z mod 1` collapsed the inversion center onto the wrong half-cell. Audit of the most common disagreement bucket `(spglib=69, moyopy=72)` (53 rows, 18 unique jids) shows 17/18 jids have bulk parent SG 164 = P-3m1 (centrosymmetric trigonal) — moyopy correct, spglib too strict on JARVIS's slightly-imperfect coordinates. The lone outlier (JVASP-13647 Ge2Te, SG 156 P3m1) flips at 1/7 symprec only and is likely a separate symprec-edge issue.

## Test plan

- [x] `cargo test -p moyo --no-fail-fast` -- 137 unit + 22 + 7 + 3 + 4 integration tests pass; no test relies on the retry workaround.
- [x] `pytest moyopy/python/tests` -- existing layer tests unchanged.
- [x] C2DB RhO2 (Rh at z = 0.5): moyopy now classifies as LG 72 / 12 ops at every symprec, matching spglib (verified end-to-end via `/tmp/c2db_rho2.py`).
- [x] `python 2d/layer.py perf-moyopy` -- full sweep regenerates `stats_moyopy.json`; 4925 joined rows / 94.9% agreement / 53 rows in the (69, 72) bucket -- identical to the workaround-version numbers, confirming functional equivalence with no regression.
- [x] `cargo fmt --check` -- clean.

[Claude Code] Generated with [Claude Code](https://claude.com/claude-code)
