### PR TITLE
Add layer dataset C API to moyoc

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -3,8 +3,9 @@ name: Check
 on:
   push:
     branches: [main]
+  # No branch filter: also run for stacked pull requests that target a
+  # feature branch instead of main
   pull_request:
-    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,8 +3,9 @@ name: CI
 on:
   push:
     branches: [main]
+  # No branch filter: also run for stacked pull requests that target a
+  # feature branch instead of main
   pull_request:
-    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/moyoc/README.md
+++ b/moyoc/README.md
@@ -57,6 +57,14 @@ MoyoDataset *dataset = moyo_dataset_new(
 // ... read dataset fields ...
 moyo_dataset_free(dataset);
 
+// Layer-group symmetry analysis
+MoyoLayerDataset *layer_dataset = moyo_layer_dataset_new(
+    basis, positions, numbers, num_atoms,
+    symprec, angle_tolerance, layer_setting, hall_number, rotate_basis
+);
+// ... read layer_dataset fields ...
+moyo_layer_dataset_free(layer_dataset);
+
 // Magnetic space-group symmetry analysis (collinear moments)
 MoyoCollinearMagneticDataset *mag_dataset = moyo_collinear_magnetic_dataset_new(
     basis, positions, numbers, magnetic_moments, num_atoms,

--- a/moyoc/src/data.rs
+++ b/moyoc/src/data.rs
@@ -1,3 +1,5 @@
+mod layer_setting;
 mod setting;
 
+pub use layer_setting::MoyoLayerSetting;
 pub use setting::MoyoSetting;

--- a/moyoc/src/data/layer_setting.rs
+++ b/moyoc/src/data/layer_setting.rs
@@ -1,0 +1,13 @@
+/// Preference for the Hall setting of the layer group.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(i32)]
+pub enum MoyoLayerSetting {
+    /// Layer Hall number specified by the `hall_number` argument (1 - 116)
+    HallNumber,
+    /// The setting of the smallest layer Hall number for each layer group
+    /// (origin choice 1 for the centrosymmetric layer groups 52, 62, 64)
+    Spglib,
+    /// BCS standard choice (de la Flor et al., Acta Cryst. A77, 559-571 (2021)):
+    /// origin choice 2 for the centrosymmetric layer groups 52, 62, 64
+    Standard,
+}

--- a/moyoc/src/dataset.rs
+++ b/moyoc/src/dataset.rs
@@ -1,6 +1,8 @@
+mod layer_group;
 mod magnetic_space_group;
 mod space_group;
 
+pub use layer_group::{MoyoLayerDataset, moyo_layer_dataset_free, moyo_layer_dataset_new};
 pub use magnetic_space_group::{
     MoyoCollinearMagneticDataset, MoyoNonCollinearMagneticDataset,
     moyo_collinear_magnetic_dataset_free, moyo_collinear_magnetic_dataset_new,

--- a/moyoc/src/dataset/layer_group.rs
+++ b/moyoc/src/dataset/layer_group.rs
@@ -1,0 +1,257 @@
+use core::ffi::c_char;
+
+use moyo::MoyoLayerDataset as LayerDataset;
+use moyo::base::{AngleTolerance, Cell, Lattice, LayerCell};
+use moyo::data::LayerSetting;
+use moyo::utils::{to_3_slice, to_3x3_slice};
+
+use crate::base::MoyoCell;
+use crate::base::MoyoOperations;
+use crate::base::cell::moyo_cell_free_members;
+use crate::base::operation::moyo_operations_free_members;
+use crate::data::MoyoLayerSetting;
+use crate::ffi::{free_cstring, free_slice, leak_cstring, leak_slice};
+
+/// Re-pack a `LayerCell` as a bulk `Cell` so it can cross the C boundary as a
+/// `MoyoCell`. The bulk-vs-layer split is enforced inside `moyo`; this
+/// conversion is a one-shot output bridge.
+fn layer_cell_to_moyo_cell(layer: &LayerCell) -> MoyoCell {
+    let cell = Cell::new(
+        Lattice {
+            basis: *layer.lattice().basis(),
+        },
+        layer.positions().to_vec(),
+        layer.numbers().to_vec(),
+    );
+    (&cell).into()
+}
+
+/// A dataset of the layer-group symmetry analysis, created by
+/// `moyo_layer_dataset_new` and freed by `moyo_layer_dataset_free`.
+#[derive(Debug, Clone)]
+#[repr(C)]
+pub struct MoyoLayerDataset {
+    // ------------------------------------------------------------------------
+    // Identification
+    // ------------------------------------------------------------------------
+    /// Layer group number (1 - 80).
+    pub number: i32,
+    /// Layer Hall symbol number (1 - 116).
+    pub hall_number: i32,
+    /// Hermann-Mauguin symbol in short notation.
+    pub hm_symbol: *const c_char,
+    // ------------------------------------------------------------------------
+    // Input cell
+    // ------------------------------------------------------------------------
+    /// Number of atoms in the input cell.
+    /// Arrays `orbits`, `wyckoffs`, `site_symmetry_symbols`, and `mapping_std_prim`
+    /// have this length.
+    pub num_atoms: i32,
+    // ------------------------------------------------------------------------
+    // Symmetry operations in the input cell
+    // ------------------------------------------------------------------------
+    /// Layer-group operations in the input cell.
+    pub operations: MoyoOperations,
+    // ------------------------------------------------------------------------
+    // Site symmetry
+    // ------------------------------------------------------------------------
+    /// The `i`th atom in the input cell is equivalent to the `orbits[i]`th atom
+    /// in the **input** cell.
+    pub orbits: *const i32,
+    /// Wyckoff letters for each site in the input cell as a NUL-terminated string.
+    pub wyckoffs: *const c_char,
+    /// Site symmetry symbols for each site in the input cell.
+    /// The orientation of the site symmetry is w.r.t. the standardized cell.
+    pub site_symmetry_symbols: *const *const c_char,
+    // ------------------------------------------------------------------------
+    // Standardized layer cell
+    // ------------------------------------------------------------------------
+    /// Conventional standardized layer cell
+    pub std_cell: MoyoCell,
+    /// Linear part of transformation from the input cell to the standardized cell.
+    pub std_linear: [[f64; 3]; 3],
+    /// Origin shift of transformation from the input cell to the standardized cell.
+    pub std_origin_shift: [f64; 3],
+    /// Rigid rotation
+    pub std_rotation_matrix: [[f64; 3]; 3],
+    /// Pearson symbol for the standardized layer cell. The first two characters
+    /// are the 2D Bravais type (`mp`, `op`, `oc`, `tp`, or `hp`).
+    pub pearson_symbol: *const c_char,
+    // ------------------------------------------------------------------------
+    // Primitive standardized layer cell
+    // ------------------------------------------------------------------------
+    /// Primitive standardized layer cell
+    pub prim_std_cell: MoyoCell,
+    /// Linear part of transformation from the input cell to the primitive standardized cell.
+    pub prim_std_linear: [[f64; 3]; 3],
+    /// Origin shift of transformation from the input cell to the primitive standardized cell.
+    pub prim_std_origin_shift: [f64; 3],
+    /// Mapping sites in the input cell to those in the primitive standardized cell.
+    /// The `i`th atom in the input cell is mapped to the `mapping_std_prim[i]`th
+    /// atom in the primitive standardized cell.
+    pub mapping_std_prim: *const i32,
+    // ------------------------------------------------------------------------
+    // Final parameters
+    // ------------------------------------------------------------------------
+    /// Actually used `symprec` in iterative symmetry search.
+    pub symprec: f64,
+    /// Actually used `angle_tolerance` in iterative symmetry search.
+    /// -1 if the default angle tolerance is used.
+    pub angle_tolerance: f64,
+}
+
+impl MoyoLayerDataset {
+    fn new(dataset: LayerDataset, num_atoms: i32) -> Self {
+        // Site symmetry
+        let wyckoffs = dataset.wyckoffs.into_iter().collect::<String>();
+        let site_symmetry_symbols = dataset
+            .site_symmetry_symbols
+            .iter()
+            .map(|s| leak_cstring(s.clone()))
+            .collect::<Vec<_>>();
+        let orbits = dataset.orbits.iter().map(|&x| x as i32).collect();
+        let mapping_std_prim = dataset.mapping_std_prim.iter().map(|&x| x as i32).collect();
+
+        // Final parameters
+        let angle_tolerance =
+            if let AngleTolerance::Radian(angle_tolerance) = dataset.angle_tolerance {
+                angle_tolerance
+            } else {
+                -1.0
+            };
+
+        Self {
+            // Identification
+            number: dataset.number,
+            hall_number: dataset.hall_number,
+            hm_symbol: leak_cstring(dataset.hm_symbol),
+            // Input cell
+            num_atoms,
+            // Symmetry operations in the input cell
+            operations: (&dataset.operations).into(),
+            // Site symmetry
+            orbits: leak_slice(orbits),
+            wyckoffs: leak_cstring(wyckoffs),
+            site_symmetry_symbols: leak_slice(site_symmetry_symbols),
+            // Standardized layer cell
+            std_cell: layer_cell_to_moyo_cell(&dataset.std_cell),
+            std_linear: to_3x3_slice(&dataset.std_linear),
+            std_origin_shift: to_3_slice(&dataset.std_origin_shift),
+            std_rotation_matrix: to_3x3_slice(&dataset.std_rotation_matrix),
+            pearson_symbol: leak_cstring(dataset.pearson_symbol),
+            // Primitive standardized layer cell
+            prim_std_cell: layer_cell_to_moyo_cell(&dataset.prim_std_cell),
+            prim_std_linear: to_3x3_slice(&dataset.prim_std_linear),
+            prim_std_origin_shift: to_3_slice(&dataset.prim_std_origin_shift),
+            mapping_std_prim: leak_slice(mapping_std_prim),
+            // Final parameters
+            symprec: dataset.symprec,
+            angle_tolerance,
+        }
+    }
+}
+
+/// Analyze the layer-group symmetry of the given cell and create a dataset.
+///
+/// - `basis`: row-wise basis vectors, `basis[i]` is the `i`th basis vector.
+///   The third basis vector must be the aperiodic stacking direction,
+///   perpendicular to the first two, which must lie in the xy-plane.
+/// - `positions`: fractional coordinates of the `num_atoms` sites.
+/// - `numbers`: atomic numbers of the `num_atoms` sites.
+/// - `angle_tolerance`: tolerance of angle between basis vectors in radians.
+///   Pass a negative value to use the default angle tolerance.
+/// - `hall_number`: preference for layer Hall symbol, only used with
+///   `MOYO_LAYER_SETTING_HALL_NUMBER`.
+/// - Returns NULL if the symmetry search fails or the arguments are invalid.
+///
+/// # Safety
+/// `basis` must point to 3 basis vectors, and `positions` and `numbers` must
+/// point to `num_atoms` elements each.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moyo_layer_dataset_new(
+    basis: *const [f64; 3],
+    positions: *const [f64; 3],
+    numbers: *const i32,
+    num_atoms: i32,
+    symprec: f64,
+    angle_tolerance: f64,
+    setting: MoyoLayerSetting,
+    hall_number: i32,
+    rotate_basis: bool,
+) -> *mut MoyoLayerDataset {
+    if basis.is_null() || positions.is_null() || numbers.is_null() || num_atoms <= 0 {
+        return std::ptr::null_mut();
+    }
+    let basis = unsafe { *(basis as *const [[f64; 3]; 3]) };
+    let cell = MoyoCell {
+        basis,
+        positions,
+        numbers,
+        num_atoms,
+    };
+    let cell: Cell = (&cell).into();
+
+    let angle_tolerance = if angle_tolerance < 0.0 {
+        AngleTolerance::default()
+    } else {
+        AngleTolerance::Radian(angle_tolerance)
+    };
+    let setting = match setting {
+        MoyoLayerSetting::HallNumber => {
+            if hall_number <= 0 {
+                return std::ptr::null_mut();
+            }
+            LayerSetting::HallNumber(hall_number)
+        }
+        MoyoLayerSetting::Spglib => LayerSetting::Spglib,
+        MoyoLayerSetting::Standard => LayerSetting::Standard,
+    };
+
+    let dataset = LayerDataset::new(&cell, symprec, angle_tolerance, setting, rotate_basis);
+    match dataset {
+        Ok(dataset) => Box::into_raw(Box::new(MoyoLayerDataset::new(dataset, num_atoms))),
+        Err(_) => std::ptr::null_mut(),
+    }
+}
+
+/// Free a dataset created by `moyo_layer_dataset_new`. Passing NULL is a no-op.
+///
+/// # Safety
+/// `dataset` must be a pointer returned by `moyo_layer_dataset_new` that has
+/// not been freed yet, or NULL.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moyo_layer_dataset_free(dataset: *mut MoyoLayerDataset) {
+    if dataset.is_null() {
+        return;
+    }
+    unsafe {
+        let dataset = Box::from_raw(dataset);
+        let num_atoms = dataset.num_atoms as usize;
+
+        // Identification
+        free_cstring(dataset.hm_symbol);
+
+        // Symmetry operations in the input cell
+        moyo_operations_free_members(&dataset.operations);
+
+        // Site symmetry
+        free_slice(dataset.orbits, num_atoms);
+        free_cstring(dataset.wyckoffs);
+        if !dataset.site_symmetry_symbols.is_null() {
+            let site_symmetry_symbols =
+                std::slice::from_raw_parts(dataset.site_symmetry_symbols, num_atoms);
+            for &s in site_symmetry_symbols {
+                free_cstring(s);
+            }
+            free_slice(dataset.site_symmetry_symbols, num_atoms);
+        }
+
+        // Standardized layer cell
+        moyo_cell_free_members(&dataset.std_cell);
+        free_cstring(dataset.pearson_symbol);
+
+        // Primitive standardized layer cell
+        moyo_cell_free_members(&dataset.prim_std_cell);
+        free_slice(dataset.mapping_std_prim, num_atoms);
+    }
+}

--- a/moyoc/src/lib.rs
+++ b/moyoc/src/lib.rs
@@ -12,12 +12,12 @@ pub use base::{
     MoyoCell, MoyoCollinearMagneticCell, MoyoMagneticOperations, MoyoNonCollinearMagneticCell,
     MoyoOperations,
 };
-pub use data::MoyoSetting;
+pub use data::{MoyoLayerSetting, MoyoSetting};
 pub use dataset::{
-    MoyoCollinearMagneticDataset, MoyoDataset, MoyoNonCollinearMagneticDataset,
+    MoyoCollinearMagneticDataset, MoyoDataset, MoyoLayerDataset, MoyoNonCollinearMagneticDataset,
     moyo_collinear_magnetic_dataset_free, moyo_collinear_magnetic_dataset_new, moyo_dataset_free,
-    moyo_dataset_new, moyo_noncollinear_magnetic_dataset_free,
-    moyo_noncollinear_magnetic_dataset_new,
+    moyo_dataset_new, moyo_layer_dataset_free, moyo_layer_dataset_new,
+    moyo_noncollinear_magnetic_dataset_free, moyo_noncollinear_magnetic_dataset_new,
 };
 
 /// Return the version string of moyoc (e.g. "0.11.0").

--- a/moyoc/tests/CMakeLists.txt
+++ b/moyoc/tests/CMakeLists.txt
@@ -17,4 +17,5 @@ function(add_moyoc_test name)
 endfunction()
 
 add_moyoc_test(test_moyoc_dataset)
+add_moyoc_test(test_moyoc_layer_dataset)
 add_moyoc_test(test_moyoc_magnetic_dataset)

--- a/moyoc/tests/test_moyoc_layer_dataset.c
+++ b/moyoc/tests/test_moyoc_layer_dataset.c
@@ -1,0 +1,122 @@
+#include <assert.h>
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "moyoc.h"
+
+// LG 61 (p4/mmm): square in-plane lattice with a single atom at (0, 0, z)
+void test_p4_per_mmm(void) {
+    double basis[3][3] = {
+        {1.0, 0.0, 0.0},
+        {0.0, 1.0, 0.0},
+        {0.0, 0.0, 5.0},
+    };
+    double positions[][3] = {
+        {0.0, 0.0, 0.1},
+    };
+    int32_t numbers[] = {1};
+    int32_t num_atoms = 1;
+
+    double symprec = 1e-4;
+    double angle_tolerance = -1;
+    MoyoLayerSetting setting = MOYO_LAYER_SETTING_STANDARD;
+    int32_t hall_number = -1;
+    bool rotate_basis = true;
+
+    MoyoLayerDataset *dataset = moyo_layer_dataset_new(
+        basis, positions, numbers, num_atoms,
+        symprec, angle_tolerance, setting, hall_number, rotate_basis
+    );
+    assert(dataset != NULL);
+
+    // Identification
+    printf("dataset->number: %d\n", dataset->number);
+    printf("dataset->hall_number: %d\n", dataset->hall_number);
+    printf("dataset->hm_symbol: %s\n", dataset->hm_symbol);
+    assert(dataset->number == 61);
+
+    // Input cell
+    assert(dataset->num_atoms == num_atoms);
+
+    // Symmetry operations in the input cell
+    printf("dataset->operations.num_operations: %d\n",
+           dataset->operations.num_operations);
+    assert(dataset->operations.num_operations == 16);
+
+    // Site symmetry
+    assert(dataset->orbits[0] == 0);
+    printf("dataset->wyckoffs: %s\n", dataset->wyckoffs);
+    assert(dataset->wyckoffs[0] == 'a');
+    printf("dataset->site_symmetry_symbols[0]: %s\n",
+           dataset->site_symmetry_symbols[0]);
+    assert(strstr(dataset->site_symmetry_symbols[0], "4/mmm") != NULL);
+
+    // Standardized layer cell: square with c along z
+    assert(dataset->std_cell.num_atoms == 1);
+    double a = 0.0;
+    double b = 0.0;
+    for (int i = 0; i < 3; i++) {
+        a += dataset->std_cell.basis[0][i] * dataset->std_cell.basis[0][i];
+        b += dataset->std_cell.basis[1][i] * dataset->std_cell.basis[1][i];
+    }
+    assert(fabs(sqrt(a) - sqrt(b)) < 1e-8);
+    printf("dataset->pearson_symbol: %s\n", dataset->pearson_symbol);
+    assert(strcmp(dataset->pearson_symbol, "tp1") == 0);
+
+    // Primitive standardized layer cell
+    assert(dataset->prim_std_cell.num_atoms == 1);
+    assert(dataset->mapping_std_prim[0] == 0);
+
+    moyo_layer_dataset_free(dataset);
+}
+
+// LG 2 (p-1): triclinic-oblique with two atoms at inversion-related positions
+void test_p_minus_1(void) {
+    double gamma = 80.0 * M_PI / 180.0;
+    double a = 1.0;
+    double b = 1.5;
+    double basis[3][3] = {
+        {a, 0.0, 0.0},
+        {b * cos(gamma), b * sin(gamma), 0.0},
+        {0.0, 0.0, 5.0},
+    };
+    double positions[][3] = {
+        {0.1, 0.2, 0.1},
+        {0.3, 0.5, 0.2},
+    };
+    int32_t numbers[] = {1, 1};
+    int32_t num_atoms = 2;
+
+    double symprec = 1e-4;
+    double angle_tolerance = -1;
+    MoyoLayerSetting setting = MOYO_LAYER_SETTING_STANDARD;
+    int32_t hall_number = -1;
+    bool rotate_basis = true;
+
+    MoyoLayerDataset *dataset = moyo_layer_dataset_new(
+        basis, positions, numbers, num_atoms,
+        symprec, angle_tolerance, setting, hall_number, rotate_basis
+    );
+    assert(dataset != NULL);
+
+    printf("dataset->number: %d\n", dataset->number);
+    printf("dataset->hall_number: %d\n", dataset->hall_number);
+    assert(dataset->number == 2);
+    assert(dataset->hall_number == 2);
+    assert(dataset->operations.num_operations == 2);
+    assert(dataset->orbits[0] == 0);
+    assert(dataset->orbits[1] == 0);
+    printf("dataset->wyckoffs: %s\n", dataset->wyckoffs);
+    assert(strcmp(dataset->wyckoffs, "ee") == 0);
+    printf("dataset->pearson_symbol: %s\n", dataset->pearson_symbol);
+    assert(strcmp(dataset->pearson_symbol, "mp2") == 0);
+
+    moyo_layer_dataset_free(dataset);
+}
+
+int main(void) {
+    test_p4_per_mmm();
+    test_p_minus_1();
+    return 0;
+}


### PR DESCRIPTION
## Summary

Second chunk of completing the moyoc C API (now based directly on `main` after #355 merged).

Adds layer-group symmetry analysis:

- `moyo_layer_dataset_new` / `moyo_layer_dataset_free` exposing `MoyoLayerDataset` (layer group number 1-80, layer Hall number 1-116, HM symbol, operations, orbits/Wyckoffs/site symmetry, standardized + primitive standardized cells, transformations, Pearson symbol)
- `MoyoLayerSetting` enum (`HALL_NUMBER` / `SPGLIB` / `STANDARD`) mirroring `MoyoSetting`
- Same argument conventions as `moyo_dataset_new`; the standardized `LayerCell`s are re-packed as `MoyoCell` at the C boundary (same bridge moyopy uses)

Also removes the `branches: [main]` filter from the `pull_request` triggers in the CI/Check workflows so the stacked follow-up PRs (#357, #358, #359) actually run tests.

## Test plan

- [x] `cargo test -p moyoc`, `cargo clippy -p moyoc --all-targets` clean
- [x] `ctest` passes under ASan: LG 61 p4/mmm (16 operations, Wyckoff `a`, site symmetry 4/mmm, Pearson `tp1`, square std cell) and LG 2 p-1 (2 operations, orbit collapse, Pearson `mp2`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
