### PR TITLE
feat(moyopy): expose LayerGroup type identification

### DIFF
--- a/moyo/src/identify/layer/layer_group.rs
+++ b/moyo/src/identify/layer/layer_group.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 use super::layer_point_group::LayerPointGroup;
 use super::normalizer::integral_normalizer_2_1;
 use crate::base::{
-    Lattice, Lattice2D, MoyoError, Operations, UnimodularTransformation, project_rotations,
+    Lattice2D, LayerLattice, MoyoError, Operations, UnimodularTransformation, project_rotations,
 };
 use crate::data::{
     LayerHallNumber, LayerHallSymbol, LayerNumber, LayerSetting, layer_hall_symbol_entry,
@@ -106,19 +106,18 @@ impl LayerGroup {
     /// (`T[0,2]=T[1,2]=T[2,0]=T[2,1]=0`, `T[2,2]=±1`) that
     /// [`LayerPointGroup::new`] and [`integral_normalizer_2_1`] rely on.
     ///
-    /// `lattice` must satisfy the layer-group periodicity contract
-    /// (`a, b` in the xy-plane, `c` along z); the reduction step relies on
-    /// extracting the upper-left 2x2 block of `lattice.basis` and only
-    /// `debug_assert!`s the layout (see [`Lattice2D::from_inplane_of`]). For
-    /// strict validation upstream of this call, build a
-    /// [`crate::base::LayerLattice`].
+    /// Taking [`LayerLattice`] (rather than [`crate::base::Lattice`]) makes
+    /// the layer-group periodicity contract (`a, b` in the xy-plane, `c`
+    /// along z) a precondition the type system enforces, so the in-plane
+    /// reduction can extract the upper-left 2x2 block of the basis without
+    /// silently dropping information.
     pub fn from_lattice(
-        lattice: &Lattice,
+        lattice: &LayerLattice,
         prim_layer_operations: &Operations,
         setting: LayerSetting,
         epsilon: f64,
     ) -> Result<Self, MoyoError> {
-        let reduced_trans_mat = Lattice2D::lift_inplane_minkowski_reduce(&lattice.basis)?;
+        let reduced_trans_mat = Lattice2D::lift_inplane_minkowski_reduce(lattice.basis())?;
         let to_reduced = UnimodularTransformation::from_linear(reduced_trans_mat);
         let reduced_prim_operations = to_reduced.transform_operations(prim_layer_operations);
 
@@ -138,6 +137,7 @@ mod tests {
     use nalgebra::{Matrix3, matrix, vector};
 
     use super::*;
+    use crate::base::{AngleTolerance, Lattice};
     use crate::data::{LayerHallSymbol, iter_layer_hall_symbol_entry};
 
     /// Round-trip: for every Hall number in LAYER_HALL_SYMBOL_DATABASE,
@@ -307,9 +307,14 @@ mod tests {
 
         // Skewed lattice in column-vector form: a, b in xy-plane; c along z.
         let skewed_basis = Matrix3::<f64>::identity() * shear.map(|e| e as f64);
-        let skewed_lattice = Lattice {
-            basis: skewed_basis,
-        };
+        let skewed_lattice = LayerLattice::new(
+            Lattice {
+                basis: skewed_basis,
+            },
+            1e-4,
+            AngleTolerance::Default,
+        )
+        .unwrap();
 
         let identified =
             LayerGroup::from_lattice(&skewed_lattice, &skewed_ops, LayerSetting::Standard, 1e-8)
@@ -334,9 +339,14 @@ mod tests {
         let lh = LayerHallSymbol::from_hall_number(canonical_hall).unwrap();
         let canonical_ops = lh.primitive_traverse();
 
-        let identity_lattice = Lattice {
-            basis: Matrix3::<f64>::identity(),
-        };
+        let identity_lattice = LayerLattice::new(
+            Lattice {
+                basis: Matrix3::<f64>::identity(),
+            },
+            1e-4,
+            AngleTolerance::Default,
+        )
+        .unwrap();
         let via_lattice = LayerGroup::from_lattice(
             &identity_lattice,
             &canonical_ops,

--- a/moyo/src/identify/layer/layer_group.rs
+++ b/moyo/src/identify/layer/layer_group.rs
@@ -3,7 +3,9 @@ use serde::Serialize;
 
 use super::layer_point_group::LayerPointGroup;
 use super::normalizer::integral_normalizer_2_1;
-use crate::base::{MoyoError, Operations, UnimodularTransformation, project_rotations};
+use crate::base::{
+    Lattice, Lattice2D, MoyoError, Operations, UnimodularTransformation, project_rotations,
+};
 use crate::data::{
     LayerHallNumber, LayerHallSymbol, LayerNumber, LayerSetting, layer_hall_symbol_entry,
 };
@@ -92,13 +94,48 @@ impl LayerGroup {
         }
         Err(MoyoError::LayerGroupTypeIdentificationError)
     }
+
+    /// Identify a layer group from a primitive layer cell whose in-plane
+    /// basis may not be Minkowski-reduced.
+    ///
+    /// Mirrors [`crate::identify::SpaceGroup::from_lattice`] but uses the
+    /// layer-aware in-plane reduction
+    /// [`Lattice2D::lift_inplane_minkowski_reduce`] to keep the aperiodic `c`
+    /// axis in place: a 3D Minkowski reduction may permute axes and break
+    /// the layer-block-form invariant
+    /// (`T[0,2]=T[1,2]=T[2,0]=T[2,1]=0`, `T[2,2]=±1`) that
+    /// [`LayerPointGroup::new`] and [`integral_normalizer_2_1`] rely on.
+    ///
+    /// `lattice` must satisfy the layer-group periodicity contract
+    /// (`a, b` in the xy-plane, `c` along z); the reduction step relies on
+    /// extracting the upper-left 2x2 block of `lattice.basis` and only
+    /// `debug_assert!`s the layout (see [`Lattice2D::from_inplane_of`]). For
+    /// strict validation upstream of this call, build a
+    /// [`crate::base::LayerLattice`].
+    pub fn from_lattice(
+        lattice: &Lattice,
+        prim_layer_operations: &Operations,
+        setting: LayerSetting,
+        epsilon: f64,
+    ) -> Result<Self, MoyoError> {
+        let reduced_trans_mat = Lattice2D::lift_inplane_minkowski_reduce(&lattice.basis)?;
+        let to_reduced = UnimodularTransformation::from_linear(reduced_trans_mat);
+        let reduced_prim_operations = to_reduced.transform_operations(prim_layer_operations);
+
+        let reduced = Self::new(&reduced_prim_operations, setting, epsilon)?;
+        Ok(LayerGroup {
+            number: reduced.number,
+            hall_number: reduced.hall_number,
+            transformation: reduced.transformation * to_reduced,
+        })
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
 
-    use nalgebra::vector;
+    use nalgebra::{Matrix3, matrix, vector};
 
     use super::*;
     use crate::data::{LayerHallSymbol, iter_layer_hall_symbol_entry};
@@ -246,5 +283,69 @@ mod tests {
                 input_hall
             );
         }
+    }
+
+    /// `from_lattice` should reduce a non-Minkowski-reduced in-plane basis
+    /// before identification and still recover the original LG. The skew
+    /// here applied to both the lattice and the operations preserves the
+    /// physical symmetry; only its representation changes.
+    #[test]
+    fn test_from_lattice_handles_inplane_skew() {
+        // LG 8 (p 2 1 1), default Hall number 12.
+        let canonical_hall: LayerHallNumber = 12;
+        let lh = LayerHallSymbol::from_hall_number(canonical_hall).unwrap();
+        let canonical_ops = lh.primitive_traverse();
+
+        // Layer-block-form unimodular shear in the ab-plane; c untouched.
+        let shear: Matrix3<i32> = matrix![
+            1, 4, 0;
+            0, 1, 0;
+            0, 0, 1;
+        ];
+        let to_skewed = UnimodularTransformation::from_linear(shear);
+        let skewed_ops = to_skewed.transform_operations(&canonical_ops);
+
+        // Skewed lattice in column-vector form: a, b in xy-plane; c along z.
+        let skewed_basis = Matrix3::<f64>::identity() * shear.map(|e| e as f64);
+        let skewed_lattice = Lattice {
+            basis: skewed_basis,
+        };
+
+        let identified =
+            LayerGroup::from_lattice(&skewed_lattice, &skewed_ops, LayerSetting::Standard, 1e-8)
+                .unwrap();
+        assert_eq!(identified.number, 8);
+        assert_eq!(identified.hall_number, canonical_hall);
+        assert_eq!(
+            identified
+                .transformation
+                .linear_as_f64()
+                .determinant()
+                .round() as i32,
+            1,
+        );
+    }
+
+    /// `from_lattice` with an already-reduced basis should agree with `new`
+    /// (the Minkowski reduction step is the identity in that case).
+    #[test]
+    fn test_from_lattice_identity_on_reduced_basis() {
+        let canonical_hall: LayerHallNumber = 12;
+        let lh = LayerHallSymbol::from_hall_number(canonical_hall).unwrap();
+        let canonical_ops = lh.primitive_traverse();
+
+        let identity_lattice = Lattice {
+            basis: Matrix3::<f64>::identity(),
+        };
+        let via_lattice = LayerGroup::from_lattice(
+            &identity_lattice,
+            &canonical_ops,
+            LayerSetting::Standard,
+            1e-8,
+        )
+        .unwrap();
+        let via_new = LayerGroup::new(&canonical_ops, LayerSetting::Standard, 1e-8).unwrap();
+        assert_eq!(via_lattice.number, via_new.number);
+        assert_eq!(via_lattice.hall_number, via_new.hall_number);
     }
 }

--- a/moyopy/python/moyopy/__init__.py
+++ b/moyopy/python/moyopy/__init__.py
@@ -6,6 +6,7 @@ from moyopy._moyopy import (
     HallSymbolEntry,
     LayerArithmeticCrystalClass,
     LayerCentering,
+    LayerGroup,
     LayerGroupType,
     LayerHallSymbolEntry,
     LayerSetting,
@@ -59,6 +60,7 @@ __all__ = [
     "MoyoLayerDataset",
     "MoyoNonCollinearMagneticDataset",
     # identify
+    "LayerGroup",
     "MagneticSpaceGroup",
     "PointGroup",
     "SpaceGroup",

--- a/moyopy/python/moyopy/_identify.pyi
+++ b/moyopy/python/moyopy/_identify.pyi
@@ -1,7 +1,7 @@
 from typing import Any
 
 from moyopy._base import UnimodularTransformation
-from moyopy._data import Setting
+from moyopy._data import LayerSetting, Setting
 
 class PointGroup:
     """Point group identified from a list of rotation matrices."""
@@ -61,6 +61,55 @@ class SpaceGroup:
     @property
     def hall_number(self) -> int:
         """Hall symbol number (1 - 530) for the chosen setting."""
+    @property
+    def linear(self) -> list[list[int]]:
+        """Linear part of the transformation from the input primitive basis to the
+        standardized basis."""
+    @property
+    def origin_shift(self) -> list[float]:
+        """Origin shift of the transformation from the input primitive basis to the
+        standardized basis."""
+    # Serialization
+    def serialize_json(self) -> str:
+        """Serialize this object to a JSON string."""
+    def as_dict(self) -> dict[str, Any]:
+        """Convert this object to a dictionary."""
+
+class LayerGroup:
+    """Layer group identified from a list of primitive layer-cell operations."""
+    def __init__(
+        self,
+        prim_rotations: list[list[list[int]]],
+        prim_translations: list[list[float]],
+        *,
+        basis: list[list[float]] | None = None,
+        setting: LayerSetting | None = None,
+        epsilon: float = 1e-4,
+    ):
+        """Identify the layer group from primitive layer-cell rotations and translations.
+
+        Parameters
+        ----------
+        prim_rotations : list[list[list[int]]]
+            Rotation matrices of the layer-group operations of the primitive layer cell.
+        prim_translations : list[list[float]]
+            Translation vectors of the layer-group operations of the primitive layer cell.
+        basis : list[list[float]] | None
+            Row-wise basis vectors of the primitive layer lattice. ``a, b`` must lie in the
+            xy-plane and ``c`` along z (the layer-group periodicity contract). When given,
+            the in-plane block is Minkowski-reduced before identification. If ``None``, an
+            identity basis is assumed.
+        setting : LayerSetting | None
+            Preference for the standardized setting of the detected layer-group type.
+        epsilon : float
+            Numerical tolerance for matching translations.
+        """
+    @property
+    def number(self) -> int:
+        """Layer-group number for the identified layer group (1 - 80)."""
+    @property
+    def hall_number(self) -> int:
+        """Layer Hall symbol number (1 - 116) for the chosen setting."""
     @property
     def linear(self) -> list[list[int]]:
         """Linear part of the transformation from the input primitive basis to the

--- a/moyopy/python/moyopy/_moyopy.pyi
+++ b/moyopy/python/moyopy/_moyopy.pyi
@@ -29,6 +29,7 @@ from moyopy._dataset import (
     MoyoNonCollinearMagneticDataset,
 )  # noqa: F401
 from moyopy._identify import (  # noqa: F401
+    LayerGroup,
     MagneticSpaceGroup,
     PointGroup,
     SpaceGroup,
@@ -68,6 +69,7 @@ __all__ = [
     # identify
     "PointGroup",
     "SpaceGroup",
+    "LayerGroup",
     "MagneticSpaceGroup",
     "integral_normalizer",
     # lib

--- a/moyopy/python/tests/test_identify.py
+++ b/moyopy/python/tests/test_identify.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 import pytest
 
 from moyopy import (
+    LayerGroup,
     MagneticSpaceGroup,
     PointGroup,
     SpaceGroup,
     UnimodularTransformation,
     integral_normalizer,
     magnetic_operations_from_uni_number,
+    operations_from_layer_number,
     operations_from_number,
 )
 
@@ -39,6 +41,47 @@ def test_identify_space_group(number: int):
         prim_rotations=operations.rotations, prim_translations=operations.translations
     )
     assert space_group.number == number
+
+
+@pytest.mark.parametrize(
+    "number",
+    [
+        1,  # p1
+        8,  # p 2 1 1
+        65,  # p 6
+    ],
+)
+def test_identify_layer_group(number: int):
+    operations = operations_from_layer_number(number, primitive=True)
+    layer_group = LayerGroup(
+        prim_rotations=operations.rotations, prim_translations=operations.translations
+    )
+    assert layer_group.number == number
+    assert 1 <= layer_group.hall_number <= 116
+    assert len(layer_group.linear) == 3
+    assert all(len(row) == 3 for row in layer_group.linear)
+    assert len(layer_group.origin_shift) == 3
+
+
+@pytest.mark.parametrize(
+    "number",
+    [
+        1,  # p1
+        8,  # p 2 1 1
+    ],
+)
+def test_identify_layer_group_with_basis(number: int):
+    # Pass an explicit identity basis to exercise the from_lattice path.
+    # The in-plane Minkowski reduction is the identity for this basis, so
+    # the result must agree with the no-basis call.
+    operations = operations_from_layer_number(number, primitive=True)
+    identity_basis = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+    layer_group = LayerGroup(
+        prim_rotations=operations.rotations,
+        prim_translations=operations.translations,
+        basis=identity_basis,
+    )
+    assert layer_group.number == number
 
 
 @pytest.mark.parametrize(

--- a/moyopy/src/identify.rs
+++ b/moyopy/src/identify.rs
@@ -5,7 +5,7 @@ use pythonize::pythonize;
 use serde::Serialize;
 use serde_json;
 
-use moyo::base::{Lattice, MagneticOperation, Operation};
+use moyo::base::{AngleTolerance, Lattice, LayerLattice, MagneticOperation, Operation};
 use moyo::data::{
     ArithmeticNumber, HallNumber, LayerHallNumber, LayerNumber, LayerSetting, Number, Setting,
     UNINumber,
@@ -387,13 +387,12 @@ impl PyLayerGroup {
             .zip(prim_translations.iter())
             .map(|(r, t)| Operation::new(to_matrix3(r), to_vector3(t)))
             .collect::<Vec<_>>();
-        let setting = setting
-            .map(LayerSetting::from)
-            .unwrap_or(LayerSetting::Spglib);
+        let setting = setting.map(LayerSetting::from).unwrap_or_default();
 
         let layer_group = if let Some(basis) = basis {
             let lattice = Lattice::from_basis(basis);
-            LayerGroup::from_lattice(&lattice, &prim_operations, setting, epsilon)?
+            let layer_lattice = LayerLattice::new(lattice, epsilon, AngleTolerance::Default)?;
+            LayerGroup::from_lattice(&layer_lattice, &prim_operations, setting, epsilon)?
         } else {
             LayerGroup::new(&prim_operations, setting, epsilon)?
         };

--- a/moyopy/src/identify.rs
+++ b/moyopy/src/identify.rs
@@ -6,14 +6,18 @@ use serde::Serialize;
 use serde_json;
 
 use moyo::base::{Lattice, MagneticOperation, Operation};
-use moyo::data::{ArithmeticNumber, HallNumber, Number, Setting, UNINumber};
+use moyo::data::{
+    ArithmeticNumber, HallNumber, LayerHallNumber, LayerNumber, LayerSetting, Number, Setting,
+    UNINumber,
+};
 use moyo::identify::{
-    MagneticSpaceGroup, PointGroup, SpaceGroup, integral_normalizer as identify_integral_normalizer,
+    LayerGroup, MagneticSpaceGroup, PointGroup, SpaceGroup,
+    integral_normalizer as identify_integral_normalizer,
 };
 use moyo::utils::{to_3x3_slice, to_matrix3, to_vector3};
 
 use crate::base::{PyMoyoError, PyUnimodularTransformation};
-use crate::data::PySetting;
+use crate::data::{PyLayerSetting, PySetting};
 
 fn has_same_rotation(lhs: &Operation, rhs: &Operation) -> bool {
     lhs.rotation == rhs.rotation
@@ -341,6 +345,125 @@ impl From<PySpaceGroup> for SpaceGroup {
 impl From<SpaceGroup> for PySpaceGroup {
     fn from(space_group: SpaceGroup) -> Self {
         PySpaceGroup(space_group)
+    }
+}
+
+/// Layer group identified from a list of primitive layer-cell operations.
+#[derive(Debug, Clone, Serialize)]
+#[pyclass(name = "LayerGroup", frozen, from_py_object)]
+#[pyo3(module = "moyopy")]
+pub struct PyLayerGroup(LayerGroup);
+
+#[pymethods]
+impl PyLayerGroup {
+    /// Identify the layer group from primitive layer-cell rotations and translations.
+    ///
+    /// Parameters
+    /// ----------
+    /// prim_rotations : list\[list\[list\[int\]\]\]
+    ///     Rotation matrices of the layer-group operations of the primitive layer cell.
+    /// prim_translations : list\[list\[float\]\]
+    ///     Translation vectors of the layer-group operations of the primitive layer cell.
+    /// basis : list\[list\[float\]\] | None
+    ///     Row-wise basis vectors of the primitive layer lattice. ``a, b`` must lie in the
+    ///     xy-plane and ``c`` along z (the layer-group periodicity contract). When given,
+    ///     the in-plane block is Minkowski-reduced before identification. If ``None``, an
+    ///     identity basis is assumed.
+    /// setting : LayerSetting | None
+    ///     Preference for the standardized setting of the detected layer-group type.
+    /// epsilon : float
+    ///     Numerical tolerance for matching translations.
+    #[new]
+    #[pyo3(signature = (prim_rotations, prim_translations, *, basis=None, setting=None, epsilon=1e-4))]
+    pub fn new(
+        prim_rotations: Vec<[[i32; 3]; 3]>,
+        prim_translations: Vec<[f64; 3]>,
+        basis: Option<[[f64; 3]; 3]>,
+        setting: Option<PyLayerSetting>,
+        epsilon: f64,
+    ) -> Result<Self, PyMoyoError> {
+        let prim_operations = prim_rotations
+            .iter()
+            .zip(prim_translations.iter())
+            .map(|(r, t)| Operation::new(to_matrix3(r), to_vector3(t)))
+            .collect::<Vec<_>>();
+        let setting = setting
+            .map(LayerSetting::from)
+            .unwrap_or(LayerSetting::Spglib);
+
+        let layer_group = if let Some(basis) = basis {
+            let lattice = Lattice::from_basis(basis);
+            LayerGroup::from_lattice(&lattice, &prim_operations, setting, epsilon)?
+        } else {
+            LayerGroup::new(&prim_operations, setting, epsilon)?
+        };
+
+        Ok(Self(layer_group))
+    }
+
+    /// Layer-group number for the identified layer group (1 - 80).
+    #[getter]
+    pub fn number(&self) -> LayerNumber {
+        self.0.number
+    }
+
+    /// Layer Hall symbol number (1 - 116) for the chosen setting.
+    #[getter]
+    pub fn hall_number(&self) -> LayerHallNumber {
+        self.0.hall_number
+    }
+
+    /// Linear part of the transformation from the input primitive basis to the standardized
+    /// basis.
+    #[getter]
+    pub fn linear(&self) -> [[i32; 3]; 3] {
+        self.0.transformation.linear_as_array()
+    }
+
+    /// Origin shift of the transformation from the input primitive basis to the standardized
+    /// basis.
+    #[getter]
+    pub fn origin_shift(&self) -> [f64; 3] {
+        self.0.transformation.origin_shift_as_array()
+    }
+
+    // ------------------------------------------------------------------------
+    // Special methods
+    // ------------------------------------------------------------------------
+    fn __repr__(&self) -> String {
+        self.serialize_json()
+    }
+
+    fn __str__(&self) -> String {
+        self.__repr__()
+    }
+
+    // ------------------------------------------------------------------------
+    // Serialization
+    // ------------------------------------------------------------------------
+    /// Serialize this object to a JSON string.
+    pub fn serialize_json(&self) -> String {
+        serde_json::to_string(&self).expect("Serialization should not fail")
+    }
+
+    /// Convert this object to a dictionary.
+    pub fn as_dict(&self) -> PyResult<Py<PyAny>> {
+        Python::attach(|py| {
+            let obj = pythonize(py, &self).expect("Python object conversion should not fail");
+            obj.into_py_any(py)
+        })
+    }
+}
+
+impl From<PyLayerGroup> for LayerGroup {
+    fn from(layer_group: PyLayerGroup) -> Self {
+        layer_group.0
+    }
+}
+
+impl From<LayerGroup> for PyLayerGroup {
+    fn from(layer_group: LayerGroup) -> Self {
+        PyLayerGroup(layer_group)
     }
 }
 

--- a/moyopy/src/lib.rs
+++ b/moyopy/src/lib.rs
@@ -20,7 +20,9 @@ use crate::dataset::{
     PyMoyoCollinearMagneticDataset, PyMoyoDataset, PyMoyoLayerDataset,
     PyMoyoNonCollinearMagneticDataset,
 };
-use crate::identify::{PyMagneticSpaceGroup, PyPointGroup, PySpaceGroup, integral_normalizer};
+use crate::identify::{
+    PyLayerGroup, PyMagneticSpaceGroup, PyPointGroup, PySpaceGroup, integral_normalizer,
+};
 
 // https://github.com/pydantic/pydantic-core/blob/main/src/lib.rs
 fn moyopy_version() -> &'static str {
@@ -82,6 +84,7 @@ fn moyopy(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // identify
     m.add_class::<PyPointGroup>()?;
     m.add_class::<PySpaceGroup>()?;
+    m.add_class::<PyLayerGroup>()?;
     m.add_class::<PyMagneticSpaceGroup>()?;
     m.add_wrapped(wrap_pyfunction!(integral_normalizer))?;
 


### PR DESCRIPTION
## Summary

- Add `LayerGroup::from_lattice` in `moyo/src/identify/layer/layer_group.rs` mirroring `SpaceGroup::from_lattice` but using `Lattice2D::lift_inplane_minkowski_reduce` so the aperiodic c-axis is preserved (a 3D Minkowski reduction would permute axes and break the layer-block-form invariant Stage 1/2 rely on).
- Add `PyLayerGroup` PyO3 binding mirroring `PySpaceGroup`, with constructor `(prim_rotations, prim_translations, *, basis=None, setting=None, epsilon=1e-4)`. Properties: `number`, `hall_number`, `linear`, `origin_shift`, plus `serialize_json` / `as_dict`.
- Wire up `moyopy/src/lib.rs`, `_identify.pyi`, `_moyopy.pyi`, `__init__.py`.

## Test plan

- [x] `cargo test -p moyo identify::layer` (incl. 2 new `from_lattice` cases: identity-basis no-op + in-plane-skew round-trip)
- [x] `pytest python/tests/test_identify.py` (incl. 3 `test_identify_layer_group` cases for LG 1/8/65 and 2 `test_identify_layer_group_with_basis` cases)
- [x] `prek` lint hooks (ruff, cargo fmt, typos)

[Claude Code] Generated with [Claude Code](https://claude.com/claude-code)
