### PR TITLE
Add Fortran interface to moyoc

### DIFF
--- a/.github/workflows/rw-c-tests.yaml
+++ b/.github/workflows/rw-c-tests.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Install cbindgen
         run: cargo binstall cbindgen --locked --no-confirm --force
       - name: Configure
-        run: cmake -S moyoc -B moyoc/build
+        run: cmake -S moyoc -B moyoc/build -DMOYOC_BUILD_FORTRAN=ON
       - name: Build
         run: cmake --build moyoc/build
       - name: Run tests

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A fast and robust crystal symmetry finder, written in Rust.
 - Rust support available via [crates.io](https://crates.io/crates/moyo): [Docs](https://docs.rs/moyo/latest/moyo/)
 - Python support available via [PyPI](https://pypi.org/project/moyopy/): [Docs](https://spglib.github.io/moyo/python/)
 - JavaScript and WebAssembly support available via [npm](https://www.npmjs.com/package/@spglib/moyo-wasm)
+- C and Fortran support available via CMake: [moyoc](moyoc/README.md)
 - Browse the 230 space groups, 80 layer groups, and 1651 magnetic space groups
   in the **moyo Crystallographic Group Viewer** at
   <https://spglib.github.io/moyo/> (static SPA powered by `moyo-wasm`).
@@ -29,6 +30,8 @@ A fast and robust crystal symmetry finder, written in Rust.
 - [Rust](moyo/README.md): core implementation
 - [Python](moyopy/README.md): Python binding
 - [C](moyoc/README.md): C binding
+- [Fortran](moyoc/README.md#fortran-interface): Fortran interface on top of the
+  C binding (optional `moyo::moyof` CMake target)
 - [JavaScript](moyo-wasm/README.md): JavaScript and WebAssembly binding
 - [Web viewer](apps/web/README.md): static Svelte + Vite + KaTeX SPA on top
   of `moyo-wasm`, deployed to GitHub Pages via
@@ -43,20 +46,21 @@ Legend: ✅ supported · 🟡 partial · ❌ not exposed · ➖ not applicable.
 | -------------------- | -------------------- | ------------- | ----------------- | ----------- | --------------------- |
 | Shared               | Core types           | ✅            | ✅                | 🟡          | 🟡                    |
 | Space group          | Dataset from cell    | ✅            | ✅                | ✅          | ✅                    |
-| Space group          | Data access          | ✅            | ✅                | ❌          | 🟡                    |
+| Space group          | Data access          | ✅            | ✅                | 🟡          | 🟡                    |
 | Space group          | Group identification | ✅            | ✅                | ❌          | ❌                    |
-| Layer group          | Dataset from cell    | ✅            | ✅                | ❌          | ❌                    |
-| Layer group          | Data access          | ✅            | ✅                | ❌          | 🟡                    |
+| Layer group          | Dataset from cell    | ✅            | ✅                | ✅          | ❌                    |
+| Layer group          | Data access          | ✅            | ✅                | 🟡          | 🟡                    |
 | Layer group          | Group identification | ✅            | ✅                | ❌          | ❌                    |
-| Magnetic space group | Dataset from cell    | ✅            | ✅                | ❌          | ❌                    |
-| Magnetic space group | Data access          | ✅            | ✅                | ❌          | 🟡                    |
+| Magnetic space group | Dataset from cell    | ✅            | ✅                | ✅          | ❌                    |
+| Magnetic space group | Data access          | ✅            | ✅                | ✅          | 🟡                    |
 | Magnetic space group | Group identification | ✅            | ✅                | ❌          | ❌                    |
 
 Notes:
 
-- Core types are `Cell`, `Operations`, and `UnimodularTransformation`. C and
-  WASM expose only `Cell` and (implicitly) `Operations` via the dataset
-  output; `UnimodularTransformation` is not bound.
+- Core types are `Cell`, `Operations`, and `UnimodularTransformation`. C
+  exposes `Cell`, magnetic cells, `Operations`, and `MagneticOperations`;
+  WASM exposes only `Cell` and (implicitly) `Operations` via the dataset
+  output. `UnimodularTransformation` is not bound in either.
 - "Dataset from cell" is the main symmetry-analysis entry point
   (`MoyoDataset`, `MoyoLayerDataset`, `MoyoCollinearMagneticDataset`,
   `MoyoNonCollinearMagneticDataset`).
@@ -66,9 +70,16 @@ Notes:
   `LayerCentering`, `LayerHallSymbolEntry`, `LayerGroupType`,
   `LayerArithmeticCrystalClass`, `operations_from_layer_number`,
   `MagneticSpaceGroupType`, `magnetic_operations_from_uni_number`).
+- C's "Data access" is 🟡 because the standalone `Centering`,
+  `ArithmeticCrystalClass`, and `WyckoffPosition` classes are not bound
+  (their content is reachable as strings through the entry and group-type
+  lookups); the settings, Hall symbol entries, group types, and
+  `operations_from_*` generators are all exposed.
 - "Group identification" recovers a group label from a primitive list of
   symmetry operations (`PointGroup` + `SpaceGroup` + `integral_normalizer`,
   `LayerGroup`, `MagneticSpaceGroup`).
+- The Fortran interface mirrors the C column one-to-one (it wraps the
+  complete moyoc API).
 
 ## How to cite moyo and its interfaces
 

--- a/moyoc/CMakeLists.txt
+++ b/moyoc/CMakeLists.txt
@@ -12,6 +12,7 @@ project(moyoc VERSION "${CMAKE_MATCH_1}" LANGUAGES C)
 
 option(MOYOC_BUILD_TESTING "Build moyoc C tests" ${PROJECT_IS_TOP_LEVEL})
 option(MOYOC_INSTALL "Generate install rules for moyoc" ${PROJECT_IS_TOP_LEVEL})
+option(MOYOC_BUILD_FORTRAN "Build the Fortran interface (moyo::moyof)" OFF)
 
 if(PROJECT_IS_TOP_LEVEL)
     if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
@@ -71,6 +72,11 @@ add_library(moyo::moyoc ALIAS moyoc)
 if(MOYOC_BUILD_TESTING)
     enable_testing()
     add_subdirectory(tests)
+endif()
+
+if(MOYOC_BUILD_FORTRAN)
+    enable_language(Fortran)
+    add_subdirectory(fortran)
 endif()
 
 if(MOYOC_INSTALL)

--- a/moyoc/README.md
+++ b/moyoc/README.md
@@ -113,3 +113,32 @@ MoyoMagneticSpaceGroupType *magnetic_space_group_type =
     moyo_magnetic_space_group_type_new(uni_number);
 moyo_magnetic_space_group_type_free(magnetic_space_group_type);
 ```
+
+## Fortran interface
+
+Configure with `-DMOYOC_BUILD_FORTRAN=ON` to build the Fortran interface and expose
+the `moyo::moyof` CMake target (requires a Fortran compiler, e.g. gfortran). Link it
+and `use moyo` from your Fortran code.
+
+The interface mirrors the C API with a few conventions:
+
+- Arrays are passed column-major: `basis(:, i)` is the i-th basis vector and
+  `positions(:, i)` is the i-th site, i.e. a transpose view of the C row-major arrays.
+- Constructors return a `type(c_ptr)` which is NULL on failure. Map it to the
+  matching `bind(c)` derived type with `c_f_pointer`, then free it with the
+  corresponding `*_free` routine.
+- C strings are converted to Fortran with `moyo_to_string`.
+
+```fortran
+use moyo
+use iso_c_binding, only: c_ptr, c_f_pointer, c_associated
+type(c_ptr) :: handle
+type(MoyoDataset), pointer :: dataset
+
+handle = moyo_dataset_new(basis, positions, numbers, num_atoms, &
+    symprec, angle_tolerance, setting, hall_number, rotate_basis)
+if (.not. c_associated(handle)) error stop "moyo_dataset_new failed"
+call c_f_pointer(handle, dataset)
+! ... read dataset fields ...
+call moyo_dataset_free(handle)
+```

--- a/moyoc/fortran/CMakeLists.txt
+++ b/moyoc/fortran/CMakeLists.txt
@@ -1,0 +1,25 @@
+add_library(moyof STATIC moyof.f90)
+target_link_libraries(moyof PUBLIC moyo::moyoc)
+
+# Expose the generated `moyo.mod` to consumers of `moyof`
+set_target_properties(moyof PROPERTIES
+    Fortran_MODULE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include")
+target_include_directories(moyof INTERFACE
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>")
+
+add_library(moyo::moyof ALIAS moyof)
+
+if(MOYOC_BUILD_TESTING)
+    add_executable(test_moyof_dataset tests/test_moyof_dataset.f90)
+    target_link_libraries(test_moyof_dataset PRIVATE moyo::moyof)
+    add_test(NAME test_moyof_dataset COMMAND test_moyof_dataset)
+endif()
+
+if(MOYOC_INSTALL)
+    include(GNUInstallDirs)
+    install(FILES "$<TARGET_FILE:moyof>" DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+    # .mod files are compiler-specific; they are only usable by the same
+    # Fortran compiler (and version) that produced them.
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/include/moyo.mod"
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+endif()

--- a/moyoc/fortran/moyof.f90
+++ b/moyoc/fortran/moyof.f90
@@ -1,0 +1,539 @@
+! Fortran interface to moyoc, the C bindings for moyo.
+!
+! Conventions for crossing the C boundary:
+! - `basis(:, i)` is the `i`th basis vector (the Fortran array is the
+!   transpose view of the row-major C `basis[3][3]`, so columns are vectors).
+! - `positions(:, i)` are the fractional coordinates of the `i`th site.
+! - 3x3 matrices stored in datasets (`std_linear`, `rotations(:, :, k)`, ...)
+!   are likewise transposed with respect to their C/Rust definition.
+! - Functions returning `type(c_ptr)` give NULL (`c_associated` is false) on
+!   failure; map the result with `c_f_pointer` and release it with the
+!   matching `*_free` routine.
+! - C strings (`type(c_ptr)` components) are converted with `moyo_to_string`.
+module moyo
+    use, intrinsic :: iso_c_binding, only: c_ptr, c_char, c_double, c_bool, &
+                                           c_int32_t, c_size_t, c_null_char, &
+                                           c_associated, c_f_pointer
+    implicit none
+    private
+
+    ! ------------------------------------------------------------------------
+    ! Setting preferences (values of the C `MoyoSetting` enum)
+    ! ------------------------------------------------------------------------
+    !> Hall number specified by the `hall_number` argument
+    integer(c_int32_t), parameter, public :: MOYO_SETTING_HALL_NUMBER = 0
+    !> The setting of the smallest Hall number
+    integer(c_int32_t), parameter, public :: MOYO_SETTING_SPGLIB = 1
+    !> Unique axis b, cell choice 1 for monoclinic, hexagonal axes for
+    !> rhombohedral, and origin choice 2 for centrosymmetric space groups
+    integer(c_int32_t), parameter, public :: MOYO_SETTING_STANDARD = 2
+
+    ! Values of the C `MoyoLayerSetting` enum
+    !> Layer Hall number specified by the `hall_number` argument (1 - 116)
+    integer(c_int32_t), parameter, public :: MOYO_LAYER_SETTING_HALL_NUMBER = 0
+    !> The setting of the smallest layer Hall number for each layer group
+    integer(c_int32_t), parameter, public :: MOYO_LAYER_SETTING_SPGLIB = 1
+    !> BCS standard choice (origin choice 2 for layer groups 52, 62, 64)
+    integer(c_int32_t), parameter, public :: MOYO_LAYER_SETTING_STANDARD = 2
+
+    ! ------------------------------------------------------------------------
+    ! Interoperable derived types mirroring moyoc.h
+    ! ------------------------------------------------------------------------
+    !> Symmetry operations. `rotations` points to `num_operations` int32 3x3
+    !> matrices and `translations` to `num_operations` real vectors; map them
+    !> with `c_f_pointer(ops%rotations, rot, [3, 3, int(ops%num_operations)])`.
+    type, bind(c), public :: MoyoOperations
+        type(c_ptr) :: rotations
+        type(c_ptr) :: translations
+        integer(c_int32_t) :: num_operations
+    end type MoyoOperations
+
+    !> Magnetic symmetry operations; `time_reversals` points to
+    !> `num_operations` `logical(c_bool)` values.
+    type, bind(c), public :: MoyoMagneticOperations
+        type(c_ptr) :: rotations
+        type(c_ptr) :: translations
+        type(c_ptr) :: time_reversals
+        integer(c_int32_t) :: num_operations
+    end type MoyoMagneticOperations
+
+    !> Crystal structure. `basis(:, i)` is the `i`th basis vector;
+    !> `positions` points to `num_atoms` fractional coordinate triplets and
+    !> `numbers` to `num_atoms` atomic numbers.
+    type, bind(c), public :: MoyoCell
+        real(c_double) :: basis(3, 3)
+        type(c_ptr) :: positions
+        type(c_ptr) :: numbers
+        integer(c_int32_t) :: num_atoms
+    end type MoyoCell
+
+    !> Collinear magnetic structure; `magnetic_moments` points to
+    !> `cell%num_atoms` scalar moments.
+    type, bind(c), public :: MoyoCollinearMagneticCell
+        type(MoyoCell) :: cell
+        type(c_ptr) :: magnetic_moments
+    end type MoyoCollinearMagneticCell
+
+    !> Non-collinear magnetic structure; `magnetic_moments` points to
+    !> `cell%num_atoms` Cartesian moment vectors.
+    type, bind(c), public :: MoyoNonCollinearMagneticCell
+        type(MoyoCell) :: cell
+        type(c_ptr) :: magnetic_moments
+    end type MoyoNonCollinearMagneticCell
+
+    !> A dataset of the symmetry analysis, created by `moyo_dataset_new` and
+    !> freed by `moyo_dataset_free`. See moyoc.h for field documentation.
+    type, bind(c), public :: MoyoDataset
+        integer(c_int32_t) :: number
+        integer(c_int32_t) :: hall_number
+        type(c_ptr) :: hm_symbol
+        integer(c_int32_t) :: num_atoms
+        type(MoyoOperations) :: operations
+        type(c_ptr) :: orbits
+        type(c_ptr) :: wyckoffs
+        type(c_ptr) :: site_symmetry_symbols
+        type(MoyoCell) :: std_cell
+        real(c_double) :: std_linear(3, 3)
+        real(c_double) :: std_origin_shift(3)
+        real(c_double) :: std_rotation_matrix(3, 3)
+        type(c_ptr) :: pearson_symbol
+        type(MoyoCell) :: prim_std_cell
+        real(c_double) :: prim_std_linear(3, 3)
+        real(c_double) :: prim_std_origin_shift(3)
+        type(c_ptr) :: mapping_std_prim
+        real(c_double) :: symprec
+        real(c_double) :: angle_tolerance
+    end type MoyoDataset
+
+    !> A dataset of the layer-group symmetry analysis, created by
+    !> `moyo_layer_dataset_new` and freed by `moyo_layer_dataset_free`.
+    type, bind(c), public :: MoyoLayerDataset
+        integer(c_int32_t) :: number
+        integer(c_int32_t) :: hall_number
+        type(c_ptr) :: hm_symbol
+        integer(c_int32_t) :: num_atoms
+        type(MoyoOperations) :: operations
+        type(c_ptr) :: orbits
+        type(c_ptr) :: wyckoffs
+        type(c_ptr) :: site_symmetry_symbols
+        type(MoyoCell) :: std_cell
+        real(c_double) :: std_linear(3, 3)
+        real(c_double) :: std_origin_shift(3)
+        real(c_double) :: std_rotation_matrix(3, 3)
+        type(c_ptr) :: pearson_symbol
+        type(MoyoCell) :: prim_std_cell
+        real(c_double) :: prim_std_linear(3, 3)
+        real(c_double) :: prim_std_origin_shift(3)
+        type(c_ptr) :: mapping_std_prim
+        real(c_double) :: symprec
+        real(c_double) :: angle_tolerance
+    end type MoyoLayerDataset
+
+    !> A dataset of the magnetic symmetry analysis of a collinear magnetic
+    !> structure, created by `moyo_collinear_magnetic_dataset_new` and freed
+    !> by `moyo_collinear_magnetic_dataset_free`.
+    type, bind(c), public :: MoyoCollinearMagneticDataset
+        integer(c_int32_t) :: uni_number
+        integer(c_int32_t) :: num_atoms
+        type(MoyoMagneticOperations) :: magnetic_operations
+        type(c_ptr) :: orbits
+        type(MoyoCollinearMagneticCell) :: std_mag_cell
+        real(c_double) :: std_linear(3, 3)
+        real(c_double) :: std_origin_shift(3)
+        real(c_double) :: std_rotation_matrix(3, 3)
+        type(MoyoCollinearMagneticCell) :: prim_std_mag_cell
+        real(c_double) :: prim_std_linear(3, 3)
+        real(c_double) :: prim_std_origin_shift(3)
+        type(c_ptr) :: mapping_std_prim
+        real(c_double) :: symprec
+        real(c_double) :: angle_tolerance
+        real(c_double) :: mag_symprec
+    end type MoyoCollinearMagneticDataset
+
+    !> A dataset of the magnetic symmetry analysis of a non-collinear magnetic
+    !> structure, created by `moyo_noncollinear_magnetic_dataset_new` and
+    !> freed by `moyo_noncollinear_magnetic_dataset_free`.
+    type, bind(c), public :: MoyoNonCollinearMagneticDataset
+        integer(c_int32_t) :: uni_number
+        integer(c_int32_t) :: num_atoms
+        type(MoyoMagneticOperations) :: magnetic_operations
+        type(c_ptr) :: orbits
+        type(MoyoNonCollinearMagneticCell) :: std_mag_cell
+        real(c_double) :: std_linear(3, 3)
+        real(c_double) :: std_origin_shift(3)
+        real(c_double) :: std_rotation_matrix(3, 3)
+        type(MoyoNonCollinearMagneticCell) :: prim_std_mag_cell
+        real(c_double) :: prim_std_linear(3, 3)
+        real(c_double) :: prim_std_origin_shift(3)
+        type(c_ptr) :: mapping_std_prim
+        real(c_double) :: symprec
+        real(c_double) :: angle_tolerance
+        real(c_double) :: mag_symprec
+    end type MoyoNonCollinearMagneticDataset
+
+    !> Hall symbol database entry, created by `moyo_hall_symbol_entry_new`
+    !> and freed by `moyo_hall_symbol_entry_free`.
+    type, bind(c), public :: MoyoHallSymbolEntry
+        integer(c_int32_t) :: hall_number
+        integer(c_int32_t) :: number
+        integer(c_int32_t) :: arithmetic_number
+        type(c_ptr) :: setting
+        type(c_ptr) :: hall_symbol
+        type(c_ptr) :: hm_short
+        type(c_ptr) :: hm_full
+        type(c_ptr) :: centering
+    end type MoyoHallSymbolEntry
+
+    !> Layer Hall symbol database entry, created by
+    !> `moyo_layer_hall_symbol_entry_new` and freed by
+    !> `moyo_layer_hall_symbol_entry_free`.
+    type, bind(c), public :: MoyoLayerHallSymbolEntry
+        integer(c_int32_t) :: hall_number
+        integer(c_int32_t) :: number
+        integer(c_int32_t) :: arithmetic_number
+        type(c_ptr) :: setting
+        type(c_ptr) :: hall_symbol
+        type(c_ptr) :: hm_short
+        type(c_ptr) :: hm_full
+        type(c_ptr) :: centering
+    end type MoyoLayerHallSymbolEntry
+
+    !> Space-group type information, created by `moyo_space_group_type_new`
+    !> and freed by `moyo_space_group_type_free`.
+    type, bind(c), public :: MoyoSpaceGroupType
+        integer(c_int32_t) :: number
+        type(c_ptr) :: hm_short
+        type(c_ptr) :: hm_full
+        integer(c_int32_t) :: arithmetic_number
+        type(c_ptr) :: arithmetic_symbol
+        type(c_ptr) :: geometric_crystal_class
+        type(c_ptr) :: crystal_system
+        type(c_ptr) :: bravais_class
+        type(c_ptr) :: lattice_system
+        type(c_ptr) :: crystal_family
+    end type MoyoSpaceGroupType
+
+    !> Layer-group type information, created by `moyo_layer_group_type_new`
+    !> and freed by `moyo_layer_group_type_free`.
+    type, bind(c), public :: MoyoLayerGroupType
+        integer(c_int32_t) :: number
+        type(c_ptr) :: hm_short
+        type(c_ptr) :: hm_full
+        integer(c_int32_t) :: arithmetic_number
+        type(c_ptr) :: arithmetic_symbol
+        type(c_ptr) :: geometric_crystal_class
+        type(c_ptr) :: bravais_class
+        type(c_ptr) :: lattice_system
+    end type MoyoLayerGroupType
+
+    !> Magnetic space-group type information, created by
+    !> `moyo_magnetic_space_group_type_new` and freed by
+    !> `moyo_magnetic_space_group_type_free`.
+    type, bind(c), public :: MoyoMagneticSpaceGroupType
+        integer(c_int32_t) :: uni_number
+        integer(c_int32_t) :: litvin_number
+        type(c_ptr) :: bns_number
+        type(c_ptr) :: og_number
+        integer(c_int32_t) :: number
+        integer(c_int32_t) :: construct_type
+    end type MoyoMagneticSpaceGroupType
+
+    public :: moyo_version
+    public :: moyo_dataset_new, moyo_dataset_free
+    public :: moyo_layer_dataset_new, moyo_layer_dataset_free
+    public :: moyo_collinear_magnetic_dataset_new, moyo_collinear_magnetic_dataset_free
+    public :: moyo_noncollinear_magnetic_dataset_new, moyo_noncollinear_magnetic_dataset_free
+    public :: moyo_operations_from_number, moyo_operations_from_layer_number
+    public :: moyo_operations_free
+    public :: moyo_magnetic_operations_from_uni_number, moyo_magnetic_operations_free
+    public :: moyo_hall_symbol_entry_new, moyo_hall_symbol_entry_free
+    public :: moyo_layer_hall_symbol_entry_new, moyo_layer_hall_symbol_entry_free
+    public :: moyo_space_group_type_new, moyo_space_group_type_free
+    public :: moyo_layer_group_type_new, moyo_layer_group_type_free
+    public :: moyo_magnetic_space_group_type_new, moyo_magnetic_space_group_type_free
+    public :: moyo_to_string
+
+    interface
+        !> Version string of moyoc; convert with `moyo_to_string`. The
+        !> returned string is statically allocated and must not be freed.
+        function moyo_version() bind(c, name="moyo_version") result(version)
+            import :: c_ptr
+            type(c_ptr) :: version
+        end function moyo_version
+
+        !> Analyze the symmetry of the given cell; returns a pointer to a
+        !> `MoyoDataset` or NULL on failure. Pass a negative
+        !> `angle_tolerance` to use the default tolerance; `hall_number` is
+        !> only used with `MOYO_SETTING_HALL_NUMBER`.
+        function moyo_dataset_new(basis, positions, numbers, num_atoms, symprec, &
+                                  angle_tolerance, setting, hall_number, rotate_basis) &
+            bind(c, name="moyo_dataset_new") result(dataset)
+            import :: c_ptr, c_double, c_int32_t, c_bool
+            real(c_double), intent(in) :: basis(3, 3)
+            real(c_double), intent(in) :: positions(3, *)
+            integer(c_int32_t), intent(in) :: numbers(*)
+            integer(c_int32_t), value :: num_atoms
+            real(c_double), value :: symprec
+            real(c_double), value :: angle_tolerance
+            integer(c_int32_t), value :: setting
+            integer(c_int32_t), value :: hall_number
+            logical(c_bool), value :: rotate_basis
+            type(c_ptr) :: dataset
+        end function moyo_dataset_new
+
+        !> Free a dataset created by `moyo_dataset_new`.
+        subroutine moyo_dataset_free(dataset) bind(c, name="moyo_dataset_free")
+            import :: c_ptr
+            type(c_ptr), value :: dataset
+        end subroutine moyo_dataset_free
+
+        !> Analyze the layer-group symmetry of the given cell; returns a
+        !> pointer to a `MoyoLayerDataset` or NULL on failure. The third
+        !> basis vector must be the aperiodic stacking direction.
+        function moyo_layer_dataset_new(basis, positions, numbers, num_atoms, symprec, &
+                                        angle_tolerance, setting, hall_number, rotate_basis) &
+            bind(c, name="moyo_layer_dataset_new") result(dataset)
+            import :: c_ptr, c_double, c_int32_t, c_bool
+            real(c_double), intent(in) :: basis(3, 3)
+            real(c_double), intent(in) :: positions(3, *)
+            integer(c_int32_t), intent(in) :: numbers(*)
+            integer(c_int32_t), value :: num_atoms
+            real(c_double), value :: symprec
+            real(c_double), value :: angle_tolerance
+            integer(c_int32_t), value :: setting
+            integer(c_int32_t), value :: hall_number
+            logical(c_bool), value :: rotate_basis
+            type(c_ptr) :: dataset
+        end function moyo_layer_dataset_new
+
+        !> Free a dataset created by `moyo_layer_dataset_new`.
+        subroutine moyo_layer_dataset_free(dataset) bind(c, name="moyo_layer_dataset_free")
+            import :: c_ptr
+            type(c_ptr), value :: dataset
+        end subroutine moyo_layer_dataset_free
+
+        !> Analyze the magnetic symmetry of a collinear magnetic cell;
+        !> returns a pointer to a `MoyoCollinearMagneticDataset` or NULL on
+        !> failure. Pass a negative `mag_symprec` to reuse `symprec`.
+        function moyo_collinear_magnetic_dataset_new(basis, positions, numbers, &
+                                                     magnetic_moments, num_atoms, symprec, &
+                                                     angle_tolerance, mag_symprec, is_axial, &
+                                                     rotate_basis) &
+            bind(c, name="moyo_collinear_magnetic_dataset_new") result(dataset)
+            import :: c_ptr, c_double, c_int32_t, c_bool
+            real(c_double), intent(in) :: basis(3, 3)
+            real(c_double), intent(in) :: positions(3, *)
+            integer(c_int32_t), intent(in) :: numbers(*)
+            real(c_double), intent(in) :: magnetic_moments(*)
+            integer(c_int32_t), value :: num_atoms
+            real(c_double), value :: symprec
+            real(c_double), value :: angle_tolerance
+            real(c_double), value :: mag_symprec
+            logical(c_bool), value :: is_axial
+            logical(c_bool), value :: rotate_basis
+            type(c_ptr) :: dataset
+        end function moyo_collinear_magnetic_dataset_new
+
+        !> Free a dataset created by `moyo_collinear_magnetic_dataset_new`.
+        subroutine moyo_collinear_magnetic_dataset_free(dataset) &
+            bind(c, name="moyo_collinear_magnetic_dataset_free")
+            import :: c_ptr
+            type(c_ptr), value :: dataset
+        end subroutine moyo_collinear_magnetic_dataset_free
+
+        !> Analyze the magnetic symmetry of a non-collinear magnetic cell
+        !> (`magnetic_moments(:, i)` is the Cartesian moment of site `i`);
+        !> returns a pointer to a `MoyoNonCollinearMagneticDataset` or NULL
+        !> on failure.
+        function moyo_noncollinear_magnetic_dataset_new(basis, positions, numbers, &
+                                                        magnetic_moments, num_atoms, symprec, &
+                                                        angle_tolerance, mag_symprec, is_axial, &
+                                                        rotate_basis) &
+            bind(c, name="moyo_noncollinear_magnetic_dataset_new") result(dataset)
+            import :: c_ptr, c_double, c_int32_t, c_bool
+            real(c_double), intent(in) :: basis(3, 3)
+            real(c_double), intent(in) :: positions(3, *)
+            integer(c_int32_t), intent(in) :: numbers(*)
+            real(c_double), intent(in) :: magnetic_moments(3, *)
+            integer(c_int32_t), value :: num_atoms
+            real(c_double), value :: symprec
+            real(c_double), value :: angle_tolerance
+            real(c_double), value :: mag_symprec
+            logical(c_bool), value :: is_axial
+            logical(c_bool), value :: rotate_basis
+            type(c_ptr) :: dataset
+        end function moyo_noncollinear_magnetic_dataset_new
+
+        !> Free a dataset created by `moyo_noncollinear_magnetic_dataset_new`.
+        subroutine moyo_noncollinear_magnetic_dataset_free(dataset) &
+            bind(c, name="moyo_noncollinear_magnetic_dataset_free")
+            import :: c_ptr
+            type(c_ptr), value :: dataset
+        end subroutine moyo_noncollinear_magnetic_dataset_free
+
+        !> Symmetry operations for a space-group ITA number (1 - 230);
+        !> returns a pointer to `MoyoOperations` or NULL on invalid input.
+        function moyo_operations_from_number(number, setting, hall_number, primitive) &
+            bind(c, name="moyo_operations_from_number") result(operations)
+            import :: c_ptr, c_int32_t, c_bool
+            integer(c_int32_t), value :: number
+            integer(c_int32_t), value :: setting
+            integer(c_int32_t), value :: hall_number
+            logical(c_bool), value :: primitive
+            type(c_ptr) :: operations
+        end function moyo_operations_from_number
+
+        !> Symmetry operations for a layer-group number (1 - 80);
+        !> returns a pointer to `MoyoOperations` or NULL on invalid input.
+        function moyo_operations_from_layer_number(number, setting, hall_number, primitive) &
+            bind(c, name="moyo_operations_from_layer_number") result(operations)
+            import :: c_ptr, c_int32_t, c_bool
+            integer(c_int32_t), value :: number
+            integer(c_int32_t), value :: setting
+            integer(c_int32_t), value :: hall_number
+            logical(c_bool), value :: primitive
+            type(c_ptr) :: operations
+        end function moyo_operations_from_layer_number
+
+        !> Free operations returned by `moyo_operations_from_number` or
+        !> `moyo_operations_from_layer_number` (not operations embedded in a
+        !> dataset).
+        subroutine moyo_operations_free(operations) bind(c, name="moyo_operations_free")
+            import :: c_ptr
+            type(c_ptr), value :: operations
+        end subroutine moyo_operations_free
+
+        !> Magnetic symmetry operations for a UNI number (1 - 1651); returns
+        !> a pointer to `MoyoMagneticOperations` or NULL on invalid input.
+        function moyo_magnetic_operations_from_uni_number(uni_number, primitive) &
+            bind(c, name="moyo_magnetic_operations_from_uni_number") result(magnetic_operations)
+            import :: c_ptr, c_int32_t, c_bool
+            integer(c_int32_t), value :: uni_number
+            logical(c_bool), value :: primitive
+            type(c_ptr) :: magnetic_operations
+        end function moyo_magnetic_operations_from_uni_number
+
+        !> Free magnetic operations returned by
+        !> `moyo_magnetic_operations_from_uni_number` (not operations
+        !> embedded in a dataset).
+        subroutine moyo_magnetic_operations_free(magnetic_operations) &
+            bind(c, name="moyo_magnetic_operations_free")
+            import :: c_ptr
+            type(c_ptr), value :: magnetic_operations
+        end subroutine moyo_magnetic_operations_free
+
+        !> Hall symbol entry for `hall_number` (1 - 530); returns a pointer
+        !> to `MoyoHallSymbolEntry` or NULL if out of range.
+        function moyo_hall_symbol_entry_new(hall_number) &
+            bind(c, name="moyo_hall_symbol_entry_new") result(entry)
+            import :: c_ptr, c_int32_t
+            integer(c_int32_t), value :: hall_number
+            type(c_ptr) :: entry
+        end function moyo_hall_symbol_entry_new
+
+        !> Free an entry created by `moyo_hall_symbol_entry_new`.
+        subroutine moyo_hall_symbol_entry_free(entry) &
+            bind(c, name="moyo_hall_symbol_entry_free")
+            import :: c_ptr
+            type(c_ptr), value :: entry
+        end subroutine moyo_hall_symbol_entry_free
+
+        !> Layer Hall symbol entry for `hall_number` (1 - 116); returns a
+        !> pointer to `MoyoLayerHallSymbolEntry` or NULL if out of range.
+        function moyo_layer_hall_symbol_entry_new(hall_number) &
+            bind(c, name="moyo_layer_hall_symbol_entry_new") result(entry)
+            import :: c_ptr, c_int32_t
+            integer(c_int32_t), value :: hall_number
+            type(c_ptr) :: entry
+        end function moyo_layer_hall_symbol_entry_new
+
+        !> Free an entry created by `moyo_layer_hall_symbol_entry_new`.
+        subroutine moyo_layer_hall_symbol_entry_free(entry) &
+            bind(c, name="moyo_layer_hall_symbol_entry_free")
+            import :: c_ptr
+            type(c_ptr), value :: entry
+        end subroutine moyo_layer_hall_symbol_entry_free
+
+        !> Space-group type information for ITA `number` (1 - 230); returns
+        !> a pointer to `MoyoSpaceGroupType` or NULL if out of range.
+        function moyo_space_group_type_new(number) &
+            bind(c, name="moyo_space_group_type_new") result(space_group_type)
+            import :: c_ptr, c_int32_t
+            integer(c_int32_t), value :: number
+            type(c_ptr) :: space_group_type
+        end function moyo_space_group_type_new
+
+        !> Free a space-group type created by `moyo_space_group_type_new`.
+        subroutine moyo_space_group_type_free(space_group_type) &
+            bind(c, name="moyo_space_group_type_free")
+            import :: c_ptr
+            type(c_ptr), value :: space_group_type
+        end subroutine moyo_space_group_type_free
+
+        !> Layer-group type information for layer-group `number` (1 - 80);
+        !> returns a pointer to `MoyoLayerGroupType` or NULL if out of range.
+        function moyo_layer_group_type_new(number) &
+            bind(c, name="moyo_layer_group_type_new") result(layer_group_type)
+            import :: c_ptr, c_int32_t
+            integer(c_int32_t), value :: number
+            type(c_ptr) :: layer_group_type
+        end function moyo_layer_group_type_new
+
+        !> Free a layer-group type created by `moyo_layer_group_type_new`.
+        subroutine moyo_layer_group_type_free(layer_group_type) &
+            bind(c, name="moyo_layer_group_type_free")
+            import :: c_ptr
+            type(c_ptr), value :: layer_group_type
+        end subroutine moyo_layer_group_type_free
+
+        !> Magnetic space-group type information for `uni_number`
+        !> (1 - 1651); returns a pointer to `MoyoMagneticSpaceGroupType` or
+        !> NULL if out of range.
+        function moyo_magnetic_space_group_type_new(uni_number) &
+            bind(c, name="moyo_magnetic_space_group_type_new") result(magnetic_space_group_type)
+            import :: c_ptr, c_int32_t
+            integer(c_int32_t), value :: uni_number
+            type(c_ptr) :: magnetic_space_group_type
+        end function moyo_magnetic_space_group_type_new
+
+        !> Free a magnetic space-group type created by
+        !> `moyo_magnetic_space_group_type_new`.
+        subroutine moyo_magnetic_space_group_type_free(magnetic_space_group_type) &
+            bind(c, name="moyo_magnetic_space_group_type_free")
+            import :: c_ptr
+            type(c_ptr), value :: magnetic_space_group_type
+        end subroutine moyo_magnetic_space_group_type_free
+    end interface
+
+    interface
+        function moyo_c_strlen(s) bind(c, name="strlen") result(length)
+            import :: c_ptr, c_size_t
+            type(c_ptr), value :: s
+            integer(c_size_t) :: length
+        end function moyo_c_strlen
+    end interface
+
+contains
+
+    !> Convert a NUL-terminated C string (`type(c_ptr)`) into a Fortran
+    !> character value. Returns an empty string for a NULL pointer.
+    function moyo_to_string(c_str) result(f_str)
+        type(c_ptr), intent(in) :: c_str
+        character(len=:), allocatable :: f_str
+        character(kind=c_char), pointer :: chars(:)
+        integer :: i, length
+
+        if (.not. c_associated(c_str)) then
+            f_str = ""
+            return
+        end if
+
+        length = int(moyo_c_strlen(c_str))
+        call c_f_pointer(c_str, chars, [length])
+        allocate (character(len=length) :: f_str)
+        do i = 1, length
+            f_str(i:i) = chars(i)
+        end do
+    end function moyo_to_string
+
+end module moyo

--- a/moyoc/fortran/tests/test_moyof_dataset.f90
+++ b/moyoc/fortran/tests/test_moyof_dataset.f90
@@ -144,6 +144,15 @@ program test_moyof_dataset
     if (c_associated(moyo_space_group_type_new(231_c_int32_t))) then
         error stop "moyo_space_group_type_new(231) did not return NULL"
     end if
+    if (c_associated(moyo_space_group_type_new(0_c_int32_t))) then
+        error stop "moyo_space_group_type_new(0) did not return NULL"
+    end if
+    if (c_associated(moyo_space_group_type_new(-huge(1_c_int32_t) - 1_c_int32_t))) then
+        error stop "moyo_space_group_type_new(INT32_MIN) did not return NULL"
+    end if
+    if (c_associated(moyo_hall_symbol_entry_new(-huge(1_c_int32_t) - 1_c_int32_t))) then
+        error stop "moyo_hall_symbol_entry_new(INT32_MIN) did not return NULL"
+    end if
 
     print *, "test_moyof_dataset: all checks passed"
 end program test_moyof_dataset

--- a/moyoc/fortran/tests/test_moyof_dataset.f90
+++ b/moyoc/fortran/tests/test_moyof_dataset.f90
@@ -1,0 +1,149 @@
+program test_moyof_dataset
+    use moyo
+    use, intrinsic :: iso_c_binding
+    implicit none
+
+    type(c_ptr) :: version_ptr
+    type(c_ptr) :: dataset_ptr
+    type(c_ptr) :: sgt_ptr
+    type(MoyoDataset), pointer :: dataset
+    type(MoyoSpaceGroupType), pointer :: sgt
+    integer(c_int32_t), pointer :: orbits(:)
+    integer(c_int32_t), pointer :: mapping_std_prim(:)
+    integer(c_int32_t), pointer :: rot(:, :, :)
+    integer(c_int32_t), parameter :: identity(3, 3) = reshape( &
+        [1, 0, 0, 0, 1, 0, 0, 0, 1], [3, 3])
+
+    real(c_double) :: basis(3, 3)
+    real(c_double) :: positions(3, 2)
+    integer(c_int32_t) :: numbers(2)
+    integer(c_int32_t) :: num_atoms
+    real(c_double) :: symprec, angle_tolerance
+    integer(c_int32_t) :: setting, hall_number
+    logical(c_bool) :: rotate_basis
+
+    real(c_double) :: a, c
+    integer :: i, j
+
+    ! Version
+    print *, "moyo_version: ", moyo_to_string(moyo_version())
+    if (len(moyo_to_string(moyo_version())) == 0) then
+        error stop "moyo_version returned an empty string"
+    end if
+
+    ! hcp structure
+    a = 3.17d0
+    c = 5.14d0
+    basis(:, 1) = [a, 0.0d0, 0.0d0]
+    basis(:, 2) = [-a / 2.0d0, a * sqrt(3.0d0) / 2.0d0, 0.0d0]
+    basis(:, 3) = [0.0d0, 0.0d0, c]
+    positions(:, 1) = [1.0d0 / 3.0d0, 2.0d0 / 3.0d0, 1.0d0 / 4.0d0]
+    positions(:, 2) = [2.0d0 / 3.0d0, 1.0d0 / 3.0d0, 3.0d0 / 4.0d0]
+    numbers = [0_c_int32_t, 0_c_int32_t]
+    num_atoms = 2
+
+    symprec = 1d-4
+    angle_tolerance = -1d0
+    setting = MOYO_SETTING_SPGLIB
+    hall_number = -1
+    rotate_basis = .true._c_bool
+
+    dataset_ptr = moyo_dataset_new(basis, positions, numbers, num_atoms, symprec, &
+                                   angle_tolerance, setting, hall_number, rotate_basis)
+    if (.not. c_associated(dataset_ptr)) then
+        error stop "moyo_dataset_new returned NULL"
+    end if
+
+    call c_f_pointer(dataset_ptr, dataset)
+
+    ! Identification
+    print *, "dataset%number: ", dataset%number
+    print *, "dataset%hall_number: ", dataset%hall_number
+    print *, "dataset%hm_symbol: ", moyo_to_string(dataset%hm_symbol)
+    if (dataset%number /= 194) then
+        error stop "dataset%number /= 194"
+    end if
+    if (dataset%hall_number /= 488) then
+        error stop "dataset%hall_number /= 488"
+    end if
+    if (moyo_to_string(dataset%hm_symbol) /= "P 6_3/m m c") then
+        error stop "dataset%hm_symbol /= P 6_3/m m c"
+    end if
+
+    ! Input cell
+    print *, "dataset%num_atoms: ", dataset%num_atoms
+    if (dataset%num_atoms /= 2) then
+        error stop "dataset%num_atoms /= 2"
+    end if
+
+    ! Symmetry operations in the input cell
+    print *, "dataset%operations%num_operations: ", dataset%operations%num_operations
+    if (dataset%operations%num_operations /= 24) then
+        error stop "dataset%operations%num_operations /= 24"
+    end if
+
+    ! First operation must be the identity
+    call c_f_pointer(dataset%operations%rotations, rot, &
+                     [3, 3, int(dataset%operations%num_operations)])
+    print *, "dataset%operations%rotations(:, :, 1):"
+    do i = 1, 3
+        print *, (rot(i, j, 1), j = 1, 3)
+    end do
+    if (any(rot(:, :, 1) /= identity)) then
+        error stop "first operation is not the identity matrix"
+    end if
+
+    ! Site symmetry
+    call c_f_pointer(dataset%orbits, orbits, [2])
+    print *, "dataset%orbits: ", orbits
+    if (any(orbits /= [0_c_int32_t, 0_c_int32_t])) then
+        error stop "dataset%orbits /= [0, 0]"
+    end if
+
+    print *, "dataset%wyckoffs: ", moyo_to_string(dataset%wyckoffs)
+    if (moyo_to_string(dataset%wyckoffs) /= "cc") then
+        error stop "dataset%wyckoffs /= cc"
+    end if
+
+    ! Standardized cell
+    print *, "dataset%pearson_symbol: ", moyo_to_string(dataset%pearson_symbol)
+    if (moyo_to_string(dataset%pearson_symbol) /= "hP2") then
+        error stop "dataset%pearson_symbol /= hP2"
+    end if
+
+    print *, "dataset%std_cell%num_atoms: ", dataset%std_cell%num_atoms
+    if (dataset%std_cell%num_atoms /= 2) then
+        error stop "dataset%std_cell%num_atoms /= 2"
+    end if
+
+    ! Primitive standardized cell
+    call c_f_pointer(dataset%mapping_std_prim, mapping_std_prim, [2])
+    print *, "dataset%mapping_std_prim: ", mapping_std_prim
+    if (any(mapping_std_prim /= [0_c_int32_t, 1_c_int32_t])) then
+        error stop "dataset%mapping_std_prim /= [0, 1]"
+    end if
+
+    call moyo_dataset_free(dataset_ptr)
+
+    ! Space-group type
+    sgt_ptr = moyo_space_group_type_new(194_c_int32_t)
+    if (.not. c_associated(sgt_ptr)) then
+        error stop "moyo_space_group_type_new(194) returned NULL"
+    end if
+    call c_f_pointer(sgt_ptr, sgt)
+    print *, "sgt%number: ", sgt%number
+    print *, "sgt%crystal_system: ", moyo_to_string(sgt%crystal_system)
+    if (sgt%number /= 194) then
+        error stop "sgt%number /= 194"
+    end if
+    if (moyo_to_string(sgt%crystal_system) /= "Hexagonal") then
+        error stop "sgt%crystal_system /= Hexagonal"
+    end if
+    call moyo_space_group_type_free(sgt_ptr)
+
+    if (c_associated(moyo_space_group_type_new(231_c_int32_t))) then
+        error stop "moyo_space_group_type_new(231) did not return NULL"
+    end if
+
+    print *, "test_moyof_dataset: all checks passed"
+end program test_moyof_dataset


### PR DESCRIPTION
## Summary

Adds a Fortran interface to moyo via the moyoc C API. **Stacked on #358** (base branch `feat/moyoc-data-entries`); merge #356-#358 first.

- `moyoc/fortran/moyof.f90`: a single `moyo` Fortran module (ISO_C_BINDING) covering the complete C API -- `bind(c)` derived types for every moyoc struct (datasets, magnetic/layer datasets, operations, cells, Hall entries, group types), interfaces for all 21 exported functions, `MOYO_SETTING_*` / `MOYO_LAYER_SETTING_*` constants, and a `moyo_to_string` helper for C strings
- Conventions: `basis(:, i)` / `positions(:, i)` columns are basis vectors / sites (transpose view of the C row-major arrays); constructors return `type(c_ptr)` (NULL on failure) mapped with `c_f_pointer` and released with the matching `*_free`
- Built as an optional CMake component: `-DMOYOC_BUILD_FORTRAN=ON` exposes the `moyo::moyof` target (static lib + propagated `moyo.mod` include dir); install rules ship the archive and module file
- `test_moyof_dataset` Fortran ctest replicating the hcp C test (P6_3/mmc identification, operations with identity-first check, orbits, Wyckoffs, Pearson symbol, mapping) plus `moyo_space_group_type_new` lookups, including lower-bound invalid inputs (`0`, `INT32_MIN`)
- The C bindings CI workflow now configures with `-DMOYOC_BUILD_FORTRAN=ON` (gfortran is preinstalled on ubuntu-latest)
- Updates the root README interface matrix for the completed moyoc API and the new Fortran interface

## Test plan

- [x] `cmake -DMOYOC_BUILD_FORTRAN=ON` configure/build with gfortran 15 (macOS arm64)
- [x] `ctest`: all 6 tests pass (5 C tests + the new Fortran test)
- [ ] Linux gfortran exercised by the updated `rw-c-tests` workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)
