### PR TITLE
docs(apps/web): note one-time github-pages env setup

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -26,6 +26,24 @@ just web-preview   # serves dist locally
 For GitHub Pages, set `VITE_BASE=/<repo>/` before `npm run build`. The CI workflow
 at `.github/workflows/deploy-web.yml` does this automatically.
 
+### One-time GitHub setup for the deploy workflow
+
+The first time `actions/deploy-pages` runs, GitHub auto-creates a `github-pages`
+environment whose "Deployment branches and tags" rule may not match `main`. If
+the deploy job reports
+
+> Branch "main" is not allowed to deploy to github-pages due to environment
+> protection rules.
+
+then, in the repo settings:
+
+1. **Settings -> Pages**: set **Source** to **GitHub Actions**.
+1. **Settings -> Environments -> github-pages -> Deployment branches and tags**:
+   either pick **No restriction**, or **Selected branches and tags** and add
+   `main`.
+
+Then re-run the failed workflow or push another commit to `main`.
+
 ## Tests
 
 ```bash


### PR DESCRIPTION
## Summary

Follow-up to #334. The first run of the `deploy-web.yml` workflow on `main` failed with

> Branch "main" is not allowed to deploy to github-pages due to environment protection rules.

That is a one-time repo-settings step (the auto-created `github-pages` environment has a default Deployment-branches rule that may not include `main`), not a code bug. Document it in `apps/web/README.md` so the next maintainer doesn't have to rediscover it.

## Required repo-settings change (one-time, outside this PR)

1. **Settings -> Pages**: set **Source** to **GitHub Actions**.
2. **Settings -> Environments -> github-pages -> Deployment branches and tags**: either pick **No restriction**, or **Selected branches and tags** and add `main`.
3. Re-run the failed workflow or push another commit to `main`.

## Test plan

- [x] mdformat / pre-commit hooks pass.
- [ ] After settings change, the next `deploy-web.yml` run reaches the deploy step and publishes to Pages.

[Claude Code] Generated with [Claude Code](https://claude.com/claude-code)
