### PR TITLE
chore: release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 Unlisted patch versions (e.g. v0.7.1, v0.7.3, v0.7.6, v0.7.7) contain only dependency or build updates with no user-visible changes.
 
+## v0.9.0 - 2026-05-09
+
+### moyo
+
+- Add layer-group identification pipeline: `LayerGroup`, `LayerHallSymbol`, `LayerSetting`, and `MoyoLayerDataset` public API (#303, #304, #305, #306, #308)
+- Add `LayerGroup::from_lattice` for in-plane lattice reduction (#318)
+
+### moyopy
+
+- Mark Development Status as Beta (#302)
+- Add `MoyoLayerDataset` and `LayerSetting` bindings (#310)
+- Add `LayerGroupType` bindings and `operations_from_layer_number` (#317)
+- Add `LayerGroup` binding for layer-group identification (#318)
+
 ## v0.8.0 - 2026-05-01
 
 ### moyo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -788,7 +788,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "moyo"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "approx",
  "criterion",
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "moyo-wasm"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "moyo",
  "serde",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "moyoc"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "approx",
  "log",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "moyopy"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "approx",
  "itertools 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "2"
 authors = ["Kohei Shinohara <kshinohara0508@gmail.com>"]
 description = "Library for Crystal Symmetry in Rust"
 edition = "2024"
-version = "0.8.0"
+version = "0.9.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/spglib/moyo"
 

--- a/moyoc/Cargo.toml
+++ b/moyoc/Cargo.toml
@@ -16,7 +16,7 @@ name = "moyoc"
 crate-type = ["cdylib"]
 
 [dependencies]
-moyo = { path = "../moyo", version = "0.8.0" }
+moyo = { path = "../moyo", version = "0.9.0" }
 nalgebra.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/moyopy/Cargo.toml
+++ b/moyopy/Cargo.toml
@@ -17,7 +17,7 @@ name = "moyopy"
 crate-type = ["cdylib"]
 
 [dependencies]
-moyo = { path = "../moyo", version = "0.8.0" }
+moyo = { path = "../moyo", version = "0.9.0" }
 nalgebra.workspace = true
 serde.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION
## Summary

- Bump workspace crates from 0.8.0 to 0.9.0 (`moyo`, `moyopy`, `moyoc`, `moyo-wasm` via lockfile).
- Add the v0.9.0 entry to `CHANGELOG.md` for the layer-group identification work landed since v0.8.0.

The headline change in this release is the layer-group identification pipeline:
- `moyo`: `LayerGroup`, `LayerHallSymbol`, `LayerSetting`, `MoyoLayerDataset`, plus `LayerGroup::from_lattice` for in-plane reduction.
- `moyopy`: bindings for `MoyoLayerDataset`, `LayerSetting`, `LayerGroupType`, `operations_from_layer_number`, and `LayerGroup`. Package classifier moved to Beta.

## Test plan

- [ ] CI green (`just test`, `just py-test`, `just c-test`, `just prek-all`).
- [ ] After CI: convert from draft to ready, tag and run `cargo release` per `CLAUDE.md`.

[Claude Code] Generated with [Claude Code](https://claude.com/claude-code)
