### PR TITLE
feat: show per-setting Wyckoff positions and operations on layer-group page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,14 @@ Unlisted patch versions (e.g. v0.7.1, v0.7.3, v0.7.6, v0.7.7) contain only depen
 ### moyo
 
 - Add `iter_wyckoff_positions_from_hall_number` and make `WyckoffPosition` public in `moyo::data` to allow looking up all Wyckoff positions of a space group by Hall number without analyzing a structure
+- Add `iter_layer_wyckoff_positions_from_hall_number` and make `LayerWyckoffPosition` public in `moyo::data` to allow looking up all Wyckoff positions of a layer group by Hall number without analyzing a structure
 
 ### moyo-wasm
 
 - Add `wyckoff_positions` data-access wrapper (and `MoyoWyckoffPosition` type) returning the Wyckoff positions of a space group for the given Hall number
 - Add `hall_symbol_entries_from_number` data-access wrapper returning every Hall-symbol entry (setting) of an ITA space-group number
+- Add `layer_wyckoff_positions` data-access wrapper (and `MoyoLayerWyckoffPosition` type) returning the Wyckoff positions of a layer group for the given Hall number
+- Add `layer_hall_symbol_entries_from_number` data-access wrapper returning every Hall-symbol entry (setting) of a layer-group number
 
 ## v0.10.0 - 2026-05-24
 

--- a/apps/web/src/components/WyckoffTable.svelte
+++ b/apps/web/src/components/WyckoffTable.svelte
@@ -1,8 +1,15 @@
 <script lang="ts">
-  import type { MoyoWyckoffPosition } from '@spglib/moyo-wasm'
   import HmSymbol from './HmSymbol.svelte'
 
-  let { positions }: { positions: MoyoWyckoffPosition[] } = $props()
+  // Structural type covering both space- and layer-group Wyckoff DTOs.
+  interface WyckoffRow {
+    multiplicity: number
+    letter: string
+    site_symmetry: string
+    coordinates: string
+  }
+
+  let { positions }: { positions: WyckoffRow[] } = $props()
 </script>
 
 <div class="table-shell">

--- a/apps/web/src/routes/LayerGroup.svelte
+++ b/apps/web/src/routes/LayerGroup.svelte
@@ -4,20 +4,30 @@
     MoyoLayerGroupType,
     MoyoLayerHallSymbolEntry,
     MoyoLayerArithmeticCrystalClass,
+    MoyoLayerWyckoffPosition,
   } from '@spglib/moyo-wasm'
   import { getMoyo, formatErr } from '../lib/wasm'
   import { LAYER_GROUP_COUNT, clampInt } from '../lib/catalog'
+  import { settingDescription } from '../lib/format'
   import InfoGrid from '../components/InfoGrid.svelte'
   import OperationsTable from '../components/OperationsTable.svelte'
+  import WyckoffTable from '../components/WyckoffTable.svelte'
+  import CollapsibleSection from '../components/CollapsibleSection.svelte'
   import HmSymbol from '../components/HmSymbol.svelte'
   import ErrorCard from '../components/ErrorCard.svelte'
   import LoadingDots from '../components/LoadingDots.svelte'
 
+  interface Setting {
+    hall: MoyoLayerHallSymbolEntry
+    operations: MoyoOperation[]
+    wyckoffs: MoyoLayerWyckoffPosition[]
+  }
+
   interface Loaded {
     type: MoyoLayerGroupType
-    hall: MoyoLayerHallSymbolEntry
     arith: MoyoLayerArithmeticCrystalClass
-    operations: MoyoOperation[]
+    defaultHallNumber: number
+    settings: Setting[]
   }
 
   let { params }: { params: { number: string } } = $props()
