### PR TITLE
feat(moyo-wasm): space-group data-access wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Unlisted patch versions (e.g. v0.7.1, v0.7.3, v0.7.6, v0.7.7) contain only depen
 
 - Expose `operations_from_number`, `operations_from_layer_number`, and `magnetic_operations_from_uni_number` from `moyo::data` so all bindings can reuse them
 
+### moyo-wasm
+
+- Add data-access wrappers for space groups: `operations_from_number`, `hall_symbol_entry`, `space_group_type`, `arithmetic_crystal_class`
+
 ## v0.9.0 - 2026-05-09
 
 ### moyo

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Legend: ✅ supported · 🟡 partial · ❌ not exposed · ➖ not applicable.
 | -------------------- | -------------------- | ------------- | ----------------- | ----------- | --------------------- |
 | Shared               | Core types           | ✅            | ✅                | 🟡          | 🟡                    |
 | Space group          | Dataset from cell    | ✅            | ✅                | ✅          | ✅                    |
-| Space group          | Data access          | ✅            | ✅                | ❌          | ❌                    |
+| Space group          | Data access          | ✅            | ✅                | ❌          | 🟡                    |
 | Space group          | Group identification | ✅            | ✅                | ❌          | ❌                    |
 | Layer group          | Dataset from cell    | ✅            | ✅                | ❌          | ❌                    |
 | Layer group          | Data access          | ✅            | ✅                | ❌          | ❌                    |

--- a/justfile
+++ b/justfile
@@ -73,3 +73,22 @@ c-test:
 [working-directory: 'moyoc']
 c-clean:
     make clean
+
+################################################################################
+# JS (WASM)
+################################################################################
+
+[group('js')]
+[working-directory: 'moyo-wasm']
+js-install:
+    npm install
+
+[group('js')]
+[working-directory: 'moyo-wasm']
+js-build:
+    npm run build
+
+[group('js')]
+[working-directory: 'moyo-wasm']
+js-test:
+    npm test

--- a/moyo-wasm/src/lib.rs
+++ b/moyo-wasm/src/lib.rs
@@ -3,8 +3,11 @@ use tsify::Tsify;
 use wasm_bindgen::prelude::*;
 
 use moyo::MoyoDataset as InternalMoyoDataset;
-use moyo::base::{AngleTolerance as InternalAngleTolerance, Cell};
-use moyo::data::Setting;
+use moyo::base::{AngleTolerance as InternalAngleTolerance, Cell, MoyoError};
+use moyo::data::{
+    Centering, CrystalFamily, CrystalSystem, LatticeSystem, Setting,
+    arithmetic_crystal_class_entry, hall_symbol_entry as core_hall_symbol_entry,
+};
 use serde::{Deserialize, Serialize};
 
 // Generic array conversion helpers
