### PR TITLE
ci: force cbindgen reinstall in C release build

### DIFF
--- a/.github/workflows/rw-c-release.yaml
+++ b/.github/workflows/rw-c-release.yaml
@@ -32,7 +32,7 @@ jobs:
           targets: ${{ matrix.target }}
       - uses: cargo-bins/cargo-binstall@9d36bebae244fb1a7fd7831d3c5a4bc8f1cab230 # main
       - name: Install cbindgen
-        run: cargo binstall cbindgen --locked --no-confirm
+        run: cargo binstall cbindgen --locked --no-confirm --force
       - name: Install cross linker
         if: matrix.target == 'aarch64-unknown-linux-gnu'
         uses: awalsh128/cache-apt-pkgs-action@2c09a5e66da6c8016428a2172bd76e5e4f14bb17 # latest


### PR DESCRIPTION
## Summary

The v0.9.0 release workflow's C build (`rw-c-release.yaml`) failed on every target with:

```
cbindgen --config cbindgen.toml --crate moyoc --output moyoc.h
make: cbindgen: No such file or directory
make: *** [Makefile:52: moyoc.h] Error 127
```

`cargo binstall cbindgen --locked --no-confirm` short-circuited with `INFO resolve: cbindgen v0.29.2 is already installed, use --force to override`, because rust-cache restored `~/.cargo/.crates.toml` without the matching binary in `~/.cargo/bin/`. The make step then can't find `cbindgen` on PATH.

Adding `--force` makes `cargo binstall` always materialize the binary regardless of cached crate metadata.

Failing run: https://github.com/spglib/moyo/actions/runs/25591329509/job/75129421412

## Test plan

- [ ] Trigger `release.yaml` (re-run / dispatch / re-tag) and confirm the four C build matrix jobs pass.

[Claude Code] Generated with [Claude Code](https://claude.com/claude-code)
