### PR TITLE
fix(ci): unify GitHub Pages deploy to avoid root 404

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -71,7 +71,7 @@ jobs:
         run: cp apps/web/dist/index.html apps/web/dist/404.html
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -9,6 +9,14 @@ on:
       - 'moyopy/**'
       - 'apps/web/**'
       - '.github/workflows/deploy-web.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'moyo/**'
+      - 'moyo-wasm/**'
+      - 'moyopy/**'
+      - 'apps/web/**'
+      - '.github/workflows/deploy-web.yml'
   workflow_dispatch:
 
 permissions:
@@ -17,8 +25,8 @@ permissions:
   id-token: write
 
 concurrency:
-  group: pages
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
@@ -86,14 +94,17 @@ jobs:
         run: sphinx-build moyopy/docs apps/web/dist/python
 
       - name: Configure Pages
+        if: github.event_name != 'pull_request'
         uses: actions/configure-pages@v5
 
       - name: Upload Pages artifact
+        if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v3
         with:
           path: apps/web/dist
 
   deploy:
+    if: github.event_name != 'pull_request'
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'moyo/**'
       - 'moyo-wasm/**'
+      - 'moyopy/**'
       - 'apps/web/**'
       - '.github/workflows/deploy-web.yml'
   workflow_dispatch:
@@ -60,6 +61,29 @@ jobs:
 
       - name: Copy index.html to 404.html for SPA fallback
         run: cp apps/web/dist/index.html apps/web/dist/404.html
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Build moyopy wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          args: --release --out dist --manifest-path moyopy/Cargo.toml
+          sccache: 'true'
+
+      - name: Install moyopy and docs dependencies
+        run: |
+          set -e
+          uv pip install --system --find-links dist moyopy
+          uv pip install --system moyopy[docs]
+
+      - name: Build docs into web app under /python
+        run: sphinx-build moyopy/docs apps/web/dist/python
 
       - name: Configure Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/rw-python-tests.yaml
+++ b/.github/workflows/rw-python-tests.yaml
@@ -68,12 +68,11 @@ jobs:
           uv pip install --system moyopy[testing,interface]
           pytest -v
 
-  # TODO:
+  # Build the Sphinx docs as a CI check. Publishing happens in
+  # deploy-web.yml, which bundles the docs under /python alongside the web
+  # app and ships them through the single GitHub Actions Pages deployment.
   docs:
     runs-on: ubuntu-latest
-    if: "!startsWith(github.ref, 'refs/tags/')"
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -97,10 +96,3 @@ jobs:
       - name: Build
         run: |
           sphinx-build moyopy/docs docs_build
-      - name: Deploy
-        if: ${{ github.event_name == 'push' }}
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs_build
-          destination_dir: python

--- a/.github/workflows/rw-python-tests.yaml
+++ b/.github/workflows/rw-python-tests.yaml
@@ -67,32 +67,3 @@ jobs:
           uv pip install --system --find-links dist moyopy
           uv pip install --system moyopy[testing,interface]
           pytest -v
-
-  # Build the Sphinx docs as a CI check. Publishing happens in
-  # deploy-web.yml, which bundles the docs under /python alongside the web
-  # app and ships them through the single GitHub Actions Pages deployment.
-  docs:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 0
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-      - name: Build wheels
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
-        with:
-          args: --release --out dist --manifest-path moyopy/Cargo.toml
-          sccache: 'true'
-      - name: Install
-        run: |
-          set -e
-          uv pip install --system --find-links dist moyopy
-          uv pip install --system moyopy[testing,docs]
-      - name: Build
-        run: |
-          sphinx-build moyopy/docs docs_build

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -34,7 +34,7 @@ jobs:
     uses: ./.github/workflows/rw-python-tests.yaml
     permissions:
       id-token: write
-      contents: write
+      contents: read
 
   c:
     needs: path-filter


### PR DESCRIPTION
## Summary

The site root (https://spglib.github.io/moyo/) was returning 404 because two deployers were fighting over GitHub Pages' single "source" setting:

- `deploy-web.yml` published the web SPA at the root via the **GitHub Actions** Pages source.
- The `docs` job in `rw-python-tests.yaml` pushed Sphinx docs to the **`gh-pages` branch** under `/python` via `peaceiris/actions-gh-pages`.

These require mutually exclusive Pages source settings and clobbered each other. When the source landed on the `gh-pages` branch (whose root has no `index.html`), the root 404'd.

This PR consolidates everything into the single GitHub Actions Pages deployment:

- **`deploy-web.yml`**: builds the moyopy wheel + Sphinx docs and writes them into `apps/web/dist/python/`, shipping the web app (root) and docs (`/python`) in one artifact. Added `moyopy/**` to the path triggers so doc edits redeploy.
- **`deploy-web.yml` build/deploy split**: added a `pull_request` trigger so the full build (wasm + web app + docs) runs on PRs as a validation check. The `Configure Pages` / `Upload Pages artifact` steps and the `deploy` job are gated to non-`pull_request` events, so PRs build but never publish. Concurrency is now per-ref and cancels redundant PR runs while never interrupting `main` deploys.
- **`rw-python-tests.yaml`**: removed the `docs` job entirely (the `peaceiris` gh-pages push and the standalone docs build). Docs build + publish is now handled solely by `deploy-web.yml`; PR-time docs build coverage is preserved by the new `pull_request` trigger there.
- **`tests.yaml`**: downgraded the python job's `contents: write` -> `read` (only needed for the removed push).

The repo's Pages source has already been switched to "GitHub Actions" (`build_type: workflow`).

## Test plan

- [ ] A PR touching `moyopy/**` / `apps/web/**` runs the `deploy-web` build job and does **not** publish/deploy.
- [ ] Merge to `main` triggers `deploy-web.yml`; the deploy job succeeds.
- [ ] https://spglib.github.io/moyo/ serves the web app (no 404).
- [ ] https://spglib.github.io/moyo/python/ serves the Sphinx docs.
- [ ] Deep doc links (e.g. `/python/standardization.html`) resolve.

[Claude Code] Generated with [Claude Code](https://claude.com/claude-code)
