### PR TITLE
Add group-type metadata lookups to moyoc

### DIFF
--- a/moyoc/README.md
+++ b/moyoc/README.md
@@ -95,4 +95,21 @@ moyo_operations_free(layer_operations);
 MoyoMagneticOperations *magnetic_operations =
     moyo_magnetic_operations_from_uni_number(uni_number, primitive);
 moyo_magnetic_operations_free(magnetic_operations);
+
+// Group-type metadata lookups
+MoyoHallSymbolEntry *entry = moyo_hall_symbol_entry_new(hall_number);
+moyo_hall_symbol_entry_free(entry);
+
+MoyoLayerHallSymbolEntry *layer_entry = moyo_layer_hall_symbol_entry_new(layer_hall_number);
+moyo_layer_hall_symbol_entry_free(layer_entry);
+
+MoyoSpaceGroupType *space_group_type = moyo_space_group_type_new(number);
+moyo_space_group_type_free(space_group_type);
+
+MoyoLayerGroupType *layer_group_type = moyo_layer_group_type_new(layer_number);
+moyo_layer_group_type_free(layer_group_type);
+
+MoyoMagneticSpaceGroupType *magnetic_space_group_type =
+    moyo_magnetic_space_group_type_new(uni_number);
+moyo_magnetic_space_group_type_free(magnetic_space_group_type);
 ```

--- a/moyoc/src/data.rs
+++ b/moyoc/src/data.rs
@@ -1,8 +1,24 @@
+mod group_type;
+mod hall_symbol;
 mod layer_setting;
+mod magnetic_space_group_type;
 mod operations;
 mod setting;
 
+pub use group_type::{
+    MoyoLayerGroupType, MoyoSpaceGroupType, moyo_layer_group_type_free, moyo_layer_group_type_new,
+    moyo_space_group_type_free, moyo_space_group_type_new,
+};
+pub use hall_symbol::{
+    MoyoHallSymbolEntry, MoyoLayerHallSymbolEntry, moyo_hall_symbol_entry_free,
+    moyo_hall_symbol_entry_new, moyo_layer_hall_symbol_entry_free,
+    moyo_layer_hall_symbol_entry_new,
+};
 pub use layer_setting::MoyoLayerSetting;
+pub use magnetic_space_group_type::{
+    MoyoMagneticSpaceGroupType, moyo_magnetic_space_group_type_free,
+    moyo_magnetic_space_group_type_new,
+};
 pub use operations::{
     moyo_magnetic_operations_free, moyo_magnetic_operations_from_uni_number, moyo_operations_free,
     moyo_operations_from_layer_number, moyo_operations_from_number,

--- a/moyoc/src/data/group_type.rs
+++ b/moyoc/src/data/group_type.rs
@@ -39,6 +39,11 @@ pub struct MoyoSpaceGroupType {
 /// Returns NULL if `number` is out of range.
 #[unsafe(no_mangle)]
 pub extern "C" fn moyo_space_group_type_new(number: i32) -> *mut MoyoSpaceGroupType {
+    // Reject lower-bound invalid numbers here: moyo indexes the database with
+    // `number - 1`, which overflows for extreme negative values.
+    if number < 1 {
+        return std::ptr::null_mut();
+    }
     let Some(hall_number) = Setting::default().hall_number(number) else {
         return std::ptr::null_mut();
     };
@@ -117,6 +122,9 @@ pub struct MoyoLayerGroupType {
 /// Returns NULL if `number` is out of range.
 #[unsafe(no_mangle)]
 pub extern "C" fn moyo_layer_group_type_new(number: i32) -> *mut MoyoLayerGroupType {
+    if number < 1 {
+        return std::ptr::null_mut();
+    }
     let Some(hall_number) = LayerSetting::default().hall_number(number) else {
         return std::ptr::null_mut();
     };

--- a/moyoc/src/data/group_type.rs
+++ b/moyoc/src/data/group_type.rs
@@ -1,0 +1,163 @@
+use core::ffi::c_char;
+
+use moyo::data::{
+    CrystalFamily, CrystalSystem, LatticeSystem, LayerSetting, Setting,
+    arithmetic_crystal_class_entry, hall_symbol_entry, layer_arithmetic_crystal_class_entry,
+    layer_hall_symbol_entry,
+};
+
+use crate::ffi::{free_cstring, leak_cstring};
+
+/// Space-group type information, created by `moyo_space_group_type_new` and
+/// freed by `moyo_space_group_type_free`.
+#[derive(Debug, Clone)]
+#[repr(C)]
+pub struct MoyoSpaceGroupType {
+    /// ITA number for space group types (1 - 230).
+    pub number: i32,
+    /// Hermann-Mauguin symbol in short notation.
+    pub hm_short: *const c_char,
+    /// Hermann-Mauguin symbol in full notation.
+    pub hm_full: *const c_char,
+    /// Number for arithmetic crystal classes (1 - 73).
+    pub arithmetic_number: i32,
+    /// Symbol for arithmetic crystal class.
+    pub arithmetic_symbol: *const c_char,
+    /// Geometric crystal class.
+    pub geometric_crystal_class: *const c_char,
+    /// Crystal system.
+    pub crystal_system: *const c_char,
+    /// Bravais class.
+    pub bravais_class: *const c_char,
+    /// Lattice system.
+    pub lattice_system: *const c_char,
+    /// Crystal family.
+    pub crystal_family: *const c_char,
+}
+
+/// Look up the space-group type information for ITA `number` (1 - 230).
+/// Returns NULL if `number` is out of range.
+#[unsafe(no_mangle)]
+pub extern "C" fn moyo_space_group_type_new(number: i32) -> *mut MoyoSpaceGroupType {
+    let Some(hall_number) = Setting::default().hall_number(number) else {
+        return std::ptr::null_mut();
+    };
+    let hall_symbol = hall_symbol_entry(hall_number).unwrap();
+    let arithmetic_entry = arithmetic_crystal_class_entry(hall_symbol.arithmetic_number).unwrap();
+
+    let geometric_crystal_class = arithmetic_entry.geometric_crystal_class;
+    let crystal_system = CrystalSystem::from_geometric_crystal_class(geometric_crystal_class);
+    let bravais_class = arithmetic_entry.bravais_class;
+    let lattice_system = LatticeSystem::from_bravais_class(bravais_class);
+    let crystal_family = CrystalFamily::from_lattice_system(lattice_system);
+
+    Box::into_raw(Box::new(MoyoSpaceGroupType {
+        number,
+        hm_short: leak_cstring(hall_symbol.hm_short.to_string()),
+        hm_full: leak_cstring(hall_symbol.hm_full.to_string()),
+        arithmetic_number: hall_symbol.arithmetic_number,
+        arithmetic_symbol: leak_cstring(arithmetic_entry.symbol.to_string()),
+        geometric_crystal_class: leak_cstring(geometric_crystal_class.to_string()),
+        crystal_system: leak_cstring(crystal_system.to_string()),
+        bravais_class: leak_cstring(bravais_class.to_string()),
+        lattice_system: leak_cstring(lattice_system.to_string()),
+        crystal_family: leak_cstring(crystal_family.to_string()),
+    }))
+}
+
+/// Free a space-group type created by `moyo_space_group_type_new`.
+/// Passing NULL is a no-op.
+///
+/// # Safety
+/// `space_group_type` must be a pointer returned by `moyo_space_group_type_new`
+/// that has not been freed yet, or NULL.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moyo_space_group_type_free(space_group_type: *mut MoyoSpaceGroupType) {
+    if space_group_type.is_null() {
+        return;
+    }
+    unsafe {
+        let space_group_type = Box::from_raw(space_group_type);
+        free_cstring(space_group_type.hm_short);
+        free_cstring(space_group_type.hm_full);
+        free_cstring(space_group_type.arithmetic_symbol);
+        free_cstring(space_group_type.geometric_crystal_class);
+        free_cstring(space_group_type.crystal_system);
+        free_cstring(space_group_type.bravais_class);
+        free_cstring(space_group_type.lattice_system);
+        free_cstring(space_group_type.crystal_family);
+    }
+}
+
+/// Layer-group type information, created by `moyo_layer_group_type_new` and
+/// freed by `moyo_layer_group_type_free`.
+#[derive(Debug, Clone)]
+#[repr(C)]
+pub struct MoyoLayerGroupType {
+    /// Layer-group number (1 - 80).
+    pub number: i32,
+    /// Hermann-Mauguin symbol in short notation.
+    pub hm_short: *const c_char,
+    /// Hermann-Mauguin symbol in full notation.
+    pub hm_full: *const c_char,
+    /// Number for layer arithmetic crystal classes (1 - 43).
+    pub arithmetic_number: i32,
+    /// Symbol for the layer arithmetic crystal class.
+    pub arithmetic_symbol: *const c_char,
+    /// Geometric crystal class. Cubic classes never occur for layer groups.
+    pub geometric_crystal_class: *const c_char,
+    /// Bravais class for the layer group's 2D lattice
+    /// ("mp", "op", "oc", "tp", or "hp").
+    pub bravais_class: *const c_char,
+    /// Lattice system ("Oblique", "Rectangular", "Square", or "Hexagonal").
+    pub lattice_system: *const c_char,
+}
+
+/// Look up the layer-group type information for layer-group `number` (1 - 80).
+/// Returns NULL if `number` is out of range.
+#[unsafe(no_mangle)]
+pub extern "C" fn moyo_layer_group_type_new(number: i32) -> *mut MoyoLayerGroupType {
+    let Some(hall_number) = LayerSetting::default().hall_number(number) else {
+        return std::ptr::null_mut();
+    };
+    let Some(lhs_entry) = layer_hall_symbol_entry(hall_number) else {
+        return std::ptr::null_mut();
+    };
+    let Some(acc_entry) = layer_arithmetic_crystal_class_entry(lhs_entry.arithmetic_number) else {
+        return std::ptr::null_mut();
+    };
+    let lattice_system = acc_entry.layer_lattice_system();
+
+    Box::into_raw(Box::new(MoyoLayerGroupType {
+        number,
+        hm_short: leak_cstring(lhs_entry.hm_short.to_string()),
+        hm_full: leak_cstring(lhs_entry.hm_full.to_string()),
+        arithmetic_number: lhs_entry.arithmetic_number,
+        arithmetic_symbol: leak_cstring(acc_entry.symbol.to_string()),
+        geometric_crystal_class: leak_cstring(acc_entry.geometric_crystal_class.to_string()),
+        bravais_class: leak_cstring(acc_entry.layer_bravais_class.to_string()),
+        lattice_system: leak_cstring(lattice_system.to_string()),
+    }))
+}
+
+/// Free a layer-group type created by `moyo_layer_group_type_new`.
+/// Passing NULL is a no-op.
+///
+/// # Safety
+/// `layer_group_type` must be a pointer returned by `moyo_layer_group_type_new`
+/// that has not been freed yet, or NULL.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moyo_layer_group_type_free(layer_group_type: *mut MoyoLayerGroupType) {
+    if layer_group_type.is_null() {
+        return;
+    }
+    unsafe {
+        let layer_group_type = Box::from_raw(layer_group_type);
+        free_cstring(layer_group_type.hm_short);
+        free_cstring(layer_group_type.hm_full);
+        free_cstring(layer_group_type.arithmetic_symbol);
+        free_cstring(layer_group_type.geometric_crystal_class);
+        free_cstring(layer_group_type.bravais_class);
+        free_cstring(layer_group_type.lattice_system);
+    }
+}

--- a/moyoc/src/data/hall_symbol.rs
+++ b/moyoc/src/data/hall_symbol.rs
@@ -1,0 +1,133 @@
+use core::ffi::c_char;
+
+use moyo::data::{hall_symbol_entry, layer_hall_symbol_entry};
+
+use crate::ffi::{free_cstring, leak_cstring};
+
+/// An entry containing space-group information for a specified Hall number,
+/// created by `moyo_hall_symbol_entry_new` and freed by
+/// `moyo_hall_symbol_entry_free`.
+#[derive(Debug, Clone)]
+#[repr(C)]
+pub struct MoyoHallSymbolEntry {
+    /// Number for Hall symbols (1 - 530).
+    pub hall_number: i32,
+    /// ITA number for space group types (1 - 230).
+    pub number: i32,
+    /// Number for arithmetic crystal classes (1 - 73).
+    pub arithmetic_number: i32,
+    /// Setting.
+    pub setting: *const c_char,
+    /// Hall symbol.
+    pub hall_symbol: *const c_char,
+    /// Hermann-Mauguin symbol in short notation.
+    pub hm_short: *const c_char,
+    /// Hermann-Mauguin symbol in full notation.
+    pub hm_full: *const c_char,
+    /// Centering symbol ("P", "A", "B", "C", "I", "R", or "F").
+    pub centering: *const c_char,
+}
+
+/// Look up the space-group Hall symbol entry for `hall_number` (1 - 530).
+/// Returns NULL if `hall_number` is out of range.
+#[unsafe(no_mangle)]
+pub extern "C" fn moyo_hall_symbol_entry_new(hall_number: i32) -> *mut MoyoHallSymbolEntry {
+    match hall_symbol_entry(hall_number) {
+        Some(entry) => Box::into_raw(Box::new(MoyoHallSymbolEntry {
+            hall_number: entry.hall_number,
+            number: entry.number,
+            arithmetic_number: entry.arithmetic_number,
+            setting: leak_cstring(entry.setting.to_string()),
+            hall_symbol: leak_cstring(entry.hall_symbol.to_string()),
+            hm_short: leak_cstring(entry.hm_short.to_string()),
+            hm_full: leak_cstring(entry.hm_full.to_string()),
+            centering: leak_cstring(format!("{:?}", entry.centering)),
+        })),
+        None => std::ptr::null_mut(),
+    }
+}
+
+/// Free an entry created by `moyo_hall_symbol_entry_new`. Passing NULL is a no-op.
+///
+/// # Safety
+/// `entry` must be a pointer returned by `moyo_hall_symbol_entry_new` that has
+/// not been freed yet, or NULL.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moyo_hall_symbol_entry_free(entry: *mut MoyoHallSymbolEntry) {
+    if entry.is_null() {
+        return;
+    }
+    unsafe {
+        let entry = Box::from_raw(entry);
+        free_cstring(entry.setting);
+        free_cstring(entry.hall_symbol);
+        free_cstring(entry.hm_short);
+        free_cstring(entry.hm_full);
+        free_cstring(entry.centering);
+    }
+}
+
+/// An entry containing layer-group information for a specified layer Hall
+/// number, created by `moyo_layer_hall_symbol_entry_new` and freed by
+/// `moyo_layer_hall_symbol_entry_free`.
+#[derive(Debug, Clone)]
+#[repr(C)]
+pub struct MoyoLayerHallSymbolEntry {
+    /// Number for layer Hall symbols (1 - 116).
+    pub hall_number: i32,
+    /// Layer-group number (1 - 80).
+    pub number: i32,
+    /// Number for layer arithmetic crystal classes (1 - 43).
+    pub arithmetic_number: i32,
+    /// Setting.
+    pub setting: *const c_char,
+    /// Hall symbol with lowercase `p`/`c` lattice prefix (layer convention).
+    pub hall_symbol: *const c_char,
+    /// Hermann-Mauguin symbol in short notation.
+    pub hm_short: *const c_char,
+    /// Hermann-Mauguin symbol in full notation.
+    pub hm_full: *const c_char,
+    /// Layer centering symbol ("P" or "C").
+    pub centering: *const c_char,
+}
+
+/// Look up the layer-group Hall symbol entry for `hall_number` (1 - 116).
+/// Returns NULL if `hall_number` is out of range.
+#[unsafe(no_mangle)]
+pub extern "C" fn moyo_layer_hall_symbol_entry_new(
+    hall_number: i32,
+) -> *mut MoyoLayerHallSymbolEntry {
+    match layer_hall_symbol_entry(hall_number) {
+        Some(entry) => Box::into_raw(Box::new(MoyoLayerHallSymbolEntry {
+            hall_number: entry.hall_number,
+            number: entry.number,
+            arithmetic_number: entry.arithmetic_number,
+            setting: leak_cstring(entry.setting.to_string()),
+            hall_symbol: leak_cstring(entry.hall_symbol.to_string()),
+            hm_short: leak_cstring(entry.hm_short.to_string()),
+            hm_full: leak_cstring(entry.hm_full.to_string()),
+            centering: leak_cstring(format!("{:?}", entry.centering)),
+        })),
+        None => std::ptr::null_mut(),
+    }
+}
+
+/// Free an entry created by `moyo_layer_hall_symbol_entry_new`. Passing NULL is a no-op.
+///
+/// # Safety
+/// `entry` must be a pointer returned by `moyo_layer_hall_symbol_entry_new`
+/// that has not been freed yet, or NULL.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moyo_layer_hall_symbol_entry_free(entry: *mut MoyoLayerHallSymbolEntry) {
+    if entry.is_null() {
+        return;
+    }
+    unsafe {
+        let entry = Box::from_raw(entry);
+        free_cstring(entry.setting);
+        free_cstring(entry.hall_symbol);
+        free_cstring(entry.hm_short);
+        free_cstring(entry.hm_full);
+        free_cstring(entry.centering);
+    }
+}

--- a/moyoc/src/data/hall_symbol.rs
+++ b/moyoc/src/data/hall_symbol.rs
@@ -32,6 +32,11 @@ pub struct MoyoHallSymbolEntry {
 /// Returns NULL if `hall_number` is out of range.
 #[unsafe(no_mangle)]
 pub extern "C" fn moyo_hall_symbol_entry_new(hall_number: i32) -> *mut MoyoHallSymbolEntry {
+    // Reject lower-bound invalid numbers here: moyo indexes the database with
+    // `hall_number - 1`, which overflows for extreme negative values.
+    if hall_number < 1 {
+        return std::ptr::null_mut();
+    }
     match hall_symbol_entry(hall_number) {
         Some(entry) => Box::into_raw(Box::new(MoyoHallSymbolEntry {
             hall_number: entry.hall_number,
@@ -97,6 +102,9 @@ pub struct MoyoLayerHallSymbolEntry {
 pub extern "C" fn moyo_layer_hall_symbol_entry_new(
     hall_number: i32,
 ) -> *mut MoyoLayerHallSymbolEntry {
+    if hall_number < 1 {
+        return std::ptr::null_mut();
+    }
     match layer_hall_symbol_entry(hall_number) {
         Some(entry) => Box::into_raw(Box::new(MoyoLayerHallSymbolEntry {
             hall_number: entry.hall_number,

--- a/moyoc/src/data/magnetic_space_group_type.rs
+++ b/moyoc/src/data/magnetic_space_group_type.rs
@@ -1,0 +1,72 @@
+use core::ffi::c_char;
+
+use moyo::data::{ConstructType, get_magnetic_space_group_type};
+
+use crate::ffi::{free_cstring, leak_cstring};
+
+/// Magnetic space-group type information, created by
+/// `moyo_magnetic_space_group_type_new` and freed by
+/// `moyo_magnetic_space_group_type_free`.
+#[derive(Debug, Clone)]
+#[repr(C)]
+pub struct MoyoMagneticSpaceGroupType {
+    /// Serial number of UNI (and BNS) symbols (1 - 1651).
+    pub uni_number: i32,
+    /// Serial number in Litvin's Magnetic group tables.
+    pub litvin_number: i32,
+    /// BNS number, e.g. "151.32".
+    pub bns_number: *const c_char,
+    /// OG number, e.g. "153.4.1270".
+    pub og_number: *const c_char,
+    /// ITA number for the reference space group in BNS setting.
+    pub number: i32,
+    /// Construct type of the magnetic space group, from 1 to 4.
+    pub construct_type: i32,
+}
+
+/// Look up the magnetic space-group type information for `uni_number` (1 - 1651).
+/// Returns NULL if `uni_number` is out of range.
+#[unsafe(no_mangle)]
+pub extern "C" fn moyo_magnetic_space_group_type_new(
+    uni_number: i32,
+) -> *mut MoyoMagneticSpaceGroupType {
+    match get_magnetic_space_group_type(uni_number) {
+        Some(magnetic_space_group_type) => {
+            let construct_type = match magnetic_space_group_type.construct_type {
+                ConstructType::Type1 => 1,
+                ConstructType::Type2 => 2,
+                ConstructType::Type3 => 3,
+                ConstructType::Type4 => 4,
+            };
+            Box::into_raw(Box::new(MoyoMagneticSpaceGroupType {
+                uni_number: magnetic_space_group_type.uni_number,
+                litvin_number: magnetic_space_group_type.litvin_number,
+                bns_number: leak_cstring(magnetic_space_group_type.bns_number.to_string()),
+                og_number: leak_cstring(magnetic_space_group_type.og_number.to_string()),
+                number: magnetic_space_group_type.number,
+                construct_type,
+            }))
+        }
+        None => std::ptr::null_mut(),
+    }
+}
+
+/// Free a magnetic space-group type created by `moyo_magnetic_space_group_type_new`.
+/// Passing NULL is a no-op.
+///
+/// # Safety
+/// `magnetic_space_group_type` must be a pointer returned by
+/// `moyo_magnetic_space_group_type_new` that has not been freed yet, or NULL.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moyo_magnetic_space_group_type_free(
+    magnetic_space_group_type: *mut MoyoMagneticSpaceGroupType,
+) {
+    if magnetic_space_group_type.is_null() {
+        return;
+    }
+    unsafe {
+        let magnetic_space_group_type = Box::from_raw(magnetic_space_group_type);
+        free_cstring(magnetic_space_group_type.bns_number);
+        free_cstring(magnetic_space_group_type.og_number);
+    }
+}

--- a/moyoc/src/data/magnetic_space_group_type.rs
+++ b/moyoc/src/data/magnetic_space_group_type.rs
@@ -30,6 +30,11 @@ pub struct MoyoMagneticSpaceGroupType {
 pub extern "C" fn moyo_magnetic_space_group_type_new(
     uni_number: i32,
 ) -> *mut MoyoMagneticSpaceGroupType {
+    // Reject lower-bound invalid numbers here: moyo indexes the database with
+    // `uni_number - 1`, which overflows for extreme negative values.
+    if uni_number < 1 {
+        return std::ptr::null_mut();
+    }
     match get_magnetic_space_group_type(uni_number) {
         Some(magnetic_space_group_type) => {
             let construct_type = match magnetic_space_group_type.construct_type {

--- a/moyoc/src/lib.rs
+++ b/moyoc/src/lib.rs
@@ -13,9 +13,14 @@ pub use base::{
     MoyoOperations,
 };
 pub use data::{
-    MoyoLayerSetting, MoyoSetting, moyo_magnetic_operations_free,
-    moyo_magnetic_operations_from_uni_number, moyo_operations_free,
-    moyo_operations_from_layer_number, moyo_operations_from_number,
+    MoyoHallSymbolEntry, MoyoLayerGroupType, MoyoLayerHallSymbolEntry, MoyoLayerSetting,
+    MoyoMagneticSpaceGroupType, MoyoSetting, MoyoSpaceGroupType, moyo_hall_symbol_entry_free,
+    moyo_hall_symbol_entry_new, moyo_layer_group_type_free, moyo_layer_group_type_new,
+    moyo_layer_hall_symbol_entry_free, moyo_layer_hall_symbol_entry_new,
+    moyo_magnetic_operations_free, moyo_magnetic_operations_from_uni_number,
+    moyo_magnetic_space_group_type_free, moyo_magnetic_space_group_type_new, moyo_operations_free,
+    moyo_operations_from_layer_number, moyo_operations_from_number, moyo_space_group_type_free,
+    moyo_space_group_type_new,
 };
 pub use dataset::{
     MoyoCollinearMagneticDataset, MoyoDataset, MoyoLayerDataset, MoyoNonCollinearMagneticDataset,

--- a/moyoc/tests/CMakeLists.txt
+++ b/moyoc/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ function(add_moyoc_test name)
     add_test(NAME ${name} COMMAND ${name})
 endfunction()
 
+add_moyoc_test(test_moyoc_data_entries)
 add_moyoc_test(test_moyoc_dataset)
 add_moyoc_test(test_moyoc_layer_dataset)
 add_moyoc_test(test_moyoc_magnetic_dataset)

--- a/moyoc/tests/test_moyoc_data_entries.c
+++ b/moyoc/tests/test_moyoc_data_entries.c
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -26,6 +27,7 @@ void test_hall_symbol_entry(void) {
     moyo_hall_symbol_entry_free(last_entry);
 
     assert(moyo_hall_symbol_entry_new(0) == NULL);
+    assert(moyo_hall_symbol_entry_new(INT32_MIN) == NULL);
     assert(moyo_hall_symbol_entry_new(531) == NULL);
 }
 
@@ -40,6 +42,7 @@ void test_layer_hall_symbol_entry(void) {
     moyo_layer_hall_symbol_entry_free(entry);
 
     assert(moyo_layer_hall_symbol_entry_new(0) == NULL);
+    assert(moyo_layer_hall_symbol_entry_new(INT32_MIN) == NULL);
     assert(moyo_layer_hall_symbol_entry_new(117) == NULL);
 }
 
@@ -62,6 +65,7 @@ void test_space_group_type(void) {
     moyo_space_group_type_free(space_group_type);
 
     assert(moyo_space_group_type_new(0) == NULL);
+    assert(moyo_space_group_type_new(INT32_MIN) == NULL);
     assert(moyo_space_group_type_new(231) == NULL);
 }
 
@@ -81,6 +85,7 @@ void test_layer_group_type(void) {
     moyo_layer_group_type_free(layer_group_type);
 
     assert(moyo_layer_group_type_new(0) == NULL);
+    assert(moyo_layer_group_type_new(INT32_MIN) == NULL);
     assert(moyo_layer_group_type_new(81) == NULL);
 }
 
@@ -101,6 +106,7 @@ void test_magnetic_space_group_type(void) {
     moyo_magnetic_space_group_type_free(magnetic_space_group_type);
 
     assert(moyo_magnetic_space_group_type_new(0) == NULL);
+    assert(moyo_magnetic_space_group_type_new(INT32_MIN) == NULL);
     assert(moyo_magnetic_space_group_type_new(1652) == NULL);
 }
 

--- a/moyoc/tests/test_moyoc_data_entries.c
+++ b/moyoc/tests/test_moyoc_data_entries.c
@@ -1,0 +1,114 @@
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "moyoc.h"
+
+void test_hall_symbol_entry(void) {
+    MoyoHallSymbolEntry *entry = moyo_hall_symbol_entry_new(1);
+    assert(entry != NULL);
+    printf("hall_number=%d number=%d hall_symbol=%s hm_short=%s centering=%s\n",
+           entry->hall_number, entry->number, entry->hall_symbol, entry->hm_short,
+           entry->centering);
+    assert(entry->hall_number == 1);
+    assert(entry->number == 1);
+    assert(entry->arithmetic_number == 1);
+    assert(strcmp(entry->hall_symbol, "P 1") == 0);
+    assert(strcmp(entry->hm_short, "P 1") == 0);
+    assert(strcmp(entry->centering, "P") == 0);
+    moyo_hall_symbol_entry_free(entry);
+
+    // Ia-3d (no. 230)
+    MoyoHallSymbolEntry *last_entry = moyo_hall_symbol_entry_new(530);
+    assert(last_entry != NULL);
+    assert(last_entry->number == 230);
+    assert(strcmp(last_entry->centering, "I") == 0);
+    moyo_hall_symbol_entry_free(last_entry);
+
+    assert(moyo_hall_symbol_entry_new(0) == NULL);
+    assert(moyo_hall_symbol_entry_new(531) == NULL);
+}
+
+void test_layer_hall_symbol_entry(void) {
+    MoyoLayerHallSymbolEntry *entry = moyo_layer_hall_symbol_entry_new(116);
+    assert(entry != NULL);
+    printf("layer hall_number=%d number=%d hm_short=%s centering=%s\n",
+           entry->hall_number, entry->number, entry->hm_short, entry->centering);
+    assert(entry->hall_number == 116);
+    assert(entry->number == 80);
+    assert(strcmp(entry->centering, "P") == 0);
+    moyo_layer_hall_symbol_entry_free(entry);
+
+    assert(moyo_layer_hall_symbol_entry_new(0) == NULL);
+    assert(moyo_layer_hall_symbol_entry_new(117) == NULL);
+}
+
+void test_space_group_type(void) {
+    // Ia-3d (no. 230)
+    MoyoSpaceGroupType *space_group_type = moyo_space_group_type_new(230);
+    assert(space_group_type != NULL);
+    printf("number=%d hm_short=%s geometric_crystal_class=%s crystal_system=%s "
+           "bravais_class=%s lattice_system=%s crystal_family=%s\n",
+           space_group_type->number, space_group_type->hm_short,
+           space_group_type->geometric_crystal_class, space_group_type->crystal_system,
+           space_group_type->bravais_class, space_group_type->lattice_system,
+           space_group_type->crystal_family);
+    assert(space_group_type->number == 230);
+    assert(strcmp(space_group_type->geometric_crystal_class, "m-3m") == 0);
+    assert(strcmp(space_group_type->crystal_system, "Cubic") == 0);
+    assert(strcmp(space_group_type->bravais_class, "cI") == 0);
+    assert(strcmp(space_group_type->lattice_system, "Cubic") == 0);
+    assert(strcmp(space_group_type->crystal_family, "Cubic") == 0);
+    moyo_space_group_type_free(space_group_type);
+
+    assert(moyo_space_group_type_new(0) == NULL);
+    assert(moyo_space_group_type_new(231) == NULL);
+}
+
+void test_layer_group_type(void) {
+    // LG 61 (p4/mmm)
+    MoyoLayerGroupType *layer_group_type = moyo_layer_group_type_new(61);
+    assert(layer_group_type != NULL);
+    printf("number=%d hm_short=%s geometric_crystal_class=%s bravais_class=%s "
+           "lattice_system=%s\n",
+           layer_group_type->number, layer_group_type->hm_short,
+           layer_group_type->geometric_crystal_class, layer_group_type->bravais_class,
+           layer_group_type->lattice_system);
+    assert(layer_group_type->number == 61);
+    assert(strcmp(layer_group_type->geometric_crystal_class, "4/mmm") == 0);
+    assert(strcmp(layer_group_type->bravais_class, "tp") == 0);
+    assert(strcmp(layer_group_type->lattice_system, "Square") == 0);
+    moyo_layer_group_type_free(layer_group_type);
+
+    assert(moyo_layer_group_type_new(0) == NULL);
+    assert(moyo_layer_group_type_new(81) == NULL);
+}
+
+void test_magnetic_space_group_type(void) {
+    // UNI 1242: R31'_c[R3] (BNS R_I3, 146.12)
+    MoyoMagneticSpaceGroupType *magnetic_space_group_type =
+        moyo_magnetic_space_group_type_new(1242);
+    assert(magnetic_space_group_type != NULL);
+    printf("uni_number=%d litvin_number=%d bns_number=%s og_number=%s number=%d "
+           "construct_type=%d\n",
+           magnetic_space_group_type->uni_number, magnetic_space_group_type->litvin_number,
+           magnetic_space_group_type->bns_number, magnetic_space_group_type->og_number,
+           magnetic_space_group_type->number, magnetic_space_group_type->construct_type);
+    assert(magnetic_space_group_type->uni_number == 1242);
+    assert(strcmp(magnetic_space_group_type->bns_number, "146.12") == 0);
+    assert(magnetic_space_group_type->number == 146);
+    assert(magnetic_space_group_type->construct_type == 4);
+    moyo_magnetic_space_group_type_free(magnetic_space_group_type);
+
+    assert(moyo_magnetic_space_group_type_new(0) == NULL);
+    assert(moyo_magnetic_space_group_type_new(1652) == NULL);
+}
+
+int main(void) {
+    test_hall_symbol_entry();
+    test_layer_hall_symbol_entry();
+    test_space_group_type();
+    test_layer_group_type();
+    test_magnetic_space_group_type();
+    return 0;
+}


### PR DESCRIPTION
## Summary

Fourth chunk of completing the moyoc C API. **Stacked on #357** (base branch `feat/moyoc-db-operations`); merge #356 and #357 first.

Adds the group-type metadata lookups (parity with moyopy's `HallSymbolEntry`, `LayerHallSymbolEntry`, `SpaceGroupType`, `LayerGroupType`, and `MagneticSpaceGroupType` classes):

- `moyo_hall_symbol_entry_new(hall_number)` -- Hall symbol database entry (1-530): ITA number, arithmetic number, setting, Hall/HM symbols, centering
- `moyo_layer_hall_symbol_entry_new(hall_number)` -- layer Hall symbol entry (1-116)
- `moyo_space_group_type_new(number)` -- space-group type info (1-230): HM symbols, arithmetic class, geometric crystal class, crystal system, Bravais class, lattice system, crystal family
- `moyo_layer_group_type_new(number)` -- layer-group type info (1-80)
- `moyo_magnetic_space_group_type_new(uni_number)` -- magnetic space-group type (1-1651): BNS/OG numbers, Litvin number, construct type
- Matching `*_free` functions; all lookups return NULL for out-of-range input, with lower-bound invalid numbers (`0`, negatives down to `INT32_MIN`) rejected at the C boundary before moyo's `number - 1` database indexing (roborev review follow-up)

Classification enums (centering, crystal system, Bravais class, ...) are exposed as their canonical string forms, matching what moyopy returns.

## Test plan

- [x] `cargo test -p moyoc`, `cargo clippy -p moyoc --all-targets` clean
- [x] `ctest` passes under ASan: Hall entries 1 (P 1) and 530 (no. 230, I centering), layer Hall entry 116 (LG 80), space-group type 230 (m-3m / Cubic / cI), layer-group type 61 (4/mmm / tp / Square), magnetic type UNI 1242 (BNS 146.12, construct type 4), NULL for out-of-range inputs including `0` and `INT32_MIN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
