### PR TITLE
Add magnetic dataset C API to moyoc

### DIFF
--- a/moyoc/README.md
+++ b/moyoc/README.md
@@ -49,10 +49,27 @@ non-CMake consumers. Prebuilt archives with this layout are attached to
 See the generated `moyoc.h` for the full API. The main entry points are:
 
 ```c
+// Space-group symmetry analysis
 MoyoDataset *dataset = moyo_dataset_new(
     basis, positions, numbers, num_atoms,
     symprec, angle_tolerance, setting, hall_number, rotate_basis
 );
 // ... read dataset fields ...
 moyo_dataset_free(dataset);
+
+// Magnetic space-group symmetry analysis (collinear moments)
+MoyoCollinearMagneticDataset *mag_dataset = moyo_collinear_magnetic_dataset_new(
+    basis, positions, numbers, magnetic_moments, num_atoms,
+    symprec, angle_tolerance, mag_symprec, is_axial, rotate_basis
+);
+// ... read mag_dataset fields ...
+moyo_collinear_magnetic_dataset_free(mag_dataset);
+
+// Magnetic space-group symmetry analysis (non-collinear moments)
+MoyoNonCollinearMagneticDataset *nc_mag_dataset = moyo_noncollinear_magnetic_dataset_new(
+    basis, positions, numbers, cartesian_magnetic_moments, num_atoms,
+    symprec, angle_tolerance, mag_symprec, is_axial, rotate_basis
+);
+// ... read nc_mag_dataset fields ...
+moyo_noncollinear_magnetic_dataset_free(nc_mag_dataset);
 ```

--- a/moyoc/src/base.rs
+++ b/moyoc/src/base.rs
@@ -1,5 +1,9 @@
 pub(crate) mod cell;
+pub(crate) mod magnetic_cell;
+pub(crate) mod magnetic_operation;
 pub(crate) mod operation;
 
 pub use cell::MoyoCell;
+pub use magnetic_cell::{MoyoCollinearMagneticCell, MoyoNonCollinearMagneticCell};
+pub use magnetic_operation::MoyoMagneticOperations;
 pub use operation::MoyoOperations;

