### PR TITLE
Release v0.10.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -374,6 +374,7 @@ moyoc.h
 
 docs/note/
 bench/mp/*.json
+bench/2d/c2db/
 
 # python-interface docs
 _build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Unlisted patch versions (e.g. v0.7.1, v0.7.3, v0.7.6, v0.7.7) contain only depen
 
 ### moyo
 
+- Add Euclidean normalizer of space groups: `Normalizer` type and `MoyoDataset::euclidean_normalizer` (#326)
 - Expose `operations_from_number`, `operations_from_layer_number`, and `magnetic_operations_from_uni_number` from `moyo::data` so all bindings can reuse them
 - Wrap layer-group symmetry search in an iterative tolerance-retry loop (`iterative_layer_symmetry_search`), recovering from `TooLargeToleranceError` raised inside `LayerPrimitiveCell::new` / `LayerPrimitiveSymmetrySearch::new` instead of propagating immediately (#337)
 - Fix `WyckoffPositionAssignmentError` for oblique layer groups (LG 5, 7) in near-square cells: the in-plane Minkowski reduction during standardization could rotate a glide off the canonical direction. The reduction is now applied only when it normalizes the canonical operation set, and its origin shift is composed correctly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 Unlisted patch versions (e.g. v0.7.1, v0.7.3, v0.7.6, v0.7.7) contain only dependency or build updates with no user-visible changes.
 
-## Unreleased
+## v0.10.0 - 2026-05-24
 
 ### moyo
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -788,7 +788,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "moyo"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "approx",
  "criterion",
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "moyo-wasm"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "moyo",
  "serde",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "moyoc"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "approx",
  "log",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "moyopy"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "approx",
  "itertools 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "2"
 authors = ["Kohei Shinohara <kshinohara0508@gmail.com>"]
 description = "Library for Crystal Symmetry in Rust"
 edition = "2024"
-version = "0.9.0"
+version = "0.10.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/spglib/moyo"
 

--- a/bench/.gitignore
+++ b/bench/.gitignore
@@ -1,1 +1,2 @@
 *.json
+*.jsonl

--- a/moyoc/Cargo.toml
+++ b/moyoc/Cargo.toml
@@ -16,7 +16,7 @@ name = "moyoc"
 crate-type = ["cdylib"]
 
 [dependencies]
-moyo = { path = "../moyo", version = "0.9.0" }
+moyo = { path = "../moyo", version = "0.10.0" }
 nalgebra.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/moyopy/Cargo.toml
+++ b/moyopy/Cargo.toml
@@ -17,7 +17,7 @@ name = "moyopy"
 crate-type = ["cdylib"]
 
 [dependencies]
-moyo = { path = "../moyo", version = "0.9.0" }
+moyo = { path = "../moyo", version = "0.10.0" }
 nalgebra.workspace = true
 serde.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION
## Summary
- Bump workspace version `0.9.0` -> `0.10.0` across `Cargo.toml`, `Cargo.lock`, `moyoc`, and `moyopy`
- Promote the `Unreleased` CHANGELOG section to `v0.10.0 - 2026-05-24`
- Ignore `bench/2d/c2db/` and `*.jsonl` benchmark artifacts

### Release highlights (v0.10.0)
**moyo**
- Expose `operations_from_number`, `operations_from_layer_number`, and `magnetic_operations_from_uni_number` from `moyo::data` for reuse across bindings
- Wrap layer-group symmetry search in an iterative tolerance-retry loop (`iterative_layer_symmetry_search`) to recover from `TooLargeToleranceError` (#337)
- Fix `WyckoffPositionAssignmentError` for oblique layer groups (LG 5, 7) in near-square cells

**moyo-wasm**
- Add data-access wrappers for space groups, layer groups, and magnetic space groups

## Test plan
- [ ] `just test` (Rust)
- [ ] `just py-build` then `just py-test` (Python bindings)
- [ ] `just c-build` then `just c-test` (C bindings)
- [ ] CI green on the release branch

[Claude Code] Generated with [Claude Code](https://claude.com/claude-code)
