### PR TITLE
refactor: accept det = +/- 1 in UnimodularTransformation::new

### DIFF
--- a/moyo/src/base/transformation.rs
+++ b/moyo/src/base/transformation.rs
@@ -29,8 +29,8 @@ pub struct UnimodularTransformation {
 impl UnimodularTransformation {
     pub fn new(linear: UnimodularLinear, origin_shift: OriginShift) -> Self {
         let det = linear.map(|e| e as f64).determinant().round() as i32;
-        if det != 1 {
-            panic!("Determinant of transformation matrix should be one.");
+        if det.abs() != 1 {
+            panic!("Determinant of unimodular transformation must be +/- 1.");
         }
 
         let linear_inv = linear
@@ -431,10 +431,60 @@ fn transform_operation_as_f64(
 mod tests {
     use nalgebra::{matrix, vector};
 
-    use super::{Lattice, LayerCell, Transformation};
+    use super::{Lattice, LayerCell, Transformation, UnimodularTransformation};
     use crate::base::AngleTolerance;
     use crate::base::cell::Cell;
     use crate::base::operation::{Operation, Translation};
+
+    #[test]
+    fn test_unimodular_transformation_accepts_det_minus_one() {
+        // Mirror in x: det = -1. Must construct without panicking.
+        let mirror = matrix![
+            -1, 0, 0;
+             0, 1, 0;
+             0, 0, 1;
+        ];
+        let t = UnimodularTransformation::from_linear(mirror);
+        assert_eq!(t.linear_as_f64().determinant().round() as i32, -1);
+        // Inverse of an involution is itself.
+        let inv = t.inverse();
+        assert_eq!(inv.linear, mirror);
+        // Conjugating a 4-fold about z by the mirror yields a 4^-1 about z
+        // (the rotation sense is reversed). Either way, the operation must
+        // be a valid integer matrix; just check round-trip via inverse.
+        let op = Operation::new(
+            matrix![
+                0, -1, 0;
+                1,  0, 0;
+                0,  0, 1;
+            ],
+            vector![0.25, 0.0, 0.0],
+        );
+        let conjugated = t.transform_operation(&op);
+        let back = inv.transform_operation(&conjugated);
+        assert_eq!(back.rotation, op.rotation);
+        assert_relative_eq!(back.translation, op.translation);
+    }
+
+    #[test]
+    #[should_panic(expected = "Determinant of unimodular transformation must be +/- 1.")]
+    fn test_unimodular_transformation_rejects_det_two() {
+        let _ = UnimodularTransformation::from_linear(matrix![
+            2, 0, 0;
+            0, 1, 0;
+            0, 0, 1;
+        ]);
+    }
+
+    #[test]
+    #[should_panic(expected = "Determinant of unimodular transformation must be +/- 1.")]
+    fn test_unimodular_transformation_rejects_singular() {
+        let _ = UnimodularTransformation::from_linear(matrix![
+            1, 0, 0;
+            0, 1, 0;
+            0, 0, 0;
+        ]);
+    }
 
     #[test]
     fn test_incompatible_transformation() {


### PR DESCRIPTION
## Summary

Relax `UnimodularTransformation::new` (`moyo/src/base/transformation.rs:30-34`)
to allow `det = +/- 1` instead of strictly `+1`. The standard
mathematical definition of "unimodular" includes `det = -1`; the prior
restriction was tighter than the type alias `UnimodularLinear` itself
(which is just `Matrix3<i32>` with no det constraint).

The constructor's `try_inverse()` and the struct's transform methods
(`transform_lattice`, `transform_operation`, `transform_cell`) are
already determinant-agnostic, so no behavior changes for existing
callers.

## Why

This is a precondition for the Euclidean normalizer work in #326
(issue #250), which needs to store improper Bravais-group elements
(`det = -1` mirrors / rotoinversions) as `UnimodularTransformation`. With
the panic in place, that PR has to work around the constructor with a
local `change_basis` helper and a parallel `match_origin_shift_general`.
Once this PR lands, those workarounds can be dropped and `Normalizer`
falls naturally into the standard transform helpers.

## Audit (no caller breaks)

All current call sites of `UnimodularTransformation::new` /
`from_linear` pass `det = +1` matrices:

- `iter_unimodular_trans_mat` in `point_group.rs` filters `det == 1`.
- `point_group.rs` constructions use the identity or matrices derived
  from a det = +1 source.
- `space_group.rs` composes `point_group.prim_trans_mat` with
  `correction_transformation_matrices`, both det = +1.

So this is a pure widening: previously valid inputs still work
identically, and previously panicking det = -1 inputs now succeed.

The separate `Transformation::new` (`transformation.rs:181-196`,
`det <= 0` panic) is for supercell expansion (stores `size = det`) and
intentionally remains unchanged.

## Test plan

- [x] `cargo test -p moyo` (144 / 144 lib + integration tests passing).
- [x] Three new tests in `transformation.rs`:
  - `test_unimodular_transformation_accepts_det_minus_one`: constructs a
    mirror, verifies inverse round-trip on a sample operation.
  - `test_unimodular_transformation_rejects_det_two` (`should_panic`):
    `det = 2` still rejected.
  - `test_unimodular_transformation_rejects_singular` (`should_panic`):
    `det = 0` still rejected.
- [x] `cargo fmt --all`, `just prek` clean.

[Claude Code] Generated with [Claude Code](https://claude.com/claude-code)