--- a/moyoc/src/base/magnetic_cell.rs
+++ b/moyoc/src/base/magnetic_cell.rs
@@ -1,0 +1,182 @@
+use moyo::base::{Collinear, MagneticCell, NonCollinear};
+use moyo::utils::{to_3_slice, to_vector3};
+
+use super::cell::{MoyoCell, moyo_cell_free_members};
+use crate::ffi::{free_slice, leak_slice};
+
+/// Collinear magnetic structure.
+/// All pointer fields are owned by the containing dataset and are freed by
+/// `moyo_collinear_magnetic_dataset_free`.
+#[derive(Debug, Clone)]
+#[repr(C)]
+pub struct MoyoCollinearMagneticCell {
+    /// Crystal structure
+    pub cell: MoyoCell,
+    /// Collinear magnetic moments of the `cell.num_atoms` sites
+    pub magnetic_moments: *const f64,
+}
+
+impl From<&MagneticCell<Collinear>> for MoyoCollinearMagneticCell {
+    fn from(magnetic_cell: &MagneticCell<Collinear>) -> Self {
+        let magnetic_moments = magnetic_cell
+            .magnetic_moments
+            .iter()
+            .map(|m| m.0)
+            .collect::<Vec<_>>();
+        Self {
+            cell: (&magnetic_cell.cell).into(),
+            magnetic_moments: leak_slice(magnetic_moments),
+        }
+    }
+}
+
+impl From<&MoyoCollinearMagneticCell> for MagneticCell<Collinear> {
+    fn from(magnetic_cell: &MoyoCollinearMagneticCell) -> Self {
+        let cell = (&magnetic_cell.cell).into();
+        let magnetic_moments = unsafe {
+            std::slice::from_raw_parts(
+                magnetic_cell.magnetic_moments,
+                magnetic_cell.cell.num_atoms as usize,
+            )
+            .iter()
+            .map(|&m| Collinear(m))
+            .collect()
+        };
+        MagneticCell::from_cell(cell, magnetic_moments)
+    }
+}
+
+pub(crate) unsafe fn moyo_collinear_magnetic_cell_free_members(
+    magnetic_cell: &MoyoCollinearMagneticCell,
+) {
+    unsafe {
+        moyo_cell_free_members(&magnetic_cell.cell);
+        free_slice(
+            magnetic_cell.magnetic_moments,
+            magnetic_cell.cell.num_atoms as usize,
+        );
+    }
+}
+
+/// Non-collinear magnetic structure.
+/// All pointer fields are owned by the containing dataset and are freed by
+/// `moyo_noncollinear_magnetic_dataset_free`.
+#[derive(Debug, Clone)]
+#[repr(C)]
+pub struct MoyoNonCollinearMagneticCell {
+    /// Crystal structure
+    pub cell: MoyoCell,
+    /// Non-collinear magnetic moments of the `cell.num_atoms` sites in Cartesian coordinates
+    pub magnetic_moments: *const [f64; 3],
+}
+
+impl From<&MagneticCell<NonCollinear>> for MoyoNonCollinearMagneticCell {
+    fn from(magnetic_cell: &MagneticCell<NonCollinear>) -> Self {
+        let magnetic_moments = magnetic_cell
+            .magnetic_moments
+            .iter()
+            .map(|m| to_3_slice(&m.0))
+            .collect::<Vec<_>>();
+        Self {
+            cell: (&magnetic_cell.cell).into(),
+            magnetic_moments: leak_slice(magnetic_moments),
+        }
+    }
+}
+
+impl From<&MoyoNonCollinearMagneticCell> for MagneticCell<NonCollinear> {
+    fn from(magnetic_cell: &MoyoNonCollinearMagneticCell) -> Self {
+        let cell = (&magnetic_cell.cell).into();
+        let magnetic_moments = unsafe {
+            std::slice::from_raw_parts(
+                magnetic_cell.magnetic_moments,
+                magnetic_cell.cell.num_atoms as usize,
+            )
+            .iter()
+            .map(|m| NonCollinear(to_vector3(m)))
+            .collect()
+        };
+        MagneticCell::from_cell(cell, magnetic_moments)
+    }
+}
+
+pub(crate) unsafe fn moyo_noncollinear_magnetic_cell_free_members(
+    magnetic_cell: &MoyoNonCollinearMagneticCell,
+) {
+    unsafe {
+        moyo_cell_free_members(&magnetic_cell.cell);
+        free_slice(
+            magnetic_cell.magnetic_moments,
+            magnetic_cell.cell.num_atoms as usize,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use moyo::base::Lattice;
+    use nalgebra::{matrix, vector};
+
+    #[test]
+    fn test_roundtrip_moyo_collinear_magnetic_cell() {
+        let original = MagneticCell::new(
+            Lattice::new(matrix![
+                1.0, 0.0, 0.0;
+                1.0, 1.0, 0.0;
+                1.0, 0.0, 1.0
+            ]),
+            vec![vector![0.0, 0.0, 0.0], vector![0.5, 0.5, 0.5]],
+            vec![1, 1],
+            vec![Collinear(0.7), Collinear(-0.7)],
+        );
+        let moyoc = MoyoCollinearMagneticCell::from(&original);
+        let reconstructed = MagneticCell::<Collinear>::from(&moyoc);
+        assert_eq!(original.num_atoms(), reconstructed.num_atoms());
+        assert_relative_eq!(
+            original.cell.lattice.basis,
+            reconstructed.cell.lattice.basis
+        );
+        for (m1, m2) in original
+            .magnetic_moments
+            .iter()
+            .zip(reconstructed.magnetic_moments.iter())
+        {
+            assert_relative_eq!(m1.0, m2.0);
+        }
+        unsafe { moyo_collinear_magnetic_cell_free_members(&moyoc) };
+    }
+
+    #[test]
+    fn test_roundtrip_moyo_noncollinear_magnetic_cell() {
+        let original = MagneticCell::new(
+            Lattice::new(matrix![
+                1.0, 0.0, 0.0;
+                1.0, 1.0, 0.0;
+                1.0, 0.0, 1.0
+            ]),
+            vec![vector![0.0, 0.0, 0.0], vector![0.5, 0.5, 0.5]],
+            vec![1, 1],
+            vec![
+                NonCollinear(vector![0.0, 0.0, 0.7]),
+                NonCollinear(vector![0.0, 0.0, -0.7]),
+            ],
+        );
+        let moyoc = MoyoNonCollinearMagneticCell::from(&original);
+        let reconstructed = MagneticCell::<NonCollinear>::from(&moyoc);
+        assert_eq!(original.num_atoms(), reconstructed.num_atoms());
+        assert_relative_eq!(
+            original.cell.lattice.basis,
+            reconstructed.cell.lattice.basis
+        );
+        for (m1, m2) in original
+            .magnetic_moments
+            .iter()
+            .zip(reconstructed.magnetic_moments.iter())
+        {
+            assert_relative_eq!(m1.0, m2.0);
+        }
+        unsafe { moyo_noncollinear_magnetic_cell_free_members(&moyoc) };
+    }
+}

--- a/moyoc/src/base/magnetic_operation.rs
+++ b/moyoc/src/base/magnetic_operation.rs
@@ -1,0 +1,115 @@
+use moyo::base::{MagneticOperation, MagneticOperations};
+use moyo::utils::{to_3_slice, to_3x3_slice, to_matrix3, to_vector3};
+
+use crate::ffi::{free_slice, leak_slice};
+
+/// Magnetic symmetry operations.
+/// All pointer fields are owned by the containing dataset and are freed
+/// together with it.
+#[derive(Debug, Clone)]
+#[repr(C)]
+pub struct MoyoMagneticOperations {
+    /// Rotation parts of the `num_operations` magnetic operations
+    pub rotations: *const [[i32; 3]; 3],
+    /// Translation parts of the `num_operations` magnetic operations
+    pub translations: *const [f64; 3],
+    /// Time-reversal parts of the `num_operations` magnetic operations
+    pub time_reversals: *const bool,
+    /// Number of magnetic symmetry operations
+    pub num_operations: i32,
+}
+
+impl From<&MagneticOperations> for MoyoMagneticOperations {
+    fn from(magnetic_operations: &MagneticOperations) -> Self {
+        let rotations = magnetic_operations
+            .iter()
+            .map(|x| to_3x3_slice(&x.operation.rotation))
+            .collect::<Vec<_>>();
+        let translations = magnetic_operations
+            .iter()
+            .map(|x| to_3_slice(&x.operation.translation))
+            .collect::<Vec<_>>();
+        let time_reversals = magnetic_operations
+            .iter()
+            .map(|x| x.time_reversal)
+            .collect::<Vec<_>>();
+        Self {
+            rotations: leak_slice(rotations),
+            translations: leak_slice(translations),
+            time_reversals: leak_slice(time_reversals),
+            num_operations: magnetic_operations.len() as i32,
+        }
+    }
+}
+
+impl From<&MoyoMagneticOperations> for MagneticOperations {
+    fn from(magnetic_operations: &MoyoMagneticOperations) -> Self {
+        let num_operations = magnetic_operations.num_operations as usize;
+        unsafe {
+            let rotations =
+                std::slice::from_raw_parts(magnetic_operations.rotations, num_operations);
+            let translations =
+                std::slice::from_raw_parts(magnetic_operations.translations, num_operations);
+            let time_reversals =
+                std::slice::from_raw_parts(magnetic_operations.time_reversals, num_operations);
+            rotations
+                .iter()
+                .zip(translations)
+                .zip(time_reversals)
+                .map(|((r, t), &tr)| MagneticOperation::new(to_matrix3(r), to_vector3(t), tr))
+                .collect()
+        }
+    }
+}
+
+pub(crate) unsafe fn moyo_magnetic_operations_free_members(
+    magnetic_operations: &MoyoMagneticOperations,
+) {
+    unsafe {
+        let num_operations = magnetic_operations.num_operations as usize;
+        free_slice(magnetic_operations.rotations, num_operations);
+        free_slice(magnetic_operations.translations, num_operations);
+        free_slice(magnetic_operations.time_reversals, num_operations);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use nalgebra::{matrix, vector};
+
+    #[test]
+    fn test_roundtrip_moyo_magnetic_operations() {
+        // P-1' generators
+        let original = vec![
+            MagneticOperation::new(
+                matrix![
+                    1, 0, 0;
+                    0, 1, 0;
+                    0, 0, 1;
+                ],
+                vector![0.0, 0.0, 0.0],
+                false,
+            ),
+            MagneticOperation::new(
+                matrix![
+                    -1, 0, 0;
+                    0, -1, 0;
+                    0, 0, -1;
+                ],
+                vector![0.0, 0.0, 0.0],
+                true,
+            ),
+        ];
+        let moyoc = MoyoMagneticOperations::from(&original);
+        let reconstructed = MagneticOperations::from(&moyoc);
+        assert_eq!(original.len(), reconstructed.len());
+        for (op1, op2) in original.iter().zip(reconstructed.iter()) {
+            assert_eq!(op1.operation.rotation, op2.operation.rotation);
+            assert_relative_eq!(op1.operation.translation, op2.operation.translation);
+            assert_eq!(op1.time_reversal, op2.time_reversal);
+        }
+        unsafe { moyo_magnetic_operations_free_members(&moyoc) };
+    }
+}

--- a/moyoc/src/dataset.rs
+++ b/moyoc/src/dataset.rs
@@ -1,3 +1,9 @@
+mod magnetic_space_group;
 mod space_group;
 
+pub use magnetic_space_group::{
+    MoyoCollinearMagneticDataset, MoyoNonCollinearMagneticDataset,
+    moyo_collinear_magnetic_dataset_free, moyo_collinear_magnetic_dataset_new,
+    moyo_noncollinear_magnetic_dataset_free, moyo_noncollinear_magnetic_dataset_new,
+};
 pub use space_group::{MoyoDataset, moyo_dataset_free, moyo_dataset_new};

--- a/moyoc/src/dataset/magnetic_space_group.rs
+++ b/moyoc/src/dataset/magnetic_space_group.rs
@@ -1,0 +1,431 @@
+use moyo::MoyoMagneticDataset as MagneticDataset;
+use moyo::base::{
+    AngleTolerance, Collinear, MagneticCell, NonCollinear, RotationMagneticMomentAction,
+};
+use moyo::utils::{to_3_slice, to_3x3_slice};
+
+use crate::base::magnetic_cell::{
+    moyo_collinear_magnetic_cell_free_members, moyo_noncollinear_magnetic_cell_free_members,
+};
+use crate::base::magnetic_operation::moyo_magnetic_operations_free_members;
+use crate::base::{
+    MoyoCell, MoyoCollinearMagneticCell, MoyoMagneticOperations, MoyoNonCollinearMagneticCell,
+};
+use crate::ffi::{free_slice, leak_slice};
+
+/// A dataset of the magnetic symmetry analysis of a collinear magnetic
+/// structure, created by `moyo_collinear_magnetic_dataset_new` and freed by
+/// `moyo_collinear_magnetic_dataset_free`.
+#[derive(Debug, Clone)]
+#[repr(C)]
+pub struct MoyoCollinearMagneticDataset {
+    // ------------------------------------------------------------------------
+    // Magnetic space-group type
+    // ------------------------------------------------------------------------
+    /// Serial number of UNI (and BNS) symbols.
+    pub uni_number: i32,
+    // ------------------------------------------------------------------------
+    // Input magnetic cell
+    // ------------------------------------------------------------------------
+    /// Number of atoms in the input magnetic cell.
+    /// Arrays `orbits` and `mapping_std_prim` have this length.
+    pub num_atoms: i32,
+    // ------------------------------------------------------------------------
+    // Magnetic symmetry operations in the input cell
+    // ------------------------------------------------------------------------
+    /// Magnetic symmetry operations in the input cell.
+    pub magnetic_operations: MoyoMagneticOperations,
+    // ------------------------------------------------------------------------
+    // Site symmetry
+    // ------------------------------------------------------------------------
+    /// The `i`th atom in the input magnetic cell is equivalent to the `orbits[i]`th atom
+    /// in the **input** magnetic cell.
+    pub orbits: *const i32,
+    // ------------------------------------------------------------------------
+    // Standardized magnetic cell
+    // ------------------------------------------------------------------------
+    /// Standardized magnetic cell
+    pub std_mag_cell: MoyoCollinearMagneticCell,
+    /// Linear part of transformation from the input magnetic cell to the standardized one.
+    pub std_linear: [[f64; 3]; 3],
+    /// Origin shift of transformation from the input magnetic cell to the standardized one.
+    pub std_origin_shift: [f64; 3],
+    /// Rigid rotation
+    pub std_rotation_matrix: [[f64; 3]; 3],
+    // ------------------------------------------------------------------------
+    // Primitive standardized magnetic cell
+    // ------------------------------------------------------------------------
+    /// Primitive standardized magnetic cell
+    pub prim_std_mag_cell: MoyoCollinearMagneticCell,
+    /// Linear part of transformation from the input magnetic cell to the primitive standardized one.
+    pub prim_std_linear: [[f64; 3]; 3],
+    /// Origin shift of transformation from the input magnetic cell to the primitive standardized one.
+    pub prim_std_origin_shift: [f64; 3],
+    /// Mapping sites in the input magnetic cell to those in the primitive standardized one.
+    /// The `i`th atom in the input magnetic cell is mapped to the `mapping_std_prim[i]`th
+    /// atom in the primitive standardized magnetic cell.
+    pub mapping_std_prim: *const i32,
+    // ------------------------------------------------------------------------
+    // Final parameters
+    // ------------------------------------------------------------------------
+    /// Actually used `symprec` in iterative symmetry search.
+    pub symprec: f64,
+    /// Actually used `angle_tolerance` in iterative symmetry search.
+    /// -1 if the default angle tolerance is used.
+    pub angle_tolerance: f64,
+    /// Actually used `mag_symprec` in iterative symmetry search.
+    pub mag_symprec: f64,
+}
+
+impl MoyoCollinearMagneticDataset {
+    fn new(dataset: MagneticDataset<Collinear>, num_atoms: i32) -> Self {
+        let orbits = dataset.orbits.iter().map(|&x| x as i32).collect();
+        let mapping_std_prim = dataset.mapping_std_prim.iter().map(|&x| x as i32).collect();
+
+        Self {
+            // Magnetic space-group type
+            uni_number: dataset.uni_number,
+            // Input magnetic cell
+            num_atoms,
+            // Magnetic symmetry operations in the input cell
+            magnetic_operations: (&dataset.magnetic_operations).into(),
+            // Site symmetry
+            orbits: leak_slice(orbits),
+            // Standardized magnetic cell
+            std_mag_cell: (&dataset.std_mag_cell).into(),
+            std_linear: to_3x3_slice(&dataset.std_linear),
+            std_origin_shift: to_3_slice(&dataset.std_origin_shift),
+            std_rotation_matrix: to_3x3_slice(&dataset.std_rotation_matrix),
+            // Primitive standardized magnetic cell
+            prim_std_mag_cell: (&dataset.prim_std_mag_cell).into(),
+            prim_std_linear: to_3x3_slice(&dataset.prim_std_linear),
+            prim_std_origin_shift: to_3_slice(&dataset.prim_std_origin_shift),
+            mapping_std_prim: leak_slice(mapping_std_prim),
+            // Final parameters
+            symprec: dataset.symprec,
+            angle_tolerance: angle_tolerance_to_f64(dataset.angle_tolerance),
+            mag_symprec: dataset.mag_symprec,
+        }
+    }
+}
+
+/// A dataset of the magnetic symmetry analysis of a non-collinear magnetic
+/// structure, created by `moyo_noncollinear_magnetic_dataset_new` and freed by
+/// `moyo_noncollinear_magnetic_dataset_free`.
+#[derive(Debug, Clone)]
+#[repr(C)]
+pub struct MoyoNonCollinearMagneticDataset {
+    // ------------------------------------------------------------------------
+    // Magnetic space-group type
+    // ------------------------------------------------------------------------
+    /// Serial number of UNI (and BNS) symbols.
+    pub uni_number: i32,
+    // ------------------------------------------------------------------------
+    // Input magnetic cell
+    // ------------------------------------------------------------------------
+    /// Number of atoms in the input magnetic cell.
+    /// Arrays `orbits` and `mapping_std_prim` have this length.
+    pub num_atoms: i32,
+    // ------------------------------------------------------------------------
+    // Magnetic symmetry operations in the input cell
+    // ------------------------------------------------------------------------
+    /// Magnetic symmetry operations in the input cell.
+    pub magnetic_operations: MoyoMagneticOperations,
+    // ------------------------------------------------------------------------
+    // Site symmetry
+    // ------------------------------------------------------------------------
+    /// The `i`th atom in the input magnetic cell is equivalent to the `orbits[i]`th atom
+    /// in the **input** magnetic cell.
+    pub orbits: *const i32,
+    // ------------------------------------------------------------------------
+    // Standardized magnetic cell
+    // ------------------------------------------------------------------------
+    /// Standardized magnetic cell
+    pub std_mag_cell: MoyoNonCollinearMagneticCell,
+    /// Linear part of transformation from the input magnetic cell to the standardized one.
+    pub std_linear: [[f64; 3]; 3],
+    /// Origin shift of transformation from the input magnetic cell to the standardized one.
+    pub std_origin_shift: [f64; 3],
+    /// Rigid rotation
+    pub std_rotation_matrix: [[f64; 3]; 3],
+    // ------------------------------------------------------------------------
+    // Primitive standardized magnetic cell
+    // ------------------------------------------------------------------------
+    /// Primitive standardized magnetic cell
+    pub prim_std_mag_cell: MoyoNonCollinearMagneticCell,
+    /// Linear part of transformation from the input magnetic cell to the primitive standardized one.
+    pub prim_std_linear: [[f64; 3]; 3],
+    /// Origin shift of transformation from the input magnetic cell to the primitive standardized one.
+    pub prim_std_origin_shift: [f64; 3],
+    /// Mapping sites in the input magnetic cell to those in the primitive standardized one.
+    /// The `i`th atom in the input magnetic cell is mapped to the `mapping_std_prim[i]`th
+    /// atom in the primitive standardized magnetic cell.
+    pub mapping_std_prim: *const i32,
+    // ------------------------------------------------------------------------
+    // Final parameters
+    // ------------------------------------------------------------------------
+    /// Actually used `symprec` in iterative symmetry search.
+    pub symprec: f64,
+    /// Actually used `angle_tolerance` in iterative symmetry search.
+    /// -1 if the default angle tolerance is used.
+    pub angle_tolerance: f64,
+    /// Actually used `mag_symprec` in iterative symmetry search.
+    pub mag_symprec: f64,
+}
+
+impl MoyoNonCollinearMagneticDataset {
+    fn new(dataset: MagneticDataset<NonCollinear>, num_atoms: i32) -> Self {
+        let orbits = dataset.orbits.iter().map(|&x| x as i32).collect();
+        let mapping_std_prim = dataset.mapping_std_prim.iter().map(|&x| x as i32).collect();
+
+        Self {
+            // Magnetic space-group type
+            uni_number: dataset.uni_number,
+            // Input magnetic cell
+            num_atoms,
+            // Magnetic symmetry operations in the input cell
+            magnetic_operations: (&dataset.magnetic_operations).into(),
+            // Site symmetry
+            orbits: leak_slice(orbits),
+            // Standardized magnetic cell
+            std_mag_cell: (&dataset.std_mag_cell).into(),
+            std_linear: to_3x3_slice(&dataset.std_linear),
+            std_origin_shift: to_3_slice(&dataset.std_origin_shift),
+            std_rotation_matrix: to_3x3_slice(&dataset.std_rotation_matrix),
+            // Primitive standardized magnetic cell
+            prim_std_mag_cell: (&dataset.prim_std_mag_cell).into(),
+            prim_std_linear: to_3x3_slice(&dataset.prim_std_linear),
+            prim_std_origin_shift: to_3_slice(&dataset.prim_std_origin_shift),
+            mapping_std_prim: leak_slice(mapping_std_prim),
+            // Final parameters
+            symprec: dataset.symprec,
+            angle_tolerance: angle_tolerance_to_f64(dataset.angle_tolerance),
+            mag_symprec: dataset.mag_symprec,
+        }
+    }
+}
+
+/// Analyze the magnetic symmetry of the given collinear magnetic cell and create a dataset.
+///
+/// - `basis`: row-wise basis vectors, `basis[i]` is the `i`th basis vector.
+/// - `positions`: fractional coordinates of the `num_atoms` sites.
+/// - `numbers`: atomic numbers of the `num_atoms` sites.
+/// - `magnetic_moments`: collinear magnetic moments of the `num_atoms` sites.
+/// - `angle_tolerance`: tolerance of angle between basis vectors in radians.
+///   Pass a negative value to use the default angle tolerance.
+/// - `mag_symprec`: tolerance for matching magnetic moments.
+///   Pass a negative value to reuse `symprec`.
+/// - `is_axial`: whether magnetic moments transform as axial vectors.
+/// - Returns NULL if the symmetry search fails or the arguments are invalid.
+///
+/// # Safety
+/// `basis` must point to 3 basis vectors, and `positions`, `numbers`, and
+/// `magnetic_moments` must point to `num_atoms` elements each.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moyo_collinear_magnetic_dataset_new(
+    basis: *const [f64; 3],
+    positions: *const [f64; 3],
+    numbers: *const i32,
+    magnetic_moments: *const f64,
+    num_atoms: i32,
+    symprec: f64,
+    angle_tolerance: f64,
+    mag_symprec: f64,
+    is_axial: bool,
+    rotate_basis: bool,
+) -> *mut MoyoCollinearMagneticDataset {
+    if basis.is_null()
+        || positions.is_null()
+        || numbers.is_null()
+        || magnetic_moments.is_null()
+        || num_atoms <= 0
+    {
+        return std::ptr::null_mut();
+    }
+    let basis = unsafe { *(basis as *const [[f64; 3]; 3]) };
+    let magnetic_cell = MoyoCollinearMagneticCell {
+        cell: MoyoCell {
+            basis,
+            positions,
+            numbers,
+            num_atoms,
+        },
+        magnetic_moments,
+    };
+    let magnetic_cell: MagneticCell<Collinear> = (&magnetic_cell).into();
+
+    let dataset = MagneticDataset::new(
+        &magnetic_cell,
+        symprec,
+        angle_tolerance_from_f64(angle_tolerance),
+        mag_symprec_from_f64(mag_symprec),
+        action_from_is_axial(is_axial),
+        rotate_basis,
+    );
+    match dataset {
+        Ok(dataset) => Box::into_raw(Box::new(MoyoCollinearMagneticDataset::new(
+            dataset, num_atoms,
+        ))),
+        Err(_) => std::ptr::null_mut(),
+    }
+}
+
+/// Free a dataset created by `moyo_collinear_magnetic_dataset_new`. Passing NULL is a no-op.
+///
+/// # Safety
+/// `dataset` must be a pointer returned by `moyo_collinear_magnetic_dataset_new`
+/// that has not been freed yet, or NULL.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moyo_collinear_magnetic_dataset_free(
+    dataset: *mut MoyoCollinearMagneticDataset,
+) {
+    if dataset.is_null() {
+        return;
+    }
+    unsafe {
+        let dataset = Box::from_raw(dataset);
+        let num_atoms = dataset.num_atoms as usize;
+
+        // Magnetic symmetry operations in the input cell
+        moyo_magnetic_operations_free_members(&dataset.magnetic_operations);
+
+        // Site symmetry
+        free_slice(dataset.orbits, num_atoms);
+
+        // Standardized magnetic cell
+        moyo_collinear_magnetic_cell_free_members(&dataset.std_mag_cell);
+
+        // Primitive standardized magnetic cell
+        moyo_collinear_magnetic_cell_free_members(&dataset.prim_std_mag_cell);
+        free_slice(dataset.mapping_std_prim, num_atoms);
+    }
+}
+
+/// Analyze the magnetic symmetry of the given non-collinear magnetic cell and create a dataset.
+///
+/// - `basis`: row-wise basis vectors, `basis[i]` is the `i`th basis vector.
+/// - `positions`: fractional coordinates of the `num_atoms` sites.
+/// - `numbers`: atomic numbers of the `num_atoms` sites.
+/// - `magnetic_moments`: non-collinear magnetic moments of the `num_atoms` sites
+///   in Cartesian coordinates.
+/// - `angle_tolerance`: tolerance of angle between basis vectors in radians.
+///   Pass a negative value to use the default angle tolerance.
+/// - `mag_symprec`: tolerance for matching magnetic moments.
+///   Pass a negative value to reuse `symprec`.
+/// - `is_axial`: whether magnetic moments transform as axial vectors.
+/// - Returns NULL if the symmetry search fails or the arguments are invalid.
+///
+/// # Safety
+/// `basis` must point to 3 basis vectors, and `positions`, `numbers`, and
+/// `magnetic_moments` must point to `num_atoms` elements each.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moyo_noncollinear_magnetic_dataset_new(
+    basis: *const [f64; 3],
+    positions: *const [f64; 3],
+    numbers: *const i32,
+    magnetic_moments: *const [f64; 3],
+    num_atoms: i32,
+    symprec: f64,
+    angle_tolerance: f64,
+    mag_symprec: f64,
+    is_axial: bool,
+    rotate_basis: bool,
+) -> *mut MoyoNonCollinearMagneticDataset {
+    if basis.is_null()
+        || positions.is_null()
+        || numbers.is_null()
+        || magnetic_moments.is_null()
+        || num_atoms <= 0
+    {
+        return std::ptr::null_mut();
+    }
+    let basis = unsafe { *(basis as *const [[f64; 3]; 3]) };
+    let magnetic_cell = MoyoNonCollinearMagneticCell {
+        cell: MoyoCell {
+            basis,
+            positions,
+            numbers,
+            num_atoms,
+        },
+        magnetic_moments,
+    };
+    let magnetic_cell: MagneticCell<NonCollinear> = (&magnetic_cell).into();
+
+    let dataset = MagneticDataset::new(
+        &magnetic_cell,
+        symprec,
+        angle_tolerance_from_f64(angle_tolerance),
+        mag_symprec_from_f64(mag_symprec),
+        action_from_is_axial(is_axial),
+        rotate_basis,
+    );
+    match dataset {
+        Ok(dataset) => Box::into_raw(Box::new(MoyoNonCollinearMagneticDataset::new(
+            dataset, num_atoms,
+        ))),
+        Err(_) => std::ptr::null_mut(),
+    }
+}
+
+/// Free a dataset created by `moyo_noncollinear_magnetic_dataset_new`. Passing NULL is a no-op.
+///
+/// # Safety
+/// `dataset` must be a pointer returned by `moyo_noncollinear_magnetic_dataset_new`
+/// that has not been freed yet, or NULL.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moyo_noncollinear_magnetic_dataset_free(
+    dataset: *mut MoyoNonCollinearMagneticDataset,
+) {
+    if dataset.is_null() {
+        return;
+    }
+    unsafe {
+        let dataset = Box::from_raw(dataset);
+        let num_atoms = dataset.num_atoms as usize;
+
+        // Magnetic symmetry operations in the input cell
+        moyo_magnetic_operations_free_members(&dataset.magnetic_operations);
+
+        // Site symmetry
+        free_slice(dataset.orbits, num_atoms);
+
+        // Standardized magnetic cell
+        moyo_noncollinear_magnetic_cell_free_members(&dataset.std_mag_cell);
+
+        // Primitive standardized magnetic cell
+        moyo_noncollinear_magnetic_cell_free_members(&dataset.prim_std_mag_cell);
+        free_slice(dataset.mapping_std_prim, num_atoms);
+    }
+}
+
+fn angle_tolerance_from_f64(angle_tolerance: f64) -> AngleTolerance {
+    if angle_tolerance < 0.0 {
+        AngleTolerance::default()
+    } else {
+        AngleTolerance::Radian(angle_tolerance)
+    }
+}
+
+fn angle_tolerance_to_f64(angle_tolerance: AngleTolerance) -> f64 {
+    if let AngleTolerance::Radian(angle_tolerance) = angle_tolerance {
+        angle_tolerance
+    } else {
+        -1.0
+    }
+}
+
+fn mag_symprec_from_f64(mag_symprec: f64) -> Option<f64> {
+    if mag_symprec < 0.0 {
+        None
+    } else {
+        Some(mag_symprec)
+    }
+}
+
+fn action_from_is_axial(is_axial: bool) -> RotationMagneticMomentAction {
+    if is_axial {
+        RotationMagneticMomentAction::Axial
+    } else {
+        RotationMagneticMomentAction::Polar
+    }
+}