@@ -58,6 +61,92 @@ pub struct MoyoOperation {
 pub enum AngleTolerance {
     Radian(f64),
     Default,
+}
+
+#[derive(Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+#[serde(tag = "type", content = "value")]
+pub enum MoyoSetting {
+    Spglib,
+    Standard,
+    HallNumber(i32),
+}
+
+impl From<MoyoSetting> for Setting {
+    fn from(s: MoyoSetting) -> Self {
+        match s {
+            MoyoSetting::Spglib => Setting::Spglib,
+            MoyoSetting::Standard => Setting::Standard,
+            MoyoSetting::HallNumber(n) => Setting::HallNumber(n),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi)]
+pub enum MoyoCentering {
+    P,
+    A,
+    B,
+    C,
+    I,
+    R,
+    F,
+}
+
+impl From<Centering> for MoyoCentering {
+    fn from(c: Centering) -> Self {
+        match c {
+            Centering::P => Self::P,
+            Centering::A => Self::A,
+            Centering::B => Self::B,
+            Centering::C => Self::C,
+            Centering::I => Self::I,
+            Centering::R => Self::R,
+            Centering::F => Self::F,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi)]
+pub struct MoyoHallSymbolEntry {
+    pub hall_number: i32,
+    pub number: i32,
+    pub arithmetic_number: i32,
+    pub setting: String,
+    pub hall_symbol: String,
+    pub hm_short: String,
+    pub hm_full: String,
+    pub centering: MoyoCentering,
+}
+
+#[derive(Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi)]
+pub struct MoyoArithmeticCrystalClass {
+    pub arithmetic_number: i32,
+    pub symbol: String,
+    pub geometric_crystal_class: String,
+    pub bravais_class: String,
+}
+
+#[derive(Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi)]
+pub struct MoyoSpaceGroupType {
+    pub number: i32,
+    pub hm_short: String,
+    pub hm_full: String,
+    pub arithmetic_number: i32,
+    pub arithmetic_symbol: String,
+    pub geometric_crystal_class: String,
+    pub crystal_system: String,
+    pub bravais_class: String,
+    pub lattice_system: String,
+    pub crystal_family: String,
+}
+
+fn map_moyo_err(err: MoyoError) -> JsValue {
+    JsValue::from_str(&format!("moyo error: {:?}", err))
 }
 
 #[derive(Serialize, Deserialize, Tsify)]
@@ -191,4 +280,74 @@ pub fn analyze_cell(cell_json: &str, symprec: f64, setting: &str) -> Result<Moyo
     )
     .map_err(|err| JsValue::from_str(&format!("moyo error: {:?}", err)))?;
     Ok(MoyoDataset::from(dataset))
+}
+
+/// Return symmetry operations for the given space-group ITA `number`.
+#[wasm_bindgen]
+pub fn operations_from_number(
+    number: i32,
+    setting: MoyoSetting,
+    primitive: bool,
+) -> Result<Vec<MoyoOperation>, JsValue> {
+    let ops = moyo::data::operations_from_number(number, setting.into(), primitive)
+        .map_err(map_moyo_err)?;
+    Ok(ops.iter().map(MoyoOperation::from).collect())
+}
+
+/// Return the Hall-symbol entry for the given `hall_number` (1 - 530).
+#[wasm_bindgen]
+pub fn hall_symbol_entry(hall_number: i32) -> Result<MoyoHallSymbolEntry, JsValue> {
+    let entry = core_hall_symbol_entry(hall_number)
+        .ok_or_else(|| JsValue::from_str(&format!("unknown hall_number: {}", hall_number)))?;
+    Ok(MoyoHallSymbolEntry {
+        hall_number: entry.hall_number,
+        number: entry.number,
+        arithmetic_number: entry.arithmetic_number,
+        setting: entry.setting.to_string(),
+        hall_symbol: entry.hall_symbol.to_string(),
+        hm_short: entry.hm_short.to_string(),
+        hm_full: entry.hm_full.to_string(),
+        centering: entry.centering.into(),
+    })
+}
+
+/// Return the arithmetic-crystal-class entry for the given `arithmetic_number` (1 - 73).
+#[wasm_bindgen]
+pub fn arithmetic_crystal_class(
+    arithmetic_number: i32,
+) -> Result<MoyoArithmeticCrystalClass, JsValue> {
+    let entry = arithmetic_crystal_class_entry(arithmetic_number).ok_or_else(|| {
+        JsValue::from_str(&format!("unknown arithmetic_number: {}", arithmetic_number))
+    })?;
+    Ok(MoyoArithmeticCrystalClass {
+        arithmetic_number: entry.arithmetic_number,
+        symbol: entry.symbol.to_string(),
+        geometric_crystal_class: entry.geometric_crystal_class.to_string(),
+        bravais_class: entry.bravais_class.to_string(),
+    })
+}
+
+/// Return the space-group-type description for the given ITA `number` (1 - 230).
+#[wasm_bindgen]
+pub fn space_group_type(number: i32) -> Result<MoyoSpaceGroupType, JsValue> {
+    let hall_number = Setting::default()
+        .hall_number(number)
+        .ok_or_else(|| JsValue::from_str(&format!("unknown space-group number: {}", number)))?;
+    let hs = core_hall_symbol_entry(hall_number).unwrap();
+    let arith = arithmetic_crystal_class_entry(hs.arithmetic_number).unwrap();
+    let crystal_system = CrystalSystem::from_geometric_crystal_class(arith.geometric_crystal_class);
+    let lattice_system = LatticeSystem::from_bravais_class(arith.bravais_class);
+    let crystal_family = CrystalFamily::from_lattice_system(lattice_system);
+    Ok(MoyoSpaceGroupType {
+        number: hs.number,
+        hm_short: hs.hm_short.to_string(),
+        hm_full: hs.hm_full.to_string(),
+        arithmetic_number: arith.arithmetic_number,
+        arithmetic_symbol: arith.symbol.to_string(),
+        geometric_crystal_class: arith.geometric_crystal_class.to_string(),
+        crystal_system: crystal_system.to_string(),
+        bravais_class: arith.bravais_class.to_string(),
+        lattice_system: lattice_system.to_string(),
+        crystal_family: crystal_family.to_string(),
+    })
 }

--- a/moyo-wasm/tests/data.test.ts
+++ b/moyo-wasm/tests/data.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import {
+  arithmetic_crystal_class,
+  hall_symbol_entry,
+  operations_from_number,
+  space_group_type,
+} from "../pkg/moyo_wasm.js";
+
+describe("operations_from_number", () => {
+  it("Ia-3d (#230, Standard) returns 96 conventional operations", () => {
+    const ops = operations_from_number(230, { type: "Standard" }, false);
+    expect(ops.length).toBe(96);
+  });
+
+  it("Ia-3d (#230, Standard, primitive) returns 48 operations", () => {
+    const ops = operations_from_number(230, { type: "Standard" }, true);
+    expect(ops.length).toBe(48);
+  });
+
+  it("Pm-3m (#221, Standard) returns 48 operations", () => {
+    const ops = operations_from_number(221, { type: "Standard" }, false);
+    expect(ops.length).toBe(48);
+  });
+
+  it("P1 (#1, Standard) returns 1 operation", () => {
+    const ops = operations_from_number(1, { type: "Standard" }, false);
+    expect(ops.length).toBe(1);
+  });
+
+  it("Spglib setting also works (#15 C2/c)", () => {
+    const ops = operations_from_number(15, { type: "Spglib" }, false);
+    expect(ops.length).toBe(8);
+  });
+
+  it("operations have 3x3 rotation and length-3 translation", () => {
+    const ops = operations_from_number(1, { type: "Standard" }, false);
+    expect(ops[0].rotation.length).toBe(9);
+    expect(ops[0].translation.length).toBe(3);
+  });
+
+  it("throws on invalid number", () => {
+    expect(() =>
+      operations_from_number(0, { type: "Standard" }, false),
+    ).toThrow();
+  });
+});
+
+describe("hall_symbol_entry", () => {
+  it("returns Fd-3c entry for hall_number 528 (#228 origin choice 2)", () => {
+    const entry = hall_symbol_entry(528);
+    expect(entry.hall_number).toBe(528);
+    expect(entry.number).toBe(228);
+    expect(entry.setting).toBe("2");
+    expect(entry.hm_short).toBe("F d -3 c");
+    expect(entry.centering).toBe("F");
+  });
+
+  it("throws on invalid hall_number", () => {
+    expect(() => hall_symbol_entry(0)).toThrow();
+  });
+});
+
+describe("arithmetic_crystal_class", () => {
+  it("returns 3m1P for arithmetic_number 45", () => {
+    const c = arithmetic_crystal_class(45);
+    expect(c.arithmetic_number).toBe(45);
+    expect(c.symbol).toBe("3m1P");
+    expect(c.geometric_crystal_class).toBe("3m");
+    expect(c.bravais_class).toBe("hP");
+  });
+
+  it("throws on invalid arithmetic_number", () => {
+    expect(() => arithmetic_crystal_class(0)).toThrow();
+  });
+});
+
+describe("space_group_type", () => {
+  it("Pm-3m (#221) reports cubic classifications", () => {
+    const t = space_group_type(221);
+    expect(t.number).toBe(221);
+    expect(t.hm_short).toBe("P m -3 m");
+    expect(t.arithmetic_number).toBe(71);
+    expect(t.arithmetic_symbol).toBe("m-3mP");
+    expect(t.geometric_crystal_class).toBe("m-3m");
+    expect(t.crystal_system).toBe("Cubic");
+    expect(t.bravais_class).toBe("cP");
+    expect(t.lattice_system).toBe("Cubic");
+    expect(t.crystal_family).toBe("Cubic");
+  });
+
+  it("R-3c (#167) reports trigonal/rhombohedral classifications", () => {
+    const t = space_group_type(167);
+    expect(t.number).toBe(167);
+    expect(t.hm_short).toBe("R -3 c");
+    expect(t.arithmetic_number).toBe(50);
+    expect(t.arithmetic_symbol).toBe("-3mR");
+    expect(t.geometric_crystal_class).toBe("-3m");
+    expect(t.crystal_system).toBe("Trigonal");
+    expect(t.bravais_class).toBe("hR");
+    expect(t.lattice_system).toBe("Rhombohedral");
+    expect(t.crystal_family).toBe("Hexagonal");
+  });
+
+  it("throws on invalid number", () => {
+    expect(() => space_group_type(0)).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- Add four `#[wasm_bindgen]` data-access functions to `moyo-wasm` so JS/TS callers can query crystallographic data without constructing a `Cell`. They wrap the corresponding `moyo::data` functions and mirror the moyopy API surface (`SpaceGroupType`, `HallSymbolEntry`, `ArithmeticCrystalClass`):
  - `operations_from_number(number, setting, primitive) -> MoyoOperation[]`
  - `hall_symbol_entry(hall_number) -> MoyoHallSymbolEntry`
  - `space_group_type(number) -> MoyoSpaceGroupType` (synthesized from `HallSymbolEntry` + `ArithmeticCrystalClassEntry`, matching `PySpaceGroupType::new`)
  - `arithmetic_crystal_class(arithmetic_number) -> MoyoArithmeticCrystalClass`
- Add Tsify DTOs (`MoyoSetting`, `MoyoCentering`, `MoyoHallSymbolEntry`, `MoyoArithmeticCrystalClass`, `MoyoSpaceGroupType`). `MoyoSetting` is a tagged enum exposing all three `Setting` variants (`Spglib`, `Standard`, `HallNumber(i32)`) — the existing `analyze_cell`'s string-based `setting` is left untouched and can be unified in a follow-up.
- Errors map through the same `JsValue::from_str(format!("moyo error: {:?}", err))` pattern used by `analyze_cell`, consolidated into a `map_moyo_err` helper.
- Out of scope: layer-group and magnetic-space-group data wrappers (same pattern, follow-up PRs).

## Test plan

- [x] `cd moyo-wasm && npm run build` — wasm-pack builds clean; generated `pkg/moyo_wasm.d.ts` contains the four new functions plus `MoyoSetting`/`MoyoCentering`/`MoyoHallSymbolEntry`/`MoyoArithmeticCrystalClass`/`MoyoSpaceGroupType`.
- [x] `cd moyo-wasm && npx vitest run` — 41/41 tests pass (14 new in `tests/data.test.ts` + 27 existing in `tests/analyze_cell.test.ts`).
- [x] New tests cover: operation counts for Ia-3d/Pm-3m/P1/C2/c, primitive vs conventional, Standard vs Spglib settings, error on invalid inputs; `HallSymbolEntry(528)` → Fd-3c origin choice 2; `ArithmeticCrystalClass(45)` → `3m1P`/`3m`/`hP`; `SpaceGroupType(221)` and `SpaceGroupType(167)` reproducing the moyopy assertions.
- [x] `just prek` — all pre-commit hooks green (cargo fmt, mdformat, typos, etc.).

[Claude Code] Generated with [Claude Code](https://claude.com/claude-code)
