### PR TITLE
fix(moyo): iterative tolerance retry for layer-group symmetry search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Unlisted patch versions (e.g. v0.7.1, v0.7.3, v0.7.6, v0.7.7) contain only depen
 ### moyo
 
 - Expose `operations_from_number`, `operations_from_layer_number`, and `magnetic_operations_from_uni_number` from `moyo::data` so all bindings can reuse them
+- Wrap layer-group symmetry search in an iterative tolerance-retry loop (`iterative_layer_symmetry_search`), recovering from `TooLargeToleranceError` raised inside `LayerPrimitiveCell::new` / `LayerPrimitiveSymmetrySearch::new` instead of propagating immediately (#337)
 
 ### moyo-wasm
 

--- a/moyo/src/lib.rs
+++ b/moyo/src/lib.rs
@@ -105,7 +105,7 @@ use crate::data::{
 };
 use crate::identify::{LayerGroup, MagneticSpaceGroup, Normalizer, SpaceGroup};
 use crate::search::{
-    LayerPrimitiveCell, LayerPrimitiveSymmetrySearch, iterative_magnetic_symmetry_search,
+    LayerPrimitiveCell, iterative_layer_symmetry_search, iterative_magnetic_symmetry_search,
     iterative_symmetry_search, magnetic_operations_in_magnetic_cell, operations_in_cell,
 };
 use crate::symmetrize::{
@@ -449,10 +449,8 @@ impl MoyoLayerDataset {
         setting: LayerSetting,
         rotate_basis: bool,
     ) -> Result<Self, MoyoError> {
-        let layer_cell = LayerCell::new(cell.clone(), symprec, angle_tolerance)?;
-        let prim_layer = LayerPrimitiveCell::new(&layer_cell, symprec)?;
-        let symmetry_search =
-            LayerPrimitiveSymmetrySearch::new(&prim_layer.layer_cell, symprec, angle_tolerance)?;
+        let (prim_layer, symmetry_search, symprec, angle_tolerance) =
+            iterative_layer_symmetry_search(cell, symprec, angle_tolerance)?;
 
         let prim_volume = prim_layer.layer_cell.lattice().basis().determinant().abs();
         let epsilon = symprec / prim_volume.powf(1.0 / 3.0);

--- a/moyo/src/search.rs
+++ b/moyo/src/search.rs
@@ -15,4 +15,6 @@ pub(crate) use primitive_symmetry_search::search_bravais_group;
 pub(super) use primitive_symmetry_search::{
     PrimitiveMagneticSymmetrySearch, magnetic_operations_in_magnetic_cell, operations_in_cell,
 };
-pub(super) use symmetry_search::{iterative_magnetic_symmetry_search, iterative_symmetry_search};
+pub(super) use symmetry_search::{
+    iterative_layer_symmetry_search, iterative_magnetic_symmetry_search, iterative_symmetry_search,
+};

--- a/moyo/src/search/symmetry_search.rs
+++ b/moyo/src/search/symmetry_search.rs
@@ -179,3 +179,65 @@ pub fn iterative_magnetic_symmetry_search<M: MagneticMoment>(
     debug!("Reach the maximum number of symmetry search trials");
     Err(MoyoError::PrimitiveMagneticSymmetrySearchError)
 }
+
+#[cfg(test)]
+mod tests {
+    use nalgebra::{Vector3, matrix};
+
+    use super::iterative_layer_symmetry_search;
+    use crate::base::{AngleTolerance, Cell, Lattice, LayerCell, MoyoError};
+    use crate::search::layer::LayerPrimitiveCell;
+
+    fn unit_square_p1_cell() -> Cell {
+        // p1 square layer, unit in-plane basis. `LayerPrimitiveCell::new`
+        // raises `TooLargeToleranceError` whenever `2 * symprec > 0.5`.
+        Cell::new(
+            Lattice::new(matrix![
+                1.0, 0.0, 0.0;
+                0.0, 1.0, 0.0;
+                0.0, 0.0, 5.0;
+            ]),
+            vec![Vector3::new(0.3, 0.4, 0.2)],
+            vec![1],
+        )
+    }
+
+    #[test]
+    fn test_iterative_layer_symmetry_search_passthrough_when_symprec_is_already_safe() {
+        // With a tight symprec the inner search succeeds on the first try, so
+        // the returned tolerances must equal the inputs.
+        let cell = unit_square_p1_cell();
+        let symprec = 1e-4;
+        let angle = AngleTolerance::Default;
+
+        let (_prim, _search, out_symprec, out_angle) =
+            iterative_layer_symmetry_search(&cell, symprec, angle).unwrap();
+        assert_eq!(out_symprec, symprec);
+        match (out_angle, angle) {
+            (AngleTolerance::Default, AngleTolerance::Default) => {}
+            other => panic!("angle tolerance changed unexpectedly: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_iterative_layer_symmetry_search_retries_after_too_large_tolerance() {
+        // For this cell, `LayerPrimitiveCell::new` errors directly at symprec
+        // = 0.3 (since 2 * 0.3 > 0.5). Confirm that error in the direct call
+        // first, then confirm the iterative wrapper recovers by reducing
+        // symprec and returning a tightened value.
+        let cell = unit_square_p1_cell();
+        let layer = LayerCell::new(cell.clone(), 0.3, AngleTolerance::Default).unwrap();
+        assert!(matches!(
+            LayerPrimitiveCell::new(&layer, 0.3),
+            Err(MoyoError::TooLargeToleranceError),
+        ));
+
+        let (_prim, _search, out_symprec, _out_angle) =
+            iterative_layer_symmetry_search(&cell, 0.3, AngleTolerance::Default).unwrap();
+        assert!(
+            out_symprec < 0.3,
+            "expected the retry to tighten symprec below the input; got {}",
+            out_symprec,
+        );
+    }
+}

--- a/moyo/src/search/symmetry_search.rs
+++ b/moyo/src/search/symmetry_search.rs
@@ -1,8 +1,9 @@
+use super::layer::{LayerPrimitiveCell, LayerPrimitiveSymmetrySearch};
 use super::primitive_cell::{PrimitiveCell, PrimitiveMagneticCell};
 use super::primitive_symmetry_search::{PrimitiveMagneticSymmetrySearch, PrimitiveSymmetrySearch};
 use crate::base::{
-    AngleTolerance, Cell, MagneticCell, MagneticMoment, MagneticSymmetryTolerances, MoyoError,
-    RotationMagneticMomentAction, SymmetryTolerances, ToleranceHandler,
+    AngleTolerance, Cell, LayerCell, MagneticCell, MagneticMoment, MagneticSymmetryTolerances,
+    MoyoError, RotationMagneticMomentAction, SymmetryTolerances, ToleranceHandler,
 };
 
 use log::debug;
@@ -47,6 +48,68 @@ pub fn iterative_symmetry_search(
         }
 
         // When the maximum number of symmetry search trials is reached, restart ToleranceHandler to try larger strides
+        tolerances = tolerance_handler.tolerances.clone();
+        debug!("Restart ToleranceHandler with {:?}", tolerances);
+    }
+    debug!("Reach the maximum number of symmetry search trials");
+    Err(MoyoError::PrimitiveSymmetrySearchError)
+}
+
+/// Layer-group counterpart of [`iterative_symmetry_search`].
+///
+/// `LayerCell::new` validates the structural layer-cell contract (`c`
+/// perpendicular to `a, b`); the errors it raises (e.g.
+/// [`MoyoError::AperiodicAxisNotOrthogonal`]) describe the input geometry, not
+/// the tolerance, so it sits outside the retry loop. Only
+/// [`LayerPrimitiveCell::new`] and [`LayerPrimitiveSymmetrySearch::new`] are
+/// retried under tightening tolerances, matching the bulk path's choice to
+/// wrap only the tolerance-sensitive symmetry-search stages.
+pub fn iterative_layer_symmetry_search(
+    cell: &Cell,
+    symprec: f64,
+    angle_tolerance: AngleTolerance,
+) -> Result<
+    (
+        LayerPrimitiveCell,
+        LayerPrimitiveSymmetrySearch,
+        f64,
+        AngleTolerance,
+    ),
+    MoyoError,
+> {
+    let layer_cell = LayerCell::new(cell.clone(), symprec, angle_tolerance)?;
+
+    let mut tolerances = SymmetryTolerances {
+        symprec,
+        angle_tolerance,
+    };
+
+    for _ in 0..MAX_TOLERANCE_HANDLER_TRIALS {
+        let mut tolerance_handler = ToleranceHandler::new(tolerances);
+
+        for _ in 0..MAX_SYMMETRY_SEARCH_TRIALS {
+            match LayerPrimitiveCell::new(&layer_cell, tolerance_handler.tolerances.symprec) {
+                Ok(prim_layer) => {
+                    match LayerPrimitiveSymmetrySearch::new(
+                        &prim_layer.layer_cell,
+                        tolerance_handler.tolerances.symprec,
+                        tolerance_handler.tolerances.angle_tolerance,
+                    ) {
+                        Ok(symmetry_search) => {
+                            return Ok((
+                                prim_layer,
+                                symmetry_search,
+                                tolerance_handler.tolerances.symprec,
+                                tolerance_handler.tolerances.angle_tolerance,
+                            ));
+                        }
+                        Err(err) => tolerance_handler.update(err),
+                    }
+                }
+                Err(err) => tolerance_handler.update(err),
+            }
+        }
+
         tolerances = tolerance_handler.tolerances.clone();
         debug!("Restart ToleranceHandler with {:?}", tolerances);
     }


### PR DESCRIPTION
## Summary

- Adds `iterative_layer_symmetry_search`, mirroring `iterative_symmetry_search` (4 outer x 16 inner ToleranceHandler trials), and wires it into `MoyoLayerDataset::new`.
- Closes a long-standing gap: the layer path called `LayerPrimitiveCell::new` and `LayerPrimitiveSymmetrySearch::new` directly, so any `TooLargeToleranceError` (or sibling) propagated straight to the caller, even though the bulk path has wrapped the analogous calls in a retry for years.
- `LayerCell::new` deliberately stays outside the loop because its failures (`AperiodicAxisNotOrthogonal`, `InPlaneAxesNotInXY`, `DegenerateLattice`) describe input geometry, not tolerance.

## Impact on the C2DB 2D materials database (16,905 structures)

The C2DB maintainer ran moyopy 0.8.0 across 201 symprecs from 1e-1 to 1e-9 and reported 42,880 errors -- 94% "Too large tolerance" (40,187), 6% Wyckoff (2,671), 26 "Too small tolerance".

Re-running on the first 500 materials (100,500 calls) with this fix:

| metric                        | pre-fix | post-fix |
| ----------------------------- | ------: | -------: |
| total errors                  |   1,415 |       89 |
| `Too large tolerance`         |   1,326 |        0 |
| `Wyckoff position assignment` |      89 |       89 |
| materials with >=1 err        |     337 |        3 |
| regressions                   |       - |        0 |

Extrapolated to the full database: ~94% reduction in moyopy errors. The residual 2,671 Wyckoff failures are raised downstream of this retry (inside `StandardizedLayerCell::new`) and will be addressed in a follow-up.

## Test plan

- [x] `cargo test -p moyo --lib` -- 154/154 passing
- [x] `pytest moyopy/python/tests` -- 50/50 passing
- [x] `just prek` -- all standard pre-commit hooks pass
- [x] Hand-picked reproducers from the C2DB error log -- 5/5 "Too large tolerance" cases that previously errored now succeed; 2/2 Wyckoff cases still fail (expected -- follow-up)
- [x] 500-material x 201-symprec sweep -- 0 regressions, 334 materials fully fixed
- [ ] Reviewer to validate on their preferred test corpus

[Claude Code] Generated with [Claude Code](https://claude.com/claude-code)