--- a/moyoc/src/lib.rs
+++ b/moyoc/src/lib.rs
@@ -8,9 +8,17 @@ pub mod base;
 pub mod data;
 pub mod dataset;
 
-pub use base::{MoyoCell, MoyoOperations};
+pub use base::{
+    MoyoCell, MoyoCollinearMagneticCell, MoyoMagneticOperations, MoyoNonCollinearMagneticCell,
+    MoyoOperations,
+};
 pub use data::MoyoSetting;
-pub use dataset::{MoyoDataset, moyo_dataset_free, moyo_dataset_new};
+pub use dataset::{
+    MoyoCollinearMagneticDataset, MoyoDataset, MoyoNonCollinearMagneticDataset,
+    moyo_collinear_magnetic_dataset_free, moyo_collinear_magnetic_dataset_new, moyo_dataset_free,
+    moyo_dataset_new, moyo_noncollinear_magnetic_dataset_free,
+    moyo_noncollinear_magnetic_dataset_new,
+};
 
 /// Return the version string of moyoc (e.g. "0.11.0").
 /// The returned string is statically allocated and must not be freed.

--- a/moyoc/tests/CMakeLists.txt
+++ b/moyoc/tests/CMakeLists.txt
@@ -1,10 +1,20 @@
-add_executable(test_moyoc_dataset test_moyoc_dataset.c)
-target_link_libraries(test_moyoc_dataset PRIVATE moyo::moyoc)
-if(NOT MSVC)
-    target_compile_options(test_moyoc_dataset PRIVATE
-        -Wall -Wextra -fsanitize=address -fno-omit-frame-pointer)
-    target_link_options(test_moyoc_dataset PRIVATE -fsanitize=address)
-    target_link_libraries(test_moyoc_dataset PRIVATE m)
-endif()
+function(add_moyoc_test name)
+    add_executable(${name} ${name}.c)
+    target_link_libraries(${name} PRIVATE moyo::moyoc)
+    if(MSVC)
+        # Re-enable assert() in Release configurations
+        target_compile_options(${name} PRIVATE /UNDEBUG)
+    else()
+        target_compile_options(${name} PRIVATE
+            # Re-enable assert() in Release configurations
+            -UNDEBUG
+            -Wall -Wextra -fsanitize=address -fno-omit-frame-pointer)
+        target_link_options(${name} PRIVATE -fsanitize=address)
+        target_link_libraries(${name} PRIVATE m)
+    endif()
 