@@ -28,10 +38,24 @@
   async function load(n: number): Promise<Loaded> {
     const m = await getMoyo()
     const type = m.layer_group_type(n)
-    const operations = m.operations_from_layer_number(n, { type: 'Standard' }, false)
-    const hall = m.layer_hall_symbol_entry(type.hall_number)
     const arith = m.layer_arithmetic_crystal_class(type.arithmetic_number)
-    return { type, hall, arith, operations }
+    const settings: Setting[] = m.layer_hall_symbol_entries_from_number(n).map((hall) => ({
+      hall,
+      operations: m.operations_from_layer_number(
+        n,
+        { type: 'HallNumber', value: hall.hall_number },
+        false
+      ),
+      wyckoffs: m.layer_wyckoff_positions(hall.hall_number),
+    }))
+    return { type, arith, defaultHallNumber: type.hall_number, settings }
+  }
+
+  function settingTitle(setting: string): string {
+    if (!setting) return settingDescription(setting)
+    const desc = settingDescription(setting)
+    // When the setting code has no human description, show it once rather than `x (x)`.
+    return desc === setting ? setting : `${desc} (${setting})`
   }
 </script>
 
@@ -44,23 +68,18 @@
       <span class="font-mono">#{d.type.number}</span>
       <HmSymbol symbol={d.type.hm_short} />
     </h1>
