### PR TITLE
fix(moyo): correct oblique layer-cell standardization for glide groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Unlisted patch versions (e.g. v0.7.1, v0.7.3, v0.7.6, v0.7.7) contain only depen
 
 - Expose `operations_from_number`, `operations_from_layer_number`, and `magnetic_operations_from_uni_number` from `moyo::data` so all bindings can reuse them
 - Wrap layer-group symmetry search in an iterative tolerance-retry loop (`iterative_layer_symmetry_search`), recovering from `TooLargeToleranceError` raised inside `LayerPrimitiveCell::new` / `LayerPrimitiveSymmetrySearch::new` instead of propagating immediately (#337)
+- Fix `WyckoffPositionAssignmentError` for oblique layer groups (LG 5, 7) in near-square cells: the in-plane Minkowski reduction during standardization could rotate a glide off the canonical direction. The reduction is now applied only when it normalizes the canonical operation set, and its origin shift is composed correctly
 
 ### moyo-wasm
 

--- a/moyo/src/symmetrize/layer_standardize.rs
+++ b/moyo/src/symmetrize/layer_standardize.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use nalgebra::Matrix3;
 use nalgebra::linalg::QR;
 
@@ -139,9 +141,11 @@ impl StandardizedLayerCell {
             .ok_or(MoyoError::StandardizationError)?
             .layer_lattice_system();
         let prim_transformation = match lattice_system {
-            LayerLatticeSystem::Oblique => {
-                standardize_oblique_layer_cell(prim_layer_cell, &layer_group.transformation)
-            }
+            LayerLatticeSystem::Oblique => standardize_oblique_layer_cell(
+                prim_layer_cell,
+                &layer_group.transformation,
+                &prim_std_operations,
+            ),
             _ => layer_group.transformation.clone(),
         };
 
@@ -259,9 +263,23 @@ impl StandardizedLayerCell {
 /// failure (degenerate basis) is mapped to identity rather than an error so
 /// standardization remains total over the inputs the LG identification
 /// already accepted.
+///
+/// The in-plane reduction `(lifted, 0)` is composed *after* the LG
+/// transformation `(L, s)`, giving `(lifted * L, lifted * s)` (the origin shift
+/// must be carried through `lifted`, not left bare). But the reduction is only
+/// applied when `lifted` *normalizes* the canonical operation set
+/// `canonical_prim_ops`: for non-symmorphic oblique groups (LG 5, 7) the glide
+/// has an intrinsic in-plane translation that a generic basis change rotates
+/// off the canonical direction. Since the downstream symmetrization uses the
+/// fixed canonical Hall operations, a reduction that moves the glide would make
+/// the transformed positions inconsistent with those operations (a half-cell
+/// displacement) and break Wyckoff assignment. When `lifted` does not normalize
+/// the group, fall back to the bare LG transformation, which is already
+/// canonical-consistent (just possibly not Minkowski-reduced).
 fn standardize_oblique_layer_cell(
     prim_layer_cell: &LayerCell,
     transformation_to_prim_std: &UnimodularTransformation,
+    canonical_prim_ops: &Operations,
 ) -> UnimodularTransformation {
     let lattice_after =
         transformation_to_prim_std.transform_lattice(&prim_layer_cell.lattice().as_lattice());
@@ -269,10 +287,40 @@ fn standardize_oblique_layer_cell(
         Ok(t) => t,
         Err(_) => return transformation_to_prim_std.clone(),
     };
+    let lifted_only = UnimodularTransformation::from_linear(lifted);
+    if !normalizes_operations(&lifted_only, canonical_prim_ops) {
+        return transformation_to_prim_std.clone();
+    }
     UnimodularTransformation::new(
         lifted * transformation_to_prim_std.linear,
-        transformation_to_prim_std.origin_shift,
+        lifted.map(|e| e as f64) * transformation_to_prim_std.origin_shift,
     )
+}
+
+/// Whether the basis change `t` maps the operation set onto itself (same
+/// rotations, same translations modulo unit-cell vectors). The canonical
+/// operations carry exact rational translations, so the comparison uses a
+/// tight tolerance.
+fn normalizes_operations(t: &UnimodularTransformation, operations: &Operations) -> bool {
+    let transformed = t.transform_operations(operations);
+    if transformed.len() != operations.len() {
+        return false;
+    }
+    let mut translation_by_rotation = HashMap::new();
+    for op in operations.iter() {
+        translation_by_rotation.insert(op.rotation, op.translation);
+    }
+    for op in transformed.iter() {
+        let Some(target) = translation_by_rotation.get(&op.rotation) else {
+            return false;
+        };
+        let mut diff = target - op.translation;
+        diff -= diff.map(|e| e.round());
+        if diff.iter().any(|e| e.abs() > 1e-6) {
+            return false;
+        }
+    }
+    true
 }
 
 /// Symmetrize the in-plane block of a layer lattice with `c` along z.

--- a/moyo/tests/test_layer_dataset.rs
+++ b/moyo/tests/test_layer_dataset.rs
@@ -271,6 +271,51 @@ fn test_layer_dataset_sip_jvasp_27741() {
     assert_eq!(dataset.num_operations(), 8);
 }
 
+/// Repro for the moyopy "Wyckoff position assignment failed" crash on a
+/// centrosymmetric LG 7 (p2/a, oblique C2h) layer in a *near-square* cell
+/// whose glide is along the in-plane diagonal (CsBr monolayer, C2DB
+/// `2BrCs-1`, symmetrized to machine precision). Cs and Br each sit on a
+/// 2-fold axis (multiplicity-2 Wyckoff site).
+///
+/// The bug: for oblique layer groups the standardizer 2D-Minkowski-reduces
+/// the in-plane basis after the LG transformation. On a near-square cell the
+/// reduction can pick a basis that rotates the intrinsic glide off the
+/// canonical direction, leaving the transformed positions inconsistent with
+/// the fixed canonical Hall operations (a half-cell displacement) so no
+/// Wyckoff position matched. The fix only applies the reduction when it
+/// normalizes the canonical operation set, else falls back to the bare LG
+/// transformation. Pre-fix this errored at symprec <= 1e-3; it must now
+/// identify LG 7 and assign every atom a Wyckoff position.
+#[test]
+fn test_layer_dataset_lg7_diagonal_glide_near_square() {
+    let cell = Cell::new(
+        Lattice::new(matrix![
+            5.13647,  0.0,     0.0;
+            -0.00071, 5.13762, 0.0;
+            0.0,      0.0,     15.65196;
+        ]),
+        vec![
+            Vector3::new(0.56917124, 0.47581949, 0.61666151),
+            Vector3::new(0.06917124, 0.97581949, 0.38333849),
+            Vector3::new(0.06917124, 0.97581949, 0.61614090),
+            Vector3::new(0.56917124, 0.47581949, 0.38385910),
+        ],
+        vec![55, 55, 35, 35],
+    );
+
+    // symprec = 1e-3 is where this previously raised
+    // `WyckoffPositionAssignmentError`.
+    let dataset = MoyoLayerDataset::with_default(&cell, 1e-3).unwrap();
+    assert_eq!(dataset.number, 7);
+    // Two species, each a multiplicity-2 orbit on a 2-fold axis.
+    assert_eq!(dataset.orbits, vec![0, 0, 2, 2]);
+    // Every atom received a Wyckoff letter (the regression: assignment must
+    // not fail); the two Cs share a letter and the two Br share a letter.
+    assert_eq!(dataset.wyckoffs.len(), 4);
+    assert_eq!(dataset.wyckoffs[0], dataset.wyckoffs[1]);
+    assert_eq!(dataset.wyckoffs[2], dataset.wyckoffs[3]);
+}
+
 /// Tilted-c input must be rejected by the layer-cell constructor.
 #[test]
 fn test_layer_dataset_rejects_tilted_c() {


### PR DESCRIPTION
## Summary

Fixes `WyckoffPositionAssignmentError` (`MoyoLayerDataset`) for oblique layer groups with glides (LG 5, 7) in near-square cells. This is the residual error cluster left after #337 (it was **symprec-independent**, not a tolerance issue).

**Root cause:** `StandardizedLayerCell` 2D-Minkowski-reduces the in-plane basis after the LG transformation for oblique groups (LG 1-7). For the non-symmorphic oblique groups (LG 5, 7) the glide carries an intrinsic in-plane translation. On a near-square cell the reduction could pick a basis that rotates that glide off the canonical direction. Since the downstream `symmetrize_positions` uses the fixed canonical Hall operations, the transformed positions then sat exactly half a cell off the glide axis, no Wyckoff position matched, and assignment failed.

**Fix** (`standardize_oblique_layer_cell`):
- Apply the in-plane reduction only when it **normalizes** the canonical operation set (same rotations, same translations mod 1); otherwise fall back to the bare LG transformation (already canonical-consistent). A glide-rotating reduction is rejected.
- Compose the reduction's origin shift correctly: `(lifted, 0) * (L, s) = (lifted*L, lifted*s)`, not `(lifted*L, s)` (a latent bug — the bare `s` left the linear part and origin shift in different bases).

## Validation on the C2DB 2D database

- All **83** materials that previously raised this error now succeed across the full symprec grid (1e-1..1e-9): 16,683 calls, **0 errors**.
- First 3000 materials (603,000 calls): **0 errors**, **0 layer-number regressions** vs the pre-fix baseline, **7,215** calls newly fixed (the #337 + this fix combined). The single layer-number difference observed (2FLiS-3 at symprec ~5e-9) is a noise-floor crossover, not a regression.

## Test plan

- [x] New regression test `test_layer_dataset_lg7_diagonal_glide_near_square` (the CsBr `2BrCs-1` repro, symmetrized to machine precision)
- [x] `cargo test -p moyo` — 156 lib + 10 layer-dataset + 3 layer-symmetry + 22 dataset + 4 magnetic + doctests, all passing
- [x] `pytest moyopy/python/tests` — 50/50 passing
- [x] `just prek` — all standard hooks pass
- [ ] Reviewer to validate on their preferred corpus

[Claude Code] Generated with [Claude Code](https://claude.com/claude-code)
