### PR TITLE
feat(moyo-wasm): add magnetic-space-group data-access wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Unlisted patch versions (e.g. v0.7.1, v0.7.3, v0.7.6, v0.7.7) contain only depen
 
 - Add data-access wrappers for space groups: `operations_from_number`, `hall_symbol_entry`, `space_group_type`, `arithmetic_crystal_class`
 - Add data-access wrappers for layer groups: `operations_from_layer_number`, `layer_hall_symbol_entry`, `layer_group_type`, `layer_arithmetic_crystal_class`
+- Add data-access wrappers for magnetic space groups: `magnetic_operations_from_uni_number`, `magnetic_hall_symbol_entry`, `magnetic_space_group_type`
 
 ## v0.9.0 - 2026-05-09
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Legend: ✅ supported · 🟡 partial · ❌ not exposed · ➖ not applicable.
 | Layer group          | Data access          | ✅            | ✅                | ❌          | 🟡                    |
 | Layer group          | Group identification | ✅            | ✅                | ❌          | ❌                    |
 | Magnetic space group | Dataset from cell    | ✅            | ✅                | ❌          | ❌                    |
-| Magnetic space group | Data access          | ✅            | ✅                | ❌          | ❌                    |
+| Magnetic space group | Data access          | ✅            | ✅                | ❌          | 🟡                    |
 | Magnetic space group | Group identification | ✅            | ✅                | ❌          | ❌                    |
 
 Notes:

--- a/moyo-wasm/src/common.rs
+++ b/moyo-wasm/src/common.rs
@@ -28,3 +28,21 @@ impl From<&moyo::base::Operation> for MoyoOperation {
         }
     }
 }
+
+#[derive(Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct MoyoMagneticOperation {
+    pub rotation: [f64; 9],
+    pub translation: [f64; 3],
+    pub time_reversal: bool,
+}
+
+impl From<&moyo::base::MagneticOperation> for MoyoMagneticOperation {
+    fn from(mop: &moyo::base::MagneticOperation) -> Self {
+        Self {
+            rotation: to_array9(mop.operation.rotation.as_slice()),
+            translation: to_3_slice(&mop.operation.translation),
+            time_reversal: mop.time_reversal,
+        }
+    }
+}

--- a/moyo-wasm/src/lib.rs
+++ b/moyo-wasm/src/lib.rs
@@ -3,4 +3,5 @@
 mod common;
 mod dataset;
 mod layer_group;
+mod magnetic;
 mod space_group;

--- a/moyo-wasm/src/magnetic.rs
+++ b/moyo-wasm/src/magnetic.rs
@@ -1,0 +1,74 @@
+use serde::{Deserialize, Serialize};
+use tsify::Tsify;
+use wasm_bindgen::prelude::*;
+
+use moyo::data::{
+    ConstructType, get_magnetic_space_group_type,
+    magnetic_hall_symbol_entry as core_magnetic_hall_symbol_entry,
+};
+
+use crate::common::{MoyoMagneticOperation, map_moyo_err};
+
+#[derive(Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi)]
+pub struct MoyoMagneticHallSymbolEntry {
+    pub uni_number: i32,
+    pub magnetic_hall_symbol: String,
+}
+
+#[derive(Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi)]
+pub struct MoyoMagneticSpaceGroupType {
+    pub uni_number: i32,
+    pub litvin_number: i32,
+    pub bns_number: String,
+    pub og_number: String,
+    pub number: i32,
+    pub construct_type: i32,
+}
+
+fn construct_type_to_i32(ct: ConstructType) -> i32 {
+    match ct {
+        ConstructType::Type1 => 1,
+        ConstructType::Type2 => 2,
+        ConstructType::Type3 => 3,
+        ConstructType::Type4 => 4,
+    }
+}
+
+/// Return magnetic symmetry operations for the given `uni_number` (1 - 1651).
+#[wasm_bindgen]
+pub fn magnetic_operations_from_uni_number(
+    uni_number: i32,
+    primitive: bool,
+) -> Result<Vec<MoyoMagneticOperation>, JsValue> {
+    let ops = moyo::data::magnetic_operations_from_uni_number(uni_number, primitive)
+        .map_err(map_moyo_err)?;
+    Ok(ops.iter().map(MoyoMagneticOperation::from).collect())
+}
+
+/// Return the magnetic Hall-symbol entry for the given `uni_number` (1 - 1651).
+#[wasm_bindgen]
+pub fn magnetic_hall_symbol_entry(uni_number: i32) -> Result<MoyoMagneticHallSymbolEntry, JsValue> {
+    let entry = core_magnetic_hall_symbol_entry(uni_number)
+        .ok_or_else(|| JsValue::from_str(&format!("unknown uni_number: {}", uni_number)))?;
+    Ok(MoyoMagneticHallSymbolEntry {
+        uni_number: entry.uni_number,
+        magnetic_hall_symbol: entry.magnetic_hall_symbol.to_string(),
+    })
+}
+
+/// Return the magnetic-space-group-type description for the given `uni_number` (1 - 1651).
+#[wasm_bindgen]
+pub fn magnetic_space_group_type(uni_number: i32) -> Result<MoyoMagneticSpaceGroupType, JsValue> {
+    let msgt = get_magnetic_space_group_type(uni_number)
+        .ok_or_else(|| JsValue::from_str(&format!("unknown uni_number: {}", uni_number)))?;
+    Ok(MoyoMagneticSpaceGroupType {
+        uni_number: msgt.uni_number,
+        litvin_number: msgt.litvin_number,
+        bns_number: msgt.bns_number.to_string(),
+        og_number: msgt.og_number.to_string(),
+        number: msgt.number,
+        construct_type: construct_type_to_i32(msgt.construct_type),
+    })
+}

