### PR TITLE
docs(moyopy): fix two MyST cross-reference warnings

### DIFF
--- a/moyopy/README.md
+++ b/moyopy/README.md
@@ -20,4 +20,4 @@ pip install moyopy[interface]
 
 ## How to cite moyopy
 
-See the citation information in [the root README](../README.md)
+See the citation information in [the root README](https://github.com/spglib/moyo/blob/main/README.md)

--- a/moyopy/docs/conf.py
+++ b/moyopy/docs/conf.py
@@ -12,6 +12,7 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.intersphinx",
     "sphinxcontrib.bibtex",
+    "sphinx_copybutton",
     # "nbsphinx",
     "myst_parser",
     "autoapi.extension",

--- a/moyopy/docs/conf.py
+++ b/moyopy/docs/conf.py
@@ -101,7 +101,7 @@ html_theme_options = {
     "repository_url": repository_url,
     "use_repository_button": True,
     "navigation_with_keys": True,
-    "globaltoc_includehidden": "true",
+    "globaltoc_includehidden": True,
     "show_toc_level": 2,
 }
 

--- a/moyopy/docs/index.md
+++ b/moyopy/docs/index.md
@@ -7,6 +7,7 @@ hidden:
     Introduction <self>
     Examples <examples/index>
     Standardization of Crystal Structures <standardization>
+    Standardization of Subperiodic Structures <layer_standardization>
     Migration Guide from spglib <migration>
     API Reference <api>
 ```

--- a/moyopy/docs/migration.md
+++ b/moyopy/docs/migration.md
@@ -31,6 +31,8 @@ Let `symmetry` be the returned dictionary of `spglib.get_symmetry()`, the fields
 - `symmetry['translations']` -> `MoyoDataset.operations.translations`
 - `symmetry['equivalent_atoms']` is not directly available in `MoyoDataset`. However, `MoyoDataset.orbits` gives Spglib's `crystallographic_orbits`.
 
+(spglibget_symmetry_dataset)=
+
 #### `spglib.get_symmetry_dataset()`
 
 Replace with `MoyoDataset`.

--- a/moyopy/pyproject.toml
+++ b/moyopy/pyproject.toml
@@ -49,6 +49,7 @@ docs = [
     "sphinxcontrib-bibtex >= 2.5",
     "sphinx-book-theme",
     "sphinx-autoapi",
+    "sphinx-copybutton",
     "myst-parser >= 2.0",
     "linkify-it-py",
 ]

--- a/moyopy/uv.lock
+++ b/moyopy/uv.lock
@@ -2014,6 +2014,7 @@ dev = [
     { name = "sphinx-autobuild", version = "2025.8.25", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinx-book-theme", version = "1.1.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx-book-theme", version = "1.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "sphinx-copybutton" },
     { name = "sphinxcontrib-bibtex" },
 ]
 docs = [
@@ -2028,6 +2029,7 @@ docs = [
     { name = "sphinx-autobuild", version = "2025.8.25", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinx-book-theme", version = "1.1.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx-book-theme", version = "1.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "sphinx-copybutton" },
     { name = "sphinxcontrib-bibtex" },
 ]
 interface = [
@@ -2075,6 +2077,7 @@ requires-dist = [
     { name = "sphinx-autoapi", marker = "extra == 'docs'" },
     { name = "sphinx-autobuild", marker = "extra == 'docs'" },
     { name = "sphinx-book-theme", marker = "extra == 'docs'" },
+    { name = "sphinx-copybutton", marker = "extra == 'docs'" },
     { name = "sphinxcontrib-bibtex", marker = "extra == 'docs'", specifier = ">=2.5" },
     { name = "typing-extensions" },
 ]
@@ -2815,7 +2818,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -4508,6 +4511,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/f7/154786f3cfb7692cd7acc24b6dfe4dcd1146b66f376b17df9e47125555e9/sphinx_book_theme-1.2.0.tar.gz", hash = "sha256:4a7ebfc7da4395309ac942ddfc38fbec5c5254c3be22195e99ad12586fbda9e3", size = 443962, upload-time = "2026-03-09T23:20:30.442Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/bf/6f506a37c7f8ecc4576caf9486e303c7af249f6d70447bb51dde9d78cb99/sphinx_book_theme-1.2.0-py3-none-any.whl", hash = "sha256:709605d308e1991c5ef0cf19c481dbe9084b62852e317fafab74382a0ee7ccfa", size = 455936, upload-time = "2026-03-09T23:20:28.788Z" },
+]
+
+[[package]]
+name = "sphinx-copybutton"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/2b/a964715e7f5295f77509e59309959f4125122d648f86b4fe7d70ca1d882c/sphinx-copybutton-0.5.2.tar.gz", hash = "sha256:4cf17c82fb9646d1bc9ca92ac280813a3b605d8c421225fd9913154103ee1fbd", size = 23039, upload-time = "2023-04-14T08:10:22.998Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/48/1ea60e74949eecb12cdd6ac43987f9fd331156388dcc2319b45e2ebb81bf/sphinx_copybutton-0.5.2-py3-none-any.whl", hash = "sha256:fb543fd386d917746c9a2c50360c7905b605726b9355cd26e9974857afeae06e", size = 13343, upload-time = "2023-04-14T08:10:20.844Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Small docs-setup batch for the moyopy Sphinx site.

**Fix two MyST cross-reference warnings** (`ddb4083`)

- `moyopy/README.md`: replace the relative link `[the root README](../README.md)` with an absolute GitHub URL. When `moyopy/README.md` is included into `moyopy/docs/index.md` via `{include} ../README.md`, Sphinx tried to resolve `../README.md` as a doc named `moyopy/README` (which does not exist in the docs source tree), producing `WARNING: Unknown source document 'moyopy/README'`.
- `moyopy/docs/migration.md`: add an explicit MyST anchor `(spglibget_symmetry_dataset)=` before the h4 heading `#### spglib.get_symmetry_dataset()`. `myst_heading_anchors = 3` only auto-generates slugs for h1-h3, so the in-page link from `spglib.get_spacegroup()` to `#spglibget_symmetry_dataset` could not resolve.

**Add `sphinx-copybutton` extension** (`6d0efd1`)

Adds copy-to-clipboard buttons on rendered code blocks. Registers the extension in `conf.py` and the dependency in the `docs` extra of `pyproject.toml`; `uv.lock` is regenerated.

**Pass `globaltoc_includehidden` as a bool** (`9ff84aa`)

`sphinx-book-theme` expects a Python bool, not the string `"true"`. Behavior is unchanged (the string was truthy), but the type now matches the theme's documented contract.

**Surface the layer-standardization page in the sidebar** (`a403476`)

Adds `layer_standardization.md` as a top-level entry in `moyopy/docs/index.md`'s toctree so it sits alongside the space-group standardization page, instead of being reachable only via inline links.

## Test plan

- [x] `uv run sphinx-build -b html docs docs/_build` (in `moyopy/`) completes without either MyST warning.
- [x] The cross-reference under "Space-group type search" -> `spglib.get_spacegroup()` jumps to the `spglib.get_symmetry_dataset()` section.
- [x] Code blocks in the rendered HTML show the copy button.
- [x] The "Standardization of Subperiodic Structures" entry appears in the sidebar toctree.
- [x] Pre-commit (`mdformat`, `ruff`, `typos`, `uv-lock`, etc.) passes.

[Claude Code] Generated with [Claude Code](https://claude.com/claude-code)