-    <p class="text-sm text-stone-600 dark:text-stone-400 font-mono">
-      {d.type.hm_full} &middot; Hall: {d.hall.hall_symbol}
-    </p>
+    <p class="text-sm text-stone-600 dark:text-stone-400 font-mono">{d.type.hm_full}</p>
   </header>
 
   <section class="space-y-6">
     <InfoGrid
       rows={[
         { label: 'Layer number', value: d.type.number, mono: true },
-        { label: 'Hall number', value: d.hall.hall_number, mono: true },
         { label: 'Short Hermann-Mauguin symbol', value: d.type.hm_short, mono: true },
         { label: 'Full Hermann-Mauguin symbol', value: d.type.hm_full, mono: true },
-        { label: 'Hall symbol', value: d.hall.hall_symbol, mono: true },
-        { label: 'Setting (Hall row)', value: d.hall.setting, mono: true },
+        { label: 'Crystal system', value: d.type.crystal_system },
         { label: 'Lattice system', value: d.type.lattice_system },
         { label: 'Bravais class', value: d.type.bravais_class, mono: true },
-        { label: 'Centering', value: d.hall.centering, mono: true },
         {
           label: 'Arithmetic crystal class',
           value: `${d.arith.arithmetic_number} (${d.arith.symbol})`,
@@ -70,7 +89,43 @@
       ]}
     />
 
-    <OperationsTable operations={d.operations} />
+    <div>
+      <h2 class="text-lg font-semibold mb-2">
+        Settings <span class="text-sm font-normal text-stone-500">({d.settings.length})</span>
+      </h2>
+      <div class="space-y-3">
+        {#each d.settings as s (s.hall.hall_number)}
+          {@const isStandard = s.hall.hall_number === d.defaultHallNumber}
+          <div
+            class="rounded border p-3 {isStandard
+              ? 'border-emerald-400 dark:border-emerald-600'
+              : 'border-stone-200 dark:border-stone-800'}"
+          >
+            <CollapsibleSection
+              title={settingTitle(s.hall.setting)}
+              badge={isStandard ? 'Standard' : undefined}
+              open={isStandard}
+            >
+              <div class="space-y-4">
+                <InfoGrid
+                  rows={[
+                    { label: 'Hall number', value: s.hall.hall_number, mono: true },
+                    { label: 'Hall symbol', value: s.hall.hall_symbol, mono: true },
+                    { label: 'Centering', value: s.hall.centering, mono: true },
+                  ]}
+                />
+                <CollapsibleSection title="Symmetry operations" count={s.operations.length}>
+                  <OperationsTable operations={s.operations} />
+                </CollapsibleSection>
+                <CollapsibleSection title="Wyckoff positions" count={s.wyckoffs.length}>
+                  <WyckoffTable positions={s.wyckoffs} />
+                </CollapsibleSection>
+              </div>
+            </CollapsibleSection>
+          </div>
+        {/each}
+      </div>
+    </div>
   </section>
 {:catch err}
   <ErrorCard message={`Failed to load layer group ${number}: ${formatErr(err)}`} />

--- a/moyo-wasm/src/layer_group.rs
+++ b/moyo-wasm/src/layer_group.rs
@@ -3,8 +3,9 @@ use tsify::Tsify;
 use wasm_bindgen::prelude::*;
 
 use moyo::data::{
-    CrystalSystem, LayerCentering, LayerSetting, layer_arithmetic_crystal_class_entry,
-    layer_hall_symbol_entry as core_layer_hall_symbol_entry,
+    CrystalSystem, LayerCentering, LayerHallSymbolEntry, LayerSetting,
+    iter_layer_hall_symbol_entry, iter_layer_wyckoff_positions_from_hall_number,
+    layer_arithmetic_crystal_class_entry, layer_hall_symbol_entry as core_layer_hall_symbol_entry,
 };
 
 use crate::common::{MoyoOperation, map_moyo_err};
@@ -57,6 +58,34 @@ pub struct MoyoLayerHallSymbolEntry {
     pub centering: MoyoLayerCentering,
 }
 
+impl From<&LayerHallSymbolEntry> for MoyoLayerHallSymbolEntry {
+    fn from(entry: &LayerHallSymbolEntry) -> Self {
+        Self {
+            hall_number: entry.hall_number,
+            number: entry.number,
+            arithmetic_number: entry.arithmetic_number,
+            setting: entry.setting.to_string(),
+            hall_symbol: entry.hall_symbol.to_string(),
+            hm_short: entry.hm_short.to_string(),
+            hm_full: entry.hm_full.to_string(),
+            centering: entry.centering.into(),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi)]
+pub struct MoyoLayerWyckoffPosition {
+    /// Multiplicity in the conventional layer cell.
+    pub multiplicity: usize,
+    /// Wyckoff letter.
+    pub letter: String,
+    /// Site-symmetry symbol.
+    pub site_symmetry: String,
+    /// Representative coordinate triplet (e.g. `x,y,z`).
+    pub coordinates: String,
+}
+
 #[derive(Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi)]
 pub struct MoyoLayerArithmeticCrystalClass {
@@ -99,16 +128,32 @@ pub fn operations_from_layer_number(
 pub fn layer_hall_symbol_entry(hall_number: i32) -> Result<MoyoLayerHallSymbolEntry, JsValue> {
     let entry = core_layer_hall_symbol_entry(hall_number)
         .ok_or_else(|| JsValue::from_str(&format!("unknown layer hall_number: {}", hall_number)))?;
-    Ok(MoyoLayerHallSymbolEntry {
-        hall_number: entry.hall_number,
-        number: entry.number,
-        arithmetic_number: entry.arithmetic_number,
-        setting: entry.setting.to_string(),
-        hall_symbol: entry.hall_symbol.to_string(),
-        hm_short: entry.hm_short.to_string(),
-        hm_full: entry.hm_full.to_string(),
-        centering: entry.centering.into(),
-    })
+    Ok(entry.into())
+}
+
+/// Return all layer Hall-symbol entries for the given layer-group `number` (1 - 80),
+/// ordered by Hall number. Each entry corresponds to one setting of the layer group.
+#[wasm_bindgen]
+pub fn layer_hall_symbol_entries_from_number(number: i32) -> Vec<MoyoLayerHallSymbolEntry> {
+    iter_layer_hall_symbol_entry()
+        .filter(|entry| entry.number == number)
+        .map(MoyoLayerHallSymbolEntry::from)
+        .collect()
+}
+
+/// Return all Wyckoff positions for the given layer Hall number (1 - 116), ordered
+/// general-position-first then descending multiplicity. Returns an empty array for
+/// unknown Hall numbers.
+#[wasm_bindgen]
+pub fn layer_wyckoff_positions(hall_number: i32) -> Vec<MoyoLayerWyckoffPosition> {
+    iter_layer_wyckoff_positions_from_hall_number(hall_number)
+        .map(|wp| MoyoLayerWyckoffPosition {
+            multiplicity: wp.multiplicity,
+            letter: wp.letter.to_string(),
+            site_symmetry: wp.site_symmetry.to_string(),
+            coordinates: wp.coordinates.to_string(),
+        })
+        .collect()
 }
 
 /// Return the layer arithmetic-crystal-class entry for the given `arithmetic_number` (1 - 43).

--- a/moyo/src/data.rs
+++ b/moyo/src/data.rs
@@ -22,7 +22,8 @@ pub use hall_symbol_database::{HallNumber, HallSymbolEntry, Number, hall_symbol_
 pub use layer::{
     LayerArithmeticCrystalClassEntry, LayerArithmeticNumber, LayerBravaisClass, LayerCentering,
     LayerCrystalSystem, LayerHallNumber, LayerHallSymbolEntry, LayerLatticeSystem, LayerNumber,
-    LayerSetting, iter_layer_arithmetic_crystal_entry, iter_layer_hall_symbol_entry,
+    LayerSetting, LayerWyckoffPosition, iter_layer_arithmetic_crystal_entry,
+    iter_layer_hall_symbol_entry, iter_layer_wyckoff_positions_from_hall_number,
     layer_arithmetic_crystal_class_entry, layer_hall_symbol_entry,
 };
 pub use magnetic::{
@@ -35,9 +36,7 @@ pub use operations::{
 pub use setting::Setting;
 
 pub(super) use arithmetic_crystal_class::iter_arithmetic_crystal_entry;
-pub(super) use layer::{
-    LayerPointGroupRepresentative, LayerWyckoffPosition, iter_layer_wyckoff_positions,
-};
+pub(super) use layer::{LayerPointGroupRepresentative, iter_layer_wyckoff_positions};
 pub(super) use magnetic::uni_number_range;
 pub(super) use point_group::PointGroupRepresentative;
 pub use wyckoff::{WyckoffPosition, iter_wyckoff_positions_from_hall_number};

--- a/moyo/src/data/layer.rs
+++ b/moyo/src/data/layer.rs
@@ -19,4 +19,7 @@ pub use layer_hall_symbol_database::{
 pub use layer_setting::LayerSetting;
 
 pub use layer_point_group::LayerPointGroupRepresentative;
-pub use layer_wyckoff::{LayerWyckoffPosition, iter_layer_wyckoff_positions};
+pub use layer_wyckoff::{
+    LayerWyckoffPosition, iter_layer_wyckoff_positions,
+    iter_layer_wyckoff_positions_from_hall_number,
+};

--- a/moyo/src/data/layer/layer_wyckoff.rs
+++ b/moyo/src/data/layer/layer_wyckoff.rs
@@ -47,6 +47,16 @@ pub fn iter_layer_wyckoff_positions(
         .filter(move |wp| wp.hall_number == hall_number && wp.multiplicity == multiplicity)
 }
 
+/// Return all Wyckoff positions for the given layer Hall number, ordered as stored
+/// in the database (general position first, then descending multiplicity).
+pub fn iter_layer_wyckoff_positions_from_hall_number(
+    hall_number: LayerHallNumber,
+) -> impl Iterator<Item = &'static LayerWyckoffPosition> {
+    LAYER_WYCKOFF_DATABASE
+        .iter()
+        .filter(move |wp| wp.hall_number == hall_number)
+}
+
 static LAYER_WYCKOFF_DATABASE: [LayerWyckoffPosition; 628] = [
     LayerWyckoffPosition::new(1, 1, 'a', "1", "x,y,z"),
     LayerWyckoffPosition::new(2, 2, 'e', "1", "x,y,z"),
@@ -700,6 +710,27 @@ mod tests {
                 entry.hall_number
             );
         }
+    }
+
+    #[test]
+    fn test_iter_layer_wyckoff_positions_from_hall_number() {
+        // Layer Hall 1 (LG 1, p1): a single general position.
+        let lg1: Vec<_> = iter_layer_wyckoff_positions_from_hall_number(1).collect();
+        assert_eq!(lg1.len(), 1);
+        assert_eq!(lg1[0].letter, 'a');
+        assert_eq!(lg1[0].multiplicity, 1);
+        assert_eq!(lg1[0].coordinates, "x,y,z");
+
+        // Layer Hall 8 (p2/m11): general position 'j' first, special 'a' last.
+        let lg8: Vec<_> = iter_layer_wyckoff_positions_from_hall_number(8).collect();
+        assert_eq!(lg8.len(), 10);
+        assert_eq!(lg8.first().unwrap().letter, 'j');
+        assert_eq!(lg8.first().unwrap().multiplicity, 4);
+        assert_eq!(lg8.last().unwrap().letter, 'a');
+        assert_eq!(lg8.last().unwrap().multiplicity, 1);
+
+        // Unknown Hall number yields nothing.
+        assert_eq!(iter_layer_wyckoff_positions_from_hall_number(0).count(), 0);
     }
 
     /// Wyckoff letters within a single Hall number are unique (each letter


### PR DESCRIPTION
## Summary

Applies the per-setting Wyckoff/operations treatment from the space-group page (#343) to the **layer-group** viewer (`/lg/<number>`). The magnetic-space-group viewer is intentionally left unchanged: moyo has no Wyckoff database and no enumerable multi-setting list for magnetic space groups (each UNI number maps to a single magnetic Hall symbol), so there is no equivalent data to surface there.

**Core + WASM data API**
- `moyo::data`: new public `iter_layer_wyckoff_positions_from_hall_number(hall_number)` and a public `LayerWyckoffPosition`, so all Wyckoff positions of a layer group can be looked up by Hall number without analyzing a structure (mirrors the space-group `iter_wyckoff_positions_from_hall_number`).
- `moyo-wasm`: `layer_wyckoff_positions(hall_number)` (+ `MoyoLayerWyckoffPosition`) and `layer_hall_symbol_entries_from_number(number)` to enumerate every Hall setting of a layer-group number. Refactored the layer Hall-entry DTO mapping into a `From<&LayerHallSymbolEntry>` impl.

**Web app (`apps/web`)**
- The layer-group page now renders setting-independent type info once, then one collapsible block per Hall setting, each with that setting's Hall number/symbol/centering plus its symmetry-operations and Wyckoff tables.
- The standard setting is highlighted with an emerald accent border and a "Standard" badge, and its block is open by default; others are collapsed.
- `WyckoffTable` is decoupled from the space-group DTO via a local structural type so it serves both the space- and layer-group pages.
- `settingTitle` collapses a setting code that has no human description (e.g. `b-ac`, used by ~20 orthorhombic layer groups) to the bare code instead of rendering a redundant `b-ac (b-ac)`.

## Test plan
- `cargo test -p moyo` — new `iter_layer_wyckoff_positions_from_hall_number` unit test (LG 1 single `1a`; LG 8 general `j` first / special `a` last; unknown Hall -> empty).
- `just js-build` — regenerates `moyo-wasm/pkg`; `layer_wyckoff_positions`, `layer_hall_symbol_entries_from_number`, and `MoyoLayerWyckoffPosition` appear in the generated `.d.ts`.
- `just web-check` (0 errors) / `just web-test` (24 tests) / `just web-build` — all green.
- `just prek` — all hooks pass.
- Headless check against the built wasm: 116 total Hall settings across LG 1-80, 34 layer groups with multiple settings (e.g. LG 5 -> `c1/c2/c3`, LG 8 -> `a/b`, LG 20 -> `""/b-ac`, LG 52 -> `1/2`).
- Manual: open `/lg/8`, `/lg/20`, `/lg/52`, `/lg/1` and verify per-setting blocks, the standard-setting highlight, and KaTeX site symmetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
