### PR TITLE
docs(moyopy): add layer-group example for 1H MoS2 monolayer

### DIFF
--- a/moyopy/examples/layer_group.py
+++ b/moyopy/examples/layer_group.py
@@ -1,0 +1,47 @@
+from math import sqrt
+
+import moyopy
+
+# MoS2 1H monolayer (layer group 78, p-6m2).
+# In-plane lattice constant a ~ 3.16 A; intra-layer S-S spacing ~ 3.12 A.
+# The third basis vector is the aperiodic stacking direction; its length is
+# arbitrary (moyo does not rescale c). See moyopy/docs/layer_standardization.md.
+a = 3.16
+c = 20.0
+basis = [
+    [a, 0.0, 0.0],
+    [-a / 2.0, a * sqrt(3.0) / 2.0, 0.0],
+    [0.0, 0.0, c],
+]
+
+# Place the Mo layer at z = 0.5 so the two S atoms straddle it within [0, 1).
+# In 1H MoS2 the two S atoms sit directly above/below the same in-plane site,
+# giving trigonal-prismatic Mo coordination (no inversion through Mo).
+zS = 1.56 / c
+positions = [
+    [0.0, 0.0, 0.5],  # Mo
+    [1.0 / 3.0, 2.0 / 3.0, 0.5 + zS],  # S top
+    [1.0 / 3.0, 2.0 / 3.0, 0.5 - zS],  # S bottom
+]
+numbers = [42, 16, 16]
+cell = moyopy.Cell(basis, positions, numbers)
+
+dataset = moyopy.MoyoLayerDataset(cell, symprec=1e-4)
+assert dataset.number == 78
+assert dataset.hall_number == 114
+assert dataset.pearson_symbol == "hp3"
+assert dataset.orbits == [0, 1, 1]
+assert dataset.wyckoffs == ["a", "e", "e"]
+assert dataset.site_symmetry_symbols == ["-6m2", "3m.", "3m."]
+# |c| is preserved and c lies on Cartesian z in the standardized cell.
+std_basis = dataset.std_cell.basis
+assert abs(std_basis[2][0]) < 1e-6
+assert abs(std_basis[2][1]) < 1e-6
+assert abs(std_basis[2][2] - c) < 1e-6
+
+# MoyoLayerDataset round-trips through JSON.
+dataset2 = moyopy.MoyoLayerDataset.deserialize_json(dataset.serialize_json())
+assert dataset2.number == dataset.number
+assert dataset2.hall_number == dataset.hall_number
+
+print(dataset)


### PR DESCRIPTION
## Summary
- Add `moyopy/examples/layer_group.py` modelled on `basic.py` so users have a concrete entry point for `MoyoLayerDataset` alongside the existing space-group examples.
- Uses 1H MoS2 monolayer (LG 78, p-6m2, Hall 114, Pearson hp3) as the demo crystal -- exercises a 1a Mo orbit and a 2g S orbit, and shows the aperiodic c-axis convention without rescaling.
- Asserts on number / hall_number / pearson_symbol / orbits / wyckoffs / site_symmetry_symbols / preserved length of c in std_cell, plus a JSON round-trip, so the script doubles as runnable documentation.

## Test plan
- [x] `moyopy/.venv/bin/python moyopy/examples/layer_group.py` exits 0 and prints the expected repr (number=78, hall_number=114).
- [x] `prek run --files moyopy/examples/layer_group.py` -- all hooks pass.
- [x] `pytest moyopy/python/tests/test_moyo_layer_dataset.py` -- 7/7 pass (no regression on the surrounding API).

[Claude Code] Generated with [Claude Code](https://claude.com/claude-code)
