### PR TITLE
feat(apps/web): list data sources on Home page

### DIFF
--- a/apps/web/src/routes/Home.svelte
+++ b/apps/web/src/routes/Home.svelte
@@ -22,38 +22,36 @@
     },
   ]
 
-  const sources: { range: string; title: string; refs: { text: string; href?: string }[] }[] = [
+  const sources: { title: string; refs: { text: string; href?: string }[] }[] = [
     {
-      range: '1 - 230',
       title: 'Space groups',
       refs: [
-        { text: 'Hall-symbol database curated by Dr. Yusuke Seto', href: 'https://yseto.net/en/sg/sg1' },
+        { text: "Seto's Hall-symbol database", href: 'https://yseto.net/en/sg/sg1' },
         {
-          text: 'Hermann-Mauguin symbols and settings: International Tables for Crystallography, Vol. A (2016)',
+          text: 'ITA Vol. A (2016)',
+          href: 'https://it.iucr.org/A/',
         },
       ],
     },
     {
-      range: '1 - 80',
       title: 'Layer groups',
       refs: [
-        { text: 'Group tabulation: International Tables for Crystallography, Vol. E (2010)' },
+        { text: 'ITA Vol. E (2010)', href: 'https://it.iucr.org/E/' },
         {
-          text: 'Hall-symbol assignments: Fu et al., "Symmetry classification of 2D materials: layer groups versus space groups", 2D Mater. 11, 035009 (2024)',
+          text: 'Fu et al., 2D Mater. 11, 035009 (2024)',
           href: 'https://doi.org/10.1088/2053-1583/ad3e0c',
         },
       ],
     },
     {
-      range: '1 - 1651',
       title: 'Magnetic space groups',
       refs: [
         {
-          text: 'Magnetic Hall symbols: Gonzalez-Platas, Katcho & Rodriguez-Carvajal, "Extension of Hall symbols of crystallographic space groups to magnetic space groups", J. Appl. Cryst. (2021)',
+          text: 'González-Platas et al., J. Appl. Cryst. (2021)',
           href: 'https://journals.iucr.org/paper?tu5004',
         },
         {
-          text: 'UNI/BNS/OG numbering and Litvin numbers: Litvin, Magnetic Group Tables (IUCr, 2013)',
+          text: 'Litvin, Magnetic Group Tables (IUCr, 2013)',
           href: 'https://www.iucr.org/publ/978-0-9553602-2-0',
         },
       ],
@@ -88,53 +86,33 @@
   </div>
 </section>
 
-<section class="py-4">
-  <h2 class="text-lg font-semibold tracking-tight">Data sources</h2>
-  <p class="mt-1 text-sm text-stone-600 dark:text-stone-400 max-w-2xl">
-    Crystallographic data embedded in this viewer is sourced from the following references.
-  </p>
-
-  <div
-    class="mt-4 border-y border-stone-300 dark:border-stone-700 divide-y divide-stone-200 dark:divide-stone-800"
-  >
+<section class="mt-8 text-xs text-stone-500 dark:text-stone-400 space-y-2">
+  <h2 class="text-xs font-medium uppercase tracking-wide text-stone-600 dark:text-stone-300">
+    Data sources
+  </h2>
+  <dl class="space-y-1">
     {#each sources as s}
-      <div class="grid grid-cols-[7rem_1fr] items-baseline gap-4 px-1 py-4">
-        <span class="font-mono text-xs text-moyo-700 dark:text-moyo-400">{s.range}</span>
-        <div>
-          <span class="block font-medium">{s.title}</span>
-          <ul class="mt-1 space-y-1 text-sm text-stone-600 dark:text-stone-400 list-disc pl-5">
-            {#each s.refs as r}
-              <li>
-                {#if r.href}
-                  <a
-                    href={r.href}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="underline hover:text-moyo-700 dark:hover:text-moyo-400"
-                  >
-                    {r.text}
-                  </a>
-                {:else}
-                  {r.text}
-                {/if}
-              </li>
-            {/each}
-          </ul>
-        </div>
+      <div class="flex flex-wrap gap-x-2">
+        <dt class="font-mono text-stone-600 dark:text-stone-300">{s.title}:</dt>
+        <dd class="flex-1 min-w-0">
+          {#each s.refs as r, i}{#if i > 0};{' '}{/if}{#if r.href}<a
+              href={r.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="underline hover:text-moyo-700 dark:hover:text-moyo-400">{r.text}</a
+            >{:else}{r.text}{/if}{/each}
+        </dd>
       </div>
     {/each}
-  </div>
-
-  <p class="mt-4 text-xs text-stone-500 dark:text-stone-400">
-    <span class="font-medium">Source code:</span>
-    <a
+  </dl>
+  <p>
+    Source: <a
       href="https://github.com/spglib/moyo"
       target="_blank"
       rel="noopener noreferrer"
       class="underline hover:text-moyo-700 dark:hover:text-moyo-400">github.com/spglib/moyo</a
     >
-    &middot; <span class="font-medium">License:</span>
-    <a
+    &middot; License: <a
       href="https://github.com/spglib/moyo/blob/main/LICENSE-MIT"
       target="_blank"
       rel="noopener noreferrer"

--- a/apps/web/src/routes/Home.svelte
+++ b/apps/web/src/routes/Home.svelte
@@ -21,6 +21,44 @@
       blurb: 'The 1651 Shubnikov / magnetic space-group types, indexed by UNI number.',
     },
   ]
+
+  const sources: { range: string; title: string; refs: { text: string; href?: string }[] }[] = [
+    {
+      range: '1 - 230',
+      title: 'Space groups',
+      refs: [
+        { text: 'Hall-symbol database curated by Dr. Yusuke Seto', href: 'https://yseto.net/en/sg/sg1' },
+        {
+          text: 'Hermann-Mauguin symbols and settings: International Tables for Crystallography, Vol. A (2016)',
+        },
+      ],
+    },
+    {
+      range: '1 - 80',
+      title: 'Layer groups',
+      refs: [
+        { text: 'Group tabulation: International Tables for Crystallography, Vol. E (2010)' },
+        {
+          text: 'Hall-symbol assignments: Fu et al., "Symmetry classification of 2D materials: layer groups versus space groups", 2D Mater. 11, 035009 (2024)',
+          href: 'https://doi.org/10.1088/2053-1583/ad3e0c',
+        },
+      ],
+    },
+    {
+      range: '1 - 1651',
+      title: 'Magnetic space groups',
+      refs: [
+        {
+          text: 'Magnetic Hall symbols: Gonzalez-Platas, Katcho & Rodriguez-Carvajal, "Extension of Hall symbols of crystallographic space groups to magnetic space groups", J. Appl. Cryst. (2021)',
+          href: 'https://journals.iucr.org/paper?tu5004',
+        },
+        {
+          text: 'UNI/BNS/OG numbering and Litvin numbers: Litvin, Magnetic Group Tables (IUCr, 2013)',
+          href: 'https://www.iucr.org/publ/978-0-9553602-2-0',
+        },
+      ],
+    },
+  ]
 </script>
 
 <section class="py-4">
@@ -48,4 +86,66 @@
       </a>
     {/each}
   </div>
+</section>
+
+<section class="py-4">
+  <h2 class="text-lg font-semibold tracking-tight">Data sources</h2>
+  <p class="mt-1 text-sm text-stone-600 dark:text-stone-400 max-w-2xl">
+    Crystallographic data embedded in this viewer is sourced from the following references.
+  </p>
+
+  <div
+    class="mt-4 border-y border-stone-300 dark:border-stone-700 divide-y divide-stone-200 dark:divide-stone-800"
+  >
+    {#each sources as s}
+      <div class="grid grid-cols-[7rem_1fr] items-baseline gap-4 px-1 py-4">
+        <span class="font-mono text-xs text-moyo-700 dark:text-moyo-400">{s.range}</span>
+        <div>
+          <span class="block font-medium">{s.title}</span>
+          <ul class="mt-1 space-y-1 text-sm text-stone-600 dark:text-stone-400 list-disc pl-5">
+            {#each s.refs as r}
+              <li>
+                {#if r.href}
+                  <a
+                    href={r.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="underline hover:text-moyo-700 dark:hover:text-moyo-400"
+                  >
+                    {r.text}
+                  </a>
+                {:else}
+                  {r.text}
+                {/if}
+              </li>
+            {/each}
+          </ul>
+        </div>
+      </div>
+    {/each}
+  </div>
+
+  <p class="mt-4 text-xs text-stone-500 dark:text-stone-400">
+    <span class="font-medium">Source code:</span>
+    <a
+      href="https://github.com/spglib/moyo"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="underline hover:text-moyo-700 dark:hover:text-moyo-400">github.com/spglib/moyo</a
+    >
+    &middot; <span class="font-medium">License:</span>
+    <a
+      href="https://github.com/spglib/moyo/blob/main/LICENSE-MIT"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="underline hover:text-moyo-700 dark:hover:text-moyo-400">MIT</a
+    >
+    or
+    <a
+      href="https://github.com/spglib/moyo/blob/main/LICENSE-APACHE"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="underline hover:text-moyo-700 dark:hover:text-moyo-400">Apache-2.0</a
+    >
+  </p>
 </section>


### PR DESCRIPTION
## Summary

- Add a compact **Data sources** footnote block at the bottom of the Home page, attributing the crystallographic databases the viewer surfaces.
- Per-family inline citations (space groups, layer groups, magnetic SGs) in a small definition list, styled as a footnote so it's not confused with the clickable group-family cards above.
- One-line tail with repository link plus pointers to the existing `LICENSE-MIT` / `LICENSE-APACHE` files (not duplicated into the web app).

## Sources listed

| Family | References |
| --- | --- |
| Space groups | Seto's Hall-symbol database; *International Tables for Crystallography, Vol. A* (2016) |
| Layer groups | *International Tables for Crystallography, Vol. E* (2010); Fu *et al.*, *2D Mater.* **11**, 035009 (2024) |
| Magnetic space groups | González-Platas, Katcho & Rodríguez-Carvajal, *J. Appl. Cryst.* (2021) — magnetic Hall symbols; Litvin, *Magnetic Group Tables* (IUCr, 2013) — UNI/BNS/OG numbering |

Only sources backing data actually rendered in the viewer are listed (e.g. Wyckoff positions are not displayed and so omitted).

## Test plan

- [x] `just web-check` (svelte-check): 0 errors, 0 warnings
- [x] `just web-build`: production bundle builds clean
- [ ] Local smoke test `just web-preview`: verify the footnote-style section renders at the bottom of `/` in both light and dark mode, doesn't read as another clickable card, and external links open in new tabs (`target="_blank" rel="noopener noreferrer"`)

[Claude Code] Generated with [Claude Code](https://claude.com/claude-code)