--- a/moyo-wasm/tests/magnetic.test.ts
+++ b/moyo-wasm/tests/magnetic.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import {
+  magnetic_hall_symbol_entry,
+  magnetic_operations_from_uni_number,
+  magnetic_space_group_type,
+} from "../pkg/moyo_wasm.js";
+
+describe("magnetic_operations_from_uni_number", () => {
+  it("UNI 1242 (R_I3, BNS 146.12) returns 18 conventional / 6 primitive", () => {
+    const ops_conv = magnetic_operations_from_uni_number(1242, false);
+    expect(ops_conv.length).toBe(18);
+    const ops_prim = magnetic_operations_from_uni_number(1242, true);
+    expect(ops_prim.length).toBe(6);
+  });
+
+  it("UNI 1 (P 1, BNS 1.1) returns a single identity operation", () => {
+    const ops = magnetic_operations_from_uni_number(1, false);
+    expect(ops.length).toBe(1);
+    expect(ops[0].time_reversal).toBe(false);
+  });
+
+  it("UNI 2 (P 1 1', BNS 1.2) returns 2 operations (identity + time reversal)", () => {
+    const ops = magnetic_operations_from_uni_number(2, false);
+    expect(ops.length).toBe(2);
+    const timeReversals = ops.map((op) => op.time_reversal).sort();
+    expect(timeReversals).toEqual([false, true]);
+  });
+
+  it("throws on invalid uni_number", () => {
+    expect(() => magnetic_operations_from_uni_number(0, false)).toThrow();
+    expect(() => magnetic_operations_from_uni_number(1652, false)).toThrow();
+  });
+});
+
+describe("magnetic_hall_symbol_entry", () => {
+  it("uni_number 1 -> 'P 1'", () => {
+    const entry = magnetic_hall_symbol_entry(1);
+    expect(entry.uni_number).toBe(1);
+    expect(entry.magnetic_hall_symbol).toBe("P 1");
+  });
+
+  it("uni_number 2 -> 'P 1 1''", () => {
+    const entry = magnetic_hall_symbol_entry(2);
+    expect(entry.uni_number).toBe(2);
+    expect(entry.magnetic_hall_symbol).toBe("P 1 1'");
+  });
+
+  it("throws on invalid uni_number", () => {
+    expect(() => magnetic_hall_symbol_entry(0)).toThrow();
+    expect(() => magnetic_hall_symbol_entry(1652)).toThrow();
+  });
+});
+
+describe("magnetic_space_group_type", () => {
+  it("uni_number 1 -> BNS 1.1, ITA 1, Type 1", () => {
+    const msgt = magnetic_space_group_type(1);
+    expect(msgt.uni_number).toBe(1);
+    expect(msgt.litvin_number).toBe(1);
+    expect(msgt.bns_number).toBe("1.1");
+    expect(msgt.og_number).toBe("1.1.1");
+    expect(msgt.number).toBe(1);
+    expect(msgt.construct_type).toBe(1);
+  });
+
+  it("uni_number 1262 -> BNS 151.32, Type 4", () => {
+    const msgt = magnetic_space_group_type(1262);
+    expect(msgt.bns_number).toBe("151.32");
+    expect(msgt.og_number).toBe("153.4.1270");
+    expect(msgt.construct_type).toBe(4);
+  });
+
+  it("throws on invalid uni_number", () => {
+    expect(() => magnetic_space_group_type(0)).toThrow();
+    expect(() => magnetic_space_group_type(1652)).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Expose three magnetic data-access functions to JS/WASM, completing the data-access surface across all three group families (space, layer, magnetic). The functions mirror the moyopy bindings:

- `magnetic_operations_from_uni_number(uni_number, primitive)` -> `MoyoMagneticOperation[]`
- `magnetic_hall_symbol_entry(uni_number)` -> `MoyoMagneticHallSymbolEntry`
- `magnetic_space_group_type(uni_number)` -> `MoyoMagneticSpaceGroupType`

New DTO `MoyoMagneticOperation` (rotation, translation, time_reversal) lives in `common.rs` next to `MoyoOperation`. `construct_type` is exposed as `i32` (1-4) to match moyopy.

Out of scope (deferred): magnetic dataset-from-cell (`MoyoCollinearMagneticDataset` / `MoyoNonCollinearMagneticDataset`) and magnetic group identification.

## Test plan

- [x] `just js-build` (wasm-pack) -- generated `pkg/moyo_wasm.d.ts` contains the three new functions plus DTOs
- [x] `just js-test` -- all 66 vitest cases pass (10 new magnetic, 56 pre-existing)
- [x] `just prek` -- pre-commit clean
- [x] Oracle values cross-checked against `moyo/src/data/operations.rs:233-241` (UNI 1242 -> 18 conv / 6 prim) and `moyopy/python/tests/data/test_magnetic_space_group_type.py` (UNI 1262 -> BNS 151.32, OG 153.4.1270, Type 4)

[Claude Code] Generated with [Claude Code](https://claude.com/claude-code)