-add_test(NAME test_moyoc_dataset COMMAND test_moyoc_dataset)
+    add_test(NAME ${name} COMMAND ${name})
+endfunction()
+
+add_moyoc_test(test_moyoc_dataset)
+add_moyoc_test(test_moyoc_magnetic_dataset)

--- a/moyoc/tests/test_moyoc_magnetic_dataset.c
+++ b/moyoc/tests/test_moyoc_magnetic_dataset.c
@@ -1,0 +1,171 @@
+#include <assert.h>
+#include <stdio.h>
+
+#include "moyoc.h"
+
+void show_magnetic_operations(const MoyoMagneticOperations *magnetic_operations) {
+    for (int i = 0; i < magnetic_operations->num_operations; i++) {
+        printf("Magnetic operation %d (time reversal: %d)\n", i,
+               magnetic_operations->time_reversals[i]);
+        for (int a = 0; a < 3; a++) {
+            for (int b = 0; b < 3; b++) {
+                printf("%2d ", magnetic_operations->rotations[i][a][b]);
+            }
+            printf("\n");
+        }
+        for (int a = 0; a < 3; a++) {
+            printf("%.2f ", magnetic_operations->translations[i][a]);
+        }
+        printf("\n");
+    }
+}
+
+void test_collinear(void) {
+    // Rutile-type MnF2, type-III magnetic space group
+    double basis[3][3] = {
+        {1.0, 0.0, 0.0},
+        {0.0, 1.0, 0.0},
+        {0.0, 0.0, 1.0},
+    };
+    double positions[][3] = {
+        // Ti (2a)
+        {0.0, 0.0, 0.0},
+        {0.5, 0.5, 0.5},
+        // O (4f)
+        {0.3, 0.3, 0.0},
+        {0.7, 0.7, 0.0},
+        {0.2, 0.8, 0.5},
+        {0.8, 0.2, 0.5},
+    };
+    int32_t numbers[] = {0, 0, 1, 1, 1, 1};
+    double magnetic_moments[] = {0.7, -0.7, 0.0, 0.0, 0.0, 0.0};
+    int32_t num_atoms = 6;
+
+    double symprec = 1e-4;
+    double angle_tolerance = -1;
+    double mag_symprec = -1;
+    bool is_axial = false;
+    bool rotate_basis = true;
+
+    MoyoCollinearMagneticDataset *dataset = moyo_collinear_magnetic_dataset_new(
+        basis, positions, numbers, magnetic_moments, num_atoms,
+        symprec, angle_tolerance, mag_symprec, is_axial, rotate_basis
+    );
+    assert(dataset != NULL);
+
+    // Magnetic space-group type
+    printf("dataset->uni_number: %d\n", dataset->uni_number);
+    assert(dataset->uni_number == 1158);  // BNS 136.498
+
+    // Input magnetic cell
+    assert(dataset->num_atoms == num_atoms);
+
+    // Magnetic symmetry operations in the input cell
+    printf("dataset->magnetic_operations:\n");
+    show_magnetic_operations(&dataset->magnetic_operations);
+    assert(dataset->magnetic_operations.num_operations == 16);
+
+    // Site symmetry
+    printf("dataset->orbits:\n");
+    for (int i = 0; i < num_atoms; i++) {
+        printf("%d ", dataset->orbits[i]);
+    }
+    printf("\n");
+    int32_t expected_orbits[] = {0, 0, 2, 2, 2, 2};
+    for (int i = 0; i < num_atoms; i++) {
+        assert(dataset->orbits[i] == expected_orbits[i]);
+    }
+
+    // Standardized magnetic cell
+    assert(dataset->std_mag_cell.cell.num_atoms == 6);
+    printf("dataset->std_mag_cell.magnetic_moments:\n");
+    for (int i = 0; i < dataset->std_mag_cell.cell.num_atoms; i++) {
+        printf("%f ", dataset->std_mag_cell.magnetic_moments[i]);
+    }
+    printf("\n");
+
+    // Primitive standardized magnetic cell
+    assert(dataset->prim_std_mag_cell.cell.num_atoms == 6);
+    printf("dataset->mapping_std_prim:\n");
+    for (int i = 0; i < num_atoms; i++) {
+        printf("%d ", dataset->mapping_std_prim[i]);
+        assert(dataset->mapping_std_prim[i] == i);
+    }
+    printf("\n");
+
+    // Final parameters
+    printf("dataset->symprec: %f\n", dataset->symprec);
+    printf("dataset->angle_tolerance: %f\n", dataset->angle_tolerance);
+    printf("dataset->mag_symprec: %f\n", dataset->mag_symprec);
+
+    moyo_collinear_magnetic_dataset_free(dataset);
+}
+
+void test_noncollinear(void) {
+    // Rutile-type structure with non-collinear moments along c
+    double basis[3][3] = {
+        {4.603, 0.0, 0.0},
+        {0.0, 4.603, 0.0},
+        {0.0, 0.0, 2.969},
+    };
+    double x_4f = 0.3046;
+    double positions[][3] = {
+        // Ti (2a)
+        {0.0, 0.0, 0.0},
+        {0.5, 0.5, 0.5},
+        // O (4f)
+        {x_4f, x_4f, 0.0},
+        {1.0 - x_4f, 1.0 - x_4f, 0.0},
+        {0.5 - x_4f, 0.5 + x_4f, 0.5},
+        {0.5 + x_4f, 0.5 - x_4f, 0.5},
+    };
+    int32_t numbers[] = {0, 0, 1, 1, 1, 1};
+    double magnetic_moments[][3] = {
+        {0.0, 0.0, 0.7},
+        {0.0, 0.0, -0.7},
+        {0.0, 0.0, 0.0},
+        {0.0, 0.0, 0.0},
+        {0.0, 0.0, 0.0},
+        {0.0, 0.0, 0.0},
+    };
+    int32_t num_atoms = 6;
+
+    double symprec = 1e-4;
+    double angle_tolerance = -1;
+    double mag_symprec = -1;
+    bool is_axial = true;
+    bool rotate_basis = true;
+
+    MoyoNonCollinearMagneticDataset *dataset = moyo_noncollinear_magnetic_dataset_new(
+        basis, positions, numbers, magnetic_moments, num_atoms,
+        symprec, angle_tolerance, mag_symprec, is_axial, rotate_basis
+    );
+    assert(dataset != NULL);
+
+    // Magnetic space-group type
+    printf("dataset->uni_number: %d\n", dataset->uni_number);
+    assert(dataset->uni_number == 1159);  // BNS 136.499
+
+    // Input magnetic cell
+    assert(dataset->num_atoms == num_atoms);
+
+    // Standardized magnetic cell
+    assert(dataset->std_mag_cell.cell.num_atoms == 6);
+    printf("dataset->std_mag_cell.magnetic_moments:\n");
+    for (int i = 0; i < dataset->std_mag_cell.cell.num_atoms; i++) {
+        printf("%f %f %f\n", dataset->std_mag_cell.magnetic_moments[i][0],
+               dataset->std_mag_cell.magnetic_moments[i][1],
+               dataset->std_mag_cell.magnetic_moments[i][2]);
+    }
+
+    // Primitive standardized magnetic cell
+    assert(dataset->prim_std_mag_cell.cell.num_atoms == 6);
+
+    moyo_noncollinear_magnetic_dataset_free(dataset);
+}
+
+int main(void) {
+    test_collinear();
+    test_noncollinear();
+    return 0;
+}


### PR DESCRIPTION
## Summary

First chunk of completing the moyoc C API (parity with moyopy's main entry points). This PR adds magnetic symmetry analysis:

- `moyo_collinear_magnetic_dataset_new` / `moyo_collinear_magnetic_dataset_free` for collinear magnetic structures (scalar moments)
- `moyo_noncollinear_magnetic_dataset_new` / `moyo_noncollinear_magnetic_dataset_free` for non-collinear magnetic structures (Cartesian vector moments)
- New C structs: `MoyoMagneticOperations` (rotations + translations + time reversals), `MoyoCollinearMagneticCell`, `MoyoNonCollinearMagneticCell`, and the two dataset structs mirroring `MoyoMagneticDataset`
- Same conventions as `moyo_dataset_new`: negative `angle_tolerance` selects the default, negative `mag_symprec` reuses `symprec`, `is_axial` selects the `RotationMagneticMomentAction` (matching moyopy's keyword)

Also fixes a latent test issue: the default Release configuration defines `NDEBUG`, which compiled out every `assert()` in the C tests. The test helper now undefines `NDEBUG` so the assertions actually run in CI.

Planned follow-up chunks (stacked PRs): layer dataset, database operation generators, group-type metadata lookups.

## Test plan

- [x] `cargo test -p moyoc` (roundtrip tests for magnetic cells and magnetic operations)
- [x] `cargo clippy -p moyoc --all-targets` clean
- [x] `ctest` passes under ASan: collinear rutile type-III (UNI 1158, 16 magnetic operations, orbits) and non-collinear rutile (UNI 1159)
- [x] Verified generated `moyoc.h` declares the new structs and functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
