### PR TITLE
Add group identification API to moyoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ Legend: ✅ supported · 🟡 partial · ❌ not exposed · ➖ not applicable.
 | Shared               | Core types           | ✅            | ✅                | 🟡          | 🟡                    |
 | Space group          | Dataset from cell    | ✅            | ✅                | ✅          | ✅                    |
 | Space group          | Data access          | ✅            | ✅                | 🟡          | 🟡                    |
-| Space group          | Group identification | ✅            | ✅                | ❌          | ❌                    |
+| Space group          | Group identification | ✅            | ✅                | 🟡          | ❌                    |
 | Layer group          | Dataset from cell    | ✅            | ✅                | ✅          | ❌                    |
 | Layer group          | Data access          | ✅            | ✅                | 🟡          | 🟡                    |
-| Layer group          | Group identification | ✅            | ✅                | ❌          | ❌                    |
+| Layer group          | Group identification | ✅            | ✅                | ✅          | ❌                    |
 | Magnetic space group | Dataset from cell    | ✅            | ✅                | ✅          | ❌                    |
 | Magnetic space group | Data access          | ✅            | ✅                | ✅          | 🟡                    |
-| Magnetic space group | Group identification | ✅            | ✅                | ❌          | ❌                    |
+| Magnetic space group | Group identification | ✅            | ✅                | ✅          | ❌                    |
 
 Notes:
 
@@ -77,7 +77,9 @@ Notes:
   `operations_from_*` generators are all exposed.
 - "Group identification" recovers a group label from a primitive list of
   symmetry operations (`PointGroup` + `SpaceGroup` + `integral_normalizer`,
-  `LayerGroup`, `MagneticSpaceGroup`).
+  `LayerGroup`, `MagneticSpaceGroup`). C's space-group row is 🟡 because
+  `integral_normalizer` is not bound; `PointGroup`, `SpaceGroup`,
+  `LayerGroup`, and `MagneticSpaceGroup` are all exposed.
 - The Fortran interface mirrors the C column one-to-one (it wraps the
   complete moyoc API).
 

--- a/moyoc/README.md
+++ b/moyoc/README.md
@@ -96,6 +96,30 @@ MoyoMagneticOperations *magnetic_operations =
     moyo_magnetic_operations_from_uni_number(uni_number, primitive);
 moyo_magnetic_operations_free(magnetic_operations);
 
+// Group identification from primitive operations
+MoyoPointGroup *point_group = moyo_point_group_new(
+    prim_rotations, num_operations, basis /* or NULL */
+);
+moyo_point_group_free(point_group);
+
+MoyoSpaceGroup *space_group = moyo_space_group_new(
+    prim_rotations, prim_translations, num_operations,
+    basis /* or NULL */, setting, hall_number, epsilon
+);
+moyo_space_group_free(space_group);
+
+MoyoLayerGroup *layer_group = moyo_layer_group_new(
+    prim_rotations, prim_translations, num_operations,
+    basis /* or NULL */, layer_setting, layer_hall_number, epsilon
+);
+moyo_layer_group_free(layer_group);
+
+MoyoMagneticSpaceGroup *magnetic_space_group = moyo_magnetic_space_group_new(
+    prim_rotations, prim_translations, prim_time_reversals, num_operations,
+    basis /* or NULL */, epsilon
+);
+moyo_magnetic_space_group_free(magnetic_space_group);
+
 // Group-type metadata lookups
 MoyoHallSymbolEntry *entry = moyo_hall_symbol_entry_new(hall_number);
 moyo_hall_symbol_entry_free(entry);

--- a/moyoc/fortran/moyof.f90
+++ b/moyoc/fortran/moyof.f90
@@ -238,6 +238,43 @@ module moyo
         integer(c_int32_t) :: construct_type
     end type MoyoMagneticSpaceGroupType
 
+    !> Point group identified by `moyo_point_group_new` and freed by
+    !> `moyo_point_group_free`. `prim_trans_mat` is the transpose view of the
+    !> row-major C matrix.
+    type, bind(c), public :: MoyoPointGroup
+        integer(c_int32_t) :: arithmetic_number
+        integer(c_int32_t) :: prim_trans_mat(3, 3)
+    end type MoyoPointGroup
+
+    !> Space group identified by `moyo_space_group_new` and freed by
+    !> `moyo_space_group_free`. `linear` is the transpose view of the
+    !> row-major C matrix.
+    type, bind(c), public :: MoyoSpaceGroup
+        integer(c_int32_t) :: number
+        integer(c_int32_t) :: hall_number
+        integer(c_int32_t) :: linear(3, 3)
+        real(c_double) :: origin_shift(3)
+    end type MoyoSpaceGroup
+
+    !> Layer group identified by `moyo_layer_group_new` and freed by
+    !> `moyo_layer_group_free`. `linear` is the transpose view of the
+    !> row-major C matrix.
+    type, bind(c), public :: MoyoLayerGroup
+        integer(c_int32_t) :: number
+        integer(c_int32_t) :: hall_number
+        integer(c_int32_t) :: linear(3, 3)
+        real(c_double) :: origin_shift(3)
+    end type MoyoLayerGroup
+
+    !> Magnetic space group identified by `moyo_magnetic_space_group_new` and
+    !> freed by `moyo_magnetic_space_group_free`. `linear` is the transpose
+    !> view of the row-major C matrix.
+    type, bind(c), public :: MoyoMagneticSpaceGroup
+        integer(c_int32_t) :: uni_number
+        integer(c_int32_t) :: linear(3, 3)
+        real(c_double) :: origin_shift(3)
+    end type MoyoMagneticSpaceGroup
+
     public :: moyo_version
     public :: moyo_dataset_new, moyo_dataset_free
     public :: moyo_layer_dataset_new, moyo_layer_dataset_free
@@ -251,6 +288,10 @@ module moyo
     public :: moyo_space_group_type_new, moyo_space_group_type_free
     public :: moyo_layer_group_type_new, moyo_layer_group_type_free
     public :: moyo_magnetic_space_group_type_new, moyo_magnetic_space_group_type_free
+    public :: moyo_point_group_new, moyo_point_group_free
+    public :: moyo_space_group_new, moyo_space_group_free
+    public :: moyo_layer_group_new, moyo_layer_group_free
+    public :: moyo_magnetic_space_group_new, moyo_magnetic_space_group_free
     public :: moyo_to_string
 
     interface
@@ -503,6 +544,109 @@ module moyo
             import :: c_ptr
             type(c_ptr), value :: magnetic_space_group_type
         end subroutine moyo_magnetic_space_group_type_free
+
+        !> Identify the point group of `num_operations` primitive rotations;
+        !> returns a pointer to `MoyoPointGroup` or NULL on failure.
+        !> `prim_rotations` points to the rotation matrices (e.g.
+        !> `ops%rotations` or `c_loc` of an `integer(c_int32_t)` array whose
+        !> `(:, :, k)` slices are the transposed matrices). Pass `c_null_ptr`
+        !> as `basis` to assume an identity basis, or `c_loc` of a
+        !> `real(c_double) :: basis(3, 3)` whose columns are the basis vectors.
+        function moyo_point_group_new(prim_rotations, num_operations, basis) &
+            bind(c, name="moyo_point_group_new") result(point_group)
+            import :: c_ptr, c_int32_t
+            type(c_ptr), value :: prim_rotations
+            integer(c_int32_t), value :: num_operations
+            type(c_ptr), value :: basis
+            type(c_ptr) :: point_group
+        end function moyo_point_group_new
+
+        !> Free a point group created by `moyo_point_group_new`.
+        subroutine moyo_point_group_free(point_group) &
+            bind(c, name="moyo_point_group_free")
+            import :: c_ptr
+            type(c_ptr), value :: point_group
+        end subroutine moyo_point_group_free
+
+        !> Identify the space group from `num_operations` primitive rotations
+        !> and translations; returns a pointer to `MoyoSpaceGroup` or NULL on
+        !> failure. Pass `c_null_ptr` as `basis` to assume an identity basis
+        !> and a negative `epsilon` to use the default tolerance (1e-4);
+        !> `hall_number` is only used with `MOYO_SETTING_HALL_NUMBER`.
+        function moyo_space_group_new(prim_rotations, prim_translations, num_operations, &
+                                      basis, setting, hall_number, epsilon) &
+            bind(c, name="moyo_space_group_new") result(space_group)
+            import :: c_ptr, c_int32_t, c_double
+            type(c_ptr), value :: prim_rotations
+            type(c_ptr), value :: prim_translations
+            integer(c_int32_t), value :: num_operations
+            type(c_ptr), value :: basis
+            integer(c_int32_t), value :: setting
+            integer(c_int32_t), value :: hall_number
+            real(c_double), value :: epsilon
+            type(c_ptr) :: space_group
+        end function moyo_space_group_new
+
+        !> Free a space group created by `moyo_space_group_new`.
+        subroutine moyo_space_group_free(space_group) &
+            bind(c, name="moyo_space_group_free")
+            import :: c_ptr
+            type(c_ptr), value :: space_group
+        end subroutine moyo_space_group_free
+
+        !> Identify the layer group from `num_operations` primitive
+        !> layer-cell rotations and translations; returns a pointer to
+        !> `MoyoLayerGroup` or NULL on failure. Pass `c_null_ptr` as `basis`
+        !> to assume an identity basis and a negative `epsilon` to use the
+        !> default tolerance (1e-4); `hall_number` is only used with
+        !> `MOYO_LAYER_SETTING_HALL_NUMBER`.
+        function moyo_layer_group_new(prim_rotations, prim_translations, num_operations, &
+                                      basis, setting, hall_number, epsilon) &
+            bind(c, name="moyo_layer_group_new") result(layer_group)
+            import :: c_ptr, c_int32_t, c_double
+            type(c_ptr), value :: prim_rotations
+            type(c_ptr), value :: prim_translations
+            integer(c_int32_t), value :: num_operations
+            type(c_ptr), value :: basis
+            integer(c_int32_t), value :: setting
+            integer(c_int32_t), value :: hall_number
+            real(c_double), value :: epsilon
+            type(c_ptr) :: layer_group
+        end function moyo_layer_group_new
+
+        !> Free a layer group created by `moyo_layer_group_new`.
+        subroutine moyo_layer_group_free(layer_group) &
+            bind(c, name="moyo_layer_group_free")
+            import :: c_ptr
+            type(c_ptr), value :: layer_group
+        end subroutine moyo_layer_group_free
+
+        !> Identify the magnetic space group from `num_operations` primitive
+        !> magnetic operations; returns a pointer to `MoyoMagneticSpaceGroup`
+        !> or NULL on failure. Pass `c_null_ptr` as `basis` to assume an
+        !> identity basis and a negative `epsilon` to use the default
+        !> tolerance (1e-4).
+        function moyo_magnetic_space_group_new(prim_rotations, prim_translations, &
+                                               prim_time_reversals, num_operations, &
+                                               basis, epsilon) &
+            bind(c, name="moyo_magnetic_space_group_new") result(magnetic_space_group)
+            import :: c_ptr, c_int32_t, c_double
+            type(c_ptr), value :: prim_rotations
+            type(c_ptr), value :: prim_translations
+            type(c_ptr), value :: prim_time_reversals
+            integer(c_int32_t), value :: num_operations
+            type(c_ptr), value :: basis
+            real(c_double), value :: epsilon
+            type(c_ptr) :: magnetic_space_group
+        end function moyo_magnetic_space_group_new
+
+        !> Free a magnetic space group created by
+        !> `moyo_magnetic_space_group_new`.
+        subroutine moyo_magnetic_space_group_free(magnetic_space_group) &
+            bind(c, name="moyo_magnetic_space_group_free")
+            import :: c_ptr
+            type(c_ptr), value :: magnetic_space_group
+        end subroutine moyo_magnetic_space_group_free
     end interface
 
     interface

--- a/moyoc/fortran/tests/test_moyof_dataset.f90
+++ b/moyoc/fortran/tests/test_moyof_dataset.f90
@@ -6,8 +6,12 @@ program test_moyof_dataset
     type(c_ptr) :: version_ptr
     type(c_ptr) :: dataset_ptr
     type(c_ptr) :: sgt_ptr
+    type(c_ptr) :: operations_ptr
+    type(c_ptr) :: space_group_ptr
     type(MoyoDataset), pointer :: dataset
     type(MoyoSpaceGroupType), pointer :: sgt
+    type(MoyoOperations), pointer :: prim_operations
+    type(MoyoSpaceGroup), pointer :: space_group
     integer(c_int32_t), pointer :: orbits(:)
     integer(c_int32_t), pointer :: mapping_std_prim(:)
     integer(c_int32_t), pointer :: rot(:, :, :)
@@ -153,6 +157,31 @@ program test_moyof_dataset
     if (c_associated(moyo_hall_symbol_entry_new(-huge(1_c_int32_t) - 1_c_int32_t))) then
         error stop "moyo_hall_symbol_entry_new(INT32_MIN) did not return NULL"
     end if
+
+    ! Group identification: primitive operations of P31c (no. 159) must
+    ! identify back to the same space group
+    operations_ptr = moyo_operations_from_number(159_c_int32_t, MOYO_SETTING_STANDARD, &
+                                                 -1_c_int32_t, .true._c_bool)
+    if (.not. c_associated(operations_ptr)) then
+        error stop "moyo_operations_from_number(159) returned NULL"
+    end if
+    call c_f_pointer(operations_ptr, prim_operations)
+
+    space_group_ptr = moyo_space_group_new(prim_operations%rotations, &
+                                           prim_operations%translations, &
+                                           prim_operations%num_operations, &
+                                           c_null_ptr, MOYO_SETTING_STANDARD, &
+                                           -1_c_int32_t, -1d0)
+    if (.not. c_associated(space_group_ptr)) then
+        error stop "moyo_space_group_new returned NULL"
+    end if
+    call c_f_pointer(space_group_ptr, space_group)
+    print *, "space_group%number: ", space_group%number
+    if (space_group%number /= 159) then
+        error stop "space_group%number /= 159"
+    end if
+    call moyo_space_group_free(space_group_ptr)
+    call moyo_operations_free(operations_ptr)
 
     print *, "test_moyof_dataset: all checks passed"
 end program test_moyof_dataset

--- a/moyoc/src/identify.rs
+++ b/moyoc/src/identify.rs
@@ -1,0 +1,123 @@
+mod layer_group;
+mod magnetic_space_group;
+mod point_group;
+mod space_group;
+
+pub use layer_group::{MoyoLayerGroup, moyo_layer_group_free, moyo_layer_group_new};
+pub use magnetic_space_group::{
+    MoyoMagneticSpaceGroup, moyo_magnetic_space_group_free, moyo_magnetic_space_group_new,
+};
+pub use point_group::{MoyoPointGroup, moyo_point_group_free, moyo_point_group_new};
+pub use space_group::{MoyoSpaceGroup, moyo_space_group_free, moyo_space_group_new};
+
+/// Default numerical tolerance for matching translations, following moyopy.
+const DEFAULT_EPSILON: f64 = 1e-4;
+
+pub(crate) fn epsilon_or_default(epsilon: f64) -> f64 {
+    if epsilon < 0.0 {
+        DEFAULT_EPSILON
+    } else {
+        epsilon
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data::{
+        MoyoLayerSetting, MoyoSetting, moyo_magnetic_operations_free,
+        moyo_magnetic_operations_from_uni_number, moyo_operations_free,
+        moyo_operations_from_layer_number, moyo_operations_from_number,
+    };
+
+    #[test]
+    fn test_moyo_point_group_new() {
+        // P3c1 -> arithmetic crystal class 45 (3m1P)
+        let operations = moyo_operations_from_number(158, MoyoSetting::Standard, 0, true);
+        assert!(!operations.is_null());
+        unsafe {
+            let point_group = moyo_point_group_new(
+                (*operations).rotations,
+                (*operations).num_operations,
+                std::ptr::null(),
+            );
+            assert!(!point_group.is_null());
+            assert_eq!((*point_group).arithmetic_number, 45);
+            moyo_point_group_free(point_group);
+            moyo_operations_free(operations);
+        }
+
+        // Invalid input
+        let null = unsafe { moyo_point_group_new(std::ptr::null(), 0, std::ptr::null()) };
+        assert!(null.is_null());
+    }
+
+    #[test]
+    fn test_moyo_space_group_new() {
+        // P31c (No. 159)
+        let operations = moyo_operations_from_number(159, MoyoSetting::Standard, 0, true);
+        assert!(!operations.is_null());
+        unsafe {
+            let space_group = moyo_space_group_new(
+                (*operations).rotations,
+                (*operations).translations,
+                (*operations).num_operations,
+                std::ptr::null(),
+                MoyoSetting::Standard,
+                0,
+                -1.0,
+            );
+            assert!(!space_group.is_null());
+            assert_eq!((*space_group).number, 159);
+            moyo_space_group_free(space_group);
+            moyo_operations_free(operations);
+        }
+    }
+
+    #[test]
+    fn test_moyo_layer_group_new() {
+        // p6 (LG 65), with and without an explicit identity basis
+        let operations = moyo_operations_from_layer_number(65, MoyoLayerSetting::Standard, 0, true);
+        assert!(!operations.is_null());
+        let identity_basis = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]];
+        unsafe {
+            for basis in [std::ptr::null(), identity_basis.as_ptr()] {
+                let layer_group = moyo_layer_group_new(
+                    (*operations).rotations,
+                    (*operations).translations,
+                    (*operations).num_operations,
+                    basis,
+                    MoyoLayerSetting::Standard,
+                    0,
+                    -1.0,
+                );
+                assert!(!layer_group.is_null());
+                assert_eq!((*layer_group).number, 65);
+                assert!((1..=116).contains(&(*layer_group).hall_number));
+                moyo_layer_group_free(layer_group);
+            }
+            moyo_operations_free(operations);
+        }
+    }
+
+    #[test]
+    fn test_moyo_magnetic_space_group_new() {
+        // R31'_c (UNI 1242)
+        let magnetic_operations = moyo_magnetic_operations_from_uni_number(1242, true);
+        assert!(!magnetic_operations.is_null());
+        unsafe {
+            let magnetic_space_group = moyo_magnetic_space_group_new(
+                (*magnetic_operations).rotations,
+                (*magnetic_operations).translations,
+                (*magnetic_operations).time_reversals,
+                (*magnetic_operations).num_operations,
+                std::ptr::null(),
+                -1.0,
+            );
+            assert!(!magnetic_space_group.is_null());
+            assert_eq!((*magnetic_space_group).uni_number, 1242);
+            moyo_magnetic_space_group_free(magnetic_space_group);
+            moyo_magnetic_operations_free(magnetic_operations);
+        }
+    }
+}

--- a/moyoc/src/identify/layer_group.rs
+++ b/moyoc/src/identify/layer_group.rs
@@ -1,0 +1,109 @@
+use moyo::base::{AngleTolerance, Lattice, LayerLattice, Operations};
+use moyo::data::LayerSetting;
+use moyo::identify::LayerGroup;
+
+use crate::base::MoyoOperations;
+use crate::data::MoyoLayerSetting;
+use crate::identify::epsilon_or_default;
+
+/// Layer group identified by `moyo_layer_group_new` and freed by
+/// `moyo_layer_group_free`.
+#[derive(Debug, Clone)]
+#[repr(C)]
+pub struct MoyoLayerGroup {
+    /// Layer-group number for the identified layer group (1 - 80).
+    pub number: i32,
+    /// Layer Hall symbol number (1 - 116) for the chosen setting.
+    pub hall_number: i32,
+    /// Linear part of the transformation from the input primitive basis to the
+    /// standardized basis.
+    pub linear: [[i32; 3]; 3],
+    /// Origin shift of the transformation from the input primitive basis to the
+    /// standardized basis.
+    pub origin_shift: [f64; 3],
+}
+
+/// Identify the layer group from primitive layer-cell rotations and translations.
+///
+/// - `prim_rotations`, `prim_translations`: rotation and translation parts of
+///   the `num_operations` layer-group operations in the primitive layer cell.
+/// - `basis`: row-wise basis vectors of the primitive layer lattice, `basis[i]`
+///   is the `i`th basis vector. `a, b` must lie in the xy-plane and `c` along z
+///   (the layer-group periodicity contract). Pass NULL to assume an identity
+///   basis.
+/// - `hall_number`: preference for layer Hall symbol, only used with
+///   `MOYO_LAYER_SETTING_HALL_NUMBER`.
+/// - `epsilon`: numerical tolerance for matching translations. Pass a negative
+///   value to use the default tolerance (1e-4).
+/// - Returns NULL if the identification fails or the arguments are invalid.
+///   Free the result with `moyo_layer_group_free`.
+///
+/// # Safety
+/// `prim_rotations` and `prim_translations` must point to `num_operations`
+/// elements each, and `basis` must point to 3 basis vectors or be NULL.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moyo_layer_group_new(
+    prim_rotations: *const [[i32; 3]; 3],
+    prim_translations: *const [f64; 3],
+    num_operations: i32,
+    basis: *const [f64; 3],
+    setting: MoyoLayerSetting,
+    hall_number: i32,
+    epsilon: f64,
+) -> *mut MoyoLayerGroup {
+    if prim_rotations.is_null() || prim_translations.is_null() || num_operations <= 0 {
+        return std::ptr::null_mut();
+    }
+    let prim_operations: Operations = (&MoyoOperations {
+        rotations: prim_rotations,
+        translations: prim_translations,
+        num_operations,
+    })
+        .into();
+    let setting = match setting {
+        MoyoLayerSetting::HallNumber => {
+            if hall_number <= 0 {
+                return std::ptr::null_mut();
+            }
+            LayerSetting::HallNumber(hall_number)
+        }
+        MoyoLayerSetting::Spglib => LayerSetting::Spglib,
+        MoyoLayerSetting::Standard => LayerSetting::Standard,
+    };
+    let epsilon = epsilon_or_default(epsilon);
+
+    let layer_group = if basis.is_null() {
+        LayerGroup::new(&prim_operations, setting, epsilon)
+    } else {
+        let basis = unsafe { *(basis as *const [[f64; 3]; 3]) };
+        LayerLattice::new(Lattice::from_basis(basis), epsilon, AngleTolerance::Default).and_then(
+            |layer_lattice| {
+                LayerGroup::from_lattice(&layer_lattice, &prim_operations, setting, epsilon)
+            },
+        )
+    };
+    match layer_group {
+        Ok(layer_group) => Box::into_raw(Box::new(MoyoLayerGroup {
+            number: layer_group.number,
+            hall_number: layer_group.hall_number,
+            linear: layer_group.transformation.linear_as_array(),
+            origin_shift: layer_group.transformation.origin_shift_as_array(),
+        })),
+        Err(_) => std::ptr::null_mut(),
+    }
+}
+
+/// Free a layer group created by `moyo_layer_group_new`. Passing NULL is a no-op.
+///
+/// # Safety
+/// `layer_group` must be a pointer returned by `moyo_layer_group_new` that has
+/// not been freed yet, or NULL.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moyo_layer_group_free(layer_group: *mut MoyoLayerGroup) {
+    if layer_group.is_null() {
+        return;
+    }
+    unsafe {
+        drop(Box::from_raw(layer_group));
+    }
+}

--- a/moyoc/src/identify/magnetic_space_group.rs
+++ b/moyoc/src/identify/magnetic_space_group.rs
@@ -1,0 +1,95 @@
+use moyo::base::{Lattice, MagneticOperations};
+use moyo::identify::MagneticSpaceGroup;
+
+use crate::base::MoyoMagneticOperations;
+use crate::identify::epsilon_or_default;
+
+/// Magnetic space group identified by `moyo_magnetic_space_group_new` and
+/// freed by `moyo_magnetic_space_group_free`.
+#[derive(Debug, Clone)]
+#[repr(C)]
+pub struct MoyoMagneticSpaceGroup {
+    /// Serial number of UNI (and BNS) symbols (1 - 1651).
+    pub uni_number: i32,
+    /// Linear part of the transformation from the input primitive basis to the
+    /// standardized basis.
+    pub linear: [[i32; 3]; 3],
+    /// Origin shift of the transformation from the input primitive basis to the
+    /// standardized basis.
+    pub origin_shift: [f64; 3],
+}
+
+/// Identify the magnetic space group from primitive magnetic operations.
+///
+/// - `prim_rotations`, `prim_translations`, `prim_time_reversals`: rotation,
+///   translation, and time-reversal parts of the `num_operations` magnetic
+///   operations in the primitive cell.
+/// - `basis`: row-wise basis vectors of the primitive lattice, `basis[i]` is
+///   the `i`th basis vector. Pass NULL to assume an identity basis.
+/// - `epsilon`: numerical tolerance for matching translations. Pass a negative
+///   value to use the default tolerance (1e-4).
+/// - Returns NULL if the identification fails or the arguments are invalid.
+///   Free the result with `moyo_magnetic_space_group_free`.
+///
+/// # Safety
+/// `prim_rotations`, `prim_translations`, and `prim_time_reversals` must point
+/// to `num_operations` elements each, and `basis` must point to 3 basis
+/// vectors or be NULL.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moyo_magnetic_space_group_new(
+    prim_rotations: *const [[i32; 3]; 3],
+    prim_translations: *const [f64; 3],
+    prim_time_reversals: *const bool,
+    num_operations: i32,
+    basis: *const [f64; 3],
+    epsilon: f64,
+) -> *mut MoyoMagneticSpaceGroup {
+    if prim_rotations.is_null()
+        || prim_translations.is_null()
+        || prim_time_reversals.is_null()
+        || num_operations <= 0
+    {
+        return std::ptr::null_mut();
+    }
+    let prim_mag_operations: MagneticOperations = (&MoyoMagneticOperations {
+        rotations: prim_rotations,
+        translations: prim_translations,
+        time_reversals: prim_time_reversals,
+        num_operations,
+    })
+        .into();
+    let epsilon = epsilon_or_default(epsilon);
+
+    let magnetic_space_group = if basis.is_null() {
+        MagneticSpaceGroup::new(&prim_mag_operations, epsilon)
+    } else {
+        let basis = unsafe { *(basis as *const [[f64; 3]; 3]) };
+        MagneticSpaceGroup::from_lattice(&Lattice::from_basis(basis), &prim_mag_operations, epsilon)
+    };
+    match magnetic_space_group {
+        Ok(magnetic_space_group) => Box::into_raw(Box::new(MoyoMagneticSpaceGroup {
+            uni_number: magnetic_space_group.uni_number,
+            linear: magnetic_space_group.transformation.linear_as_array(),
+            origin_shift: magnetic_space_group.transformation.origin_shift_as_array(),
+        })),
+        Err(_) => std::ptr::null_mut(),
+    }
+}
+
+/// Free a magnetic space group created by `moyo_magnetic_space_group_new`.
+/// Passing NULL is a no-op.
+///
+/// # Safety
+/// `magnetic_space_group` must be a pointer returned by
+/// `moyo_magnetic_space_group_new` that has not been freed yet, or NULL.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moyo_magnetic_space_group_free(
+    magnetic_space_group: *mut MoyoMagneticSpaceGroup,
+) {
+    if magnetic_space_group.is_null() {
+        return;
+    }
+    unsafe {
+        drop(Box::from_raw(magnetic_space_group));
+    }
+}

--- a/moyoc/src/identify/point_group.rs
+++ b/moyoc/src/identify/point_group.rs
@@ -1,0 +1,72 @@
+use moyo::base::Lattice;
+use moyo::identify::PointGroup;
+use moyo::utils::{to_3x3_slice, to_matrix3};
+
+/// Point group identified by `moyo_point_group_new` and freed by
+/// `moyo_point_group_free`.
+#[derive(Debug, Clone)]
+#[repr(C)]
+pub struct MoyoPointGroup {
+    /// Number for the arithmetic crystal class (1 - 73).
+    pub arithmetic_number: i32,
+    /// Transformation matrix from the input primitive basis to the standardized basis.
+    pub prim_trans_mat: [[i32; 3]; 3],
+}
+
+/// Identify the point group of the given primitive rotations.
+///
+/// - `prim_rotations`: rotation matrices of the `num_operations` operations in
+///   the primitive cell.
+/// - `basis`: row-wise basis vectors of the primitive lattice, `basis[i]` is
+///   the `i`th basis vector. Pass NULL to assume an identity basis.
+/// - Returns NULL if the identification fails or the arguments are invalid.
+///   Free the result with `moyo_point_group_free`.
+///
+/// # Safety
+/// `prim_rotations` must point to `num_operations` elements, and `basis` must
+/// point to 3 basis vectors or be NULL.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moyo_point_group_new(
+    prim_rotations: *const [[i32; 3]; 3],
+    num_operations: i32,
+    basis: *const [f64; 3],
+) -> *mut MoyoPointGroup {
+    if prim_rotations.is_null() || num_operations <= 0 {
+        return std::ptr::null_mut();
+    }
+    let prim_rotations = unsafe {
+        std::slice::from_raw_parts(prim_rotations, num_operations as usize)
+            .iter()
+            .map(to_matrix3)
+            .collect::<Vec<_>>()
+    };
+
+    let point_group = if basis.is_null() {
+        PointGroup::new(&prim_rotations)
+    } else {
+        let basis = unsafe { *(basis as *const [[f64; 3]; 3]) };
+        PointGroup::from_lattice(&Lattice::from_basis(basis), &prim_rotations)
+    };
+    match point_group {
+        Ok(point_group) => Box::into_raw(Box::new(MoyoPointGroup {
+            arithmetic_number: point_group.arithmetic_number,
+            prim_trans_mat: to_3x3_slice(&point_group.prim_trans_mat),
+        })),
+        Err(_) => std::ptr::null_mut(),
+    }
+}
+
+/// Free a point group created by `moyo_point_group_new`. Passing NULL is a no-op.
+///
+/// # Safety
+/// `point_group` must be a pointer returned by `moyo_point_group_new` that has
+/// not been freed yet, or NULL.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moyo_point_group_free(point_group: *mut MoyoPointGroup) {
+    if point_group.is_null() {
+        return;
+    }
+    unsafe {
+        drop(Box::from_raw(point_group));
+    }
+}

--- a/moyoc/src/identify/space_group.rs
+++ b/moyoc/src/identify/space_group.rs
@@ -1,0 +1,108 @@
+use moyo::base::{Lattice, Operations};
+use moyo::data::Setting;
+use moyo::identify::SpaceGroup;
+
+use crate::base::MoyoOperations;
+use crate::data::MoyoSetting;
+use crate::identify::epsilon_or_default;
+
+/// Space group identified by `moyo_space_group_new` and freed by
+/// `moyo_space_group_free`.
+#[derive(Debug, Clone)]
+#[repr(C)]
+pub struct MoyoSpaceGroup {
+    /// ITA number for the identified space group (1 - 230).
+    pub number: i32,
+    /// Hall symbol number (1 - 530) for the chosen setting.
+    pub hall_number: i32,
+    /// Linear part of the transformation from the input primitive basis to the
+    /// standardized basis.
+    pub linear: [[i32; 3]; 3],
+    /// Origin shift of the transformation from the input primitive basis to the
+    /// standardized basis.
+    pub origin_shift: [f64; 3],
+}
+
+/// Identify the space group from primitive rotations and translations.
+///
+/// - `prim_rotations`, `prim_translations`: rotation and translation parts of
+///   the `num_operations` operations in the primitive cell.
+/// - `basis`: row-wise basis vectors of the primitive lattice, `basis[i]` is
+///   the `i`th basis vector. Pass NULL to assume an identity basis.
+/// - `hall_number`: preference for Hall symbol, only used with
+///   `MOYO_SETTING_HALL_NUMBER`.
+/// - `epsilon`: numerical tolerance for matching translations. Pass a negative
+///   value to use the default tolerance (1e-4).
+/// - Returns NULL if the identification fails or the arguments are invalid.
+///   Free the result with `moyo_space_group_free`.
+///
+/// # Safety
+/// `prim_rotations` and `prim_translations` must point to `num_operations`
+/// elements each, and `basis` must point to 3 basis vectors or be NULL.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moyo_space_group_new(
+    prim_rotations: *const [[i32; 3]; 3],
+    prim_translations: *const [f64; 3],
+    num_operations: i32,
+    basis: *const [f64; 3],
+    setting: MoyoSetting,
+    hall_number: i32,
+    epsilon: f64,
+) -> *mut MoyoSpaceGroup {
+    if prim_rotations.is_null() || prim_translations.is_null() || num_operations <= 0 {
+        return std::ptr::null_mut();
+    }
+    let prim_operations: Operations = (&MoyoOperations {
+        rotations: prim_rotations,
+        translations: prim_translations,
+        num_operations,
+    })
+        .into();
+    let setting = match setting {
+        MoyoSetting::HallNumber => {
+            if hall_number <= 0 {
+                return std::ptr::null_mut();
+            }
+            Setting::HallNumber(hall_number)
+        }
+        MoyoSetting::Spglib => Setting::Spglib,
+        MoyoSetting::Standard => Setting::Standard,
+    };
+    let epsilon = epsilon_or_default(epsilon);
+
+    let space_group = if basis.is_null() {
+        SpaceGroup::new(&prim_operations, setting, epsilon)
+    } else {
+        let basis = unsafe { *(basis as *const [[f64; 3]; 3]) };
+        SpaceGroup::from_lattice(
+            &Lattice::from_basis(basis),
+            &prim_operations,
+            setting,
+            epsilon,
+        )
+    };
+    match space_group {
+        Ok(space_group) => Box::into_raw(Box::new(MoyoSpaceGroup {
+            number: space_group.number,
+            hall_number: space_group.hall_number,
+            linear: space_group.transformation.linear_as_array(),
+            origin_shift: space_group.transformation.origin_shift_as_array(),
+        })),
+        Err(_) => std::ptr::null_mut(),
+    }
+}
+
+/// Free a space group created by `moyo_space_group_new`. Passing NULL is a no-op.
+///
+/// # Safety
+/// `space_group` must be a pointer returned by `moyo_space_group_new` that has
+/// not been freed yet, or NULL.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moyo_space_group_free(space_group: *mut MoyoSpaceGroup) {
+    if space_group.is_null() {
+        return;
+    }
+    unsafe {
+        drop(Box::from_raw(space_group));
+    }
+}

--- a/moyoc/src/lib.rs
+++ b/moyoc/src/lib.rs
@@ -7,6 +7,7 @@ use core::ffi::c_char;
 pub mod base;
 pub mod data;
 pub mod dataset;
+pub mod identify;
 
 pub use base::{
     MoyoCell, MoyoCollinearMagneticCell, MoyoMagneticOperations, MoyoNonCollinearMagneticCell,
@@ -27,6 +28,11 @@ pub use dataset::{
     moyo_collinear_magnetic_dataset_free, moyo_collinear_magnetic_dataset_new, moyo_dataset_free,
     moyo_dataset_new, moyo_layer_dataset_free, moyo_layer_dataset_new,
     moyo_noncollinear_magnetic_dataset_free, moyo_noncollinear_magnetic_dataset_new,
+};
+pub use identify::{
+    MoyoLayerGroup, MoyoMagneticSpaceGroup, MoyoPointGroup, MoyoSpaceGroup, moyo_layer_group_free,
+    moyo_layer_group_new, moyo_magnetic_space_group_free, moyo_magnetic_space_group_new,
+    moyo_point_group_free, moyo_point_group_new, moyo_space_group_free, moyo_space_group_new,
 };
 
 /// Return the version string of moyoc (e.g. "0.11.0").

--- a/moyoc/tests/CMakeLists.txt
+++ b/moyoc/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ endfunction()
 
 add_moyoc_test(test_moyoc_data_entries)
 add_moyoc_test(test_moyoc_dataset)
+add_moyoc_test(test_moyoc_identify)
 add_moyoc_test(test_moyoc_layer_dataset)
 add_moyoc_test(test_moyoc_magnetic_dataset)
 add_moyoc_test(test_moyoc_operations)

--- a/moyoc/tests/test_moyoc_identify.c
+++ b/moyoc/tests/test_moyoc_identify.c
@@ -1,0 +1,125 @@
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "moyoc.h"
+
+void test_point_group(void) {
+    // P3c1 (no. 158) -> arithmetic crystal class 45 (3m1P)
+    MoyoOperations *operations =
+        moyo_operations_from_number(158, MOYO_SETTING_STANDARD, -1, true);
+    assert(operations != NULL);
+
+    MoyoPointGroup *point_group =
+        moyo_point_group_new(operations->rotations, operations->num_operations, NULL);
+    assert(point_group != NULL);
+    printf("arithmetic_number (no. 158): %d\n", point_group->arithmetic_number);
+    assert(point_group->arithmetic_number == 45);
+    moyo_point_group_free(point_group);
+
+    // Identity basis must give the same result as no basis
+    const double identity_basis[3][3] = {
+        {1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}};
+    MoyoPointGroup *point_group_with_basis = moyo_point_group_new(
+        operations->rotations, operations->num_operations, identity_basis);
+    assert(point_group_with_basis != NULL);
+    assert(point_group_with_basis->arithmetic_number == 45);
+    moyo_point_group_free(point_group_with_basis);
+
+    moyo_operations_free(operations);
+
+    // Invalid arguments return NULL
+    const int32_t identity_rotation[1][3][3] = {{{1, 0, 0}, {0, 1, 0}, {0, 0, 1}}};
+    assert(moyo_point_group_new(NULL, 1, NULL) == NULL);
+    assert(moyo_point_group_new(identity_rotation, 0, NULL) == NULL);
+}
+
+void test_space_group(void) {
+    // P31c (no. 159)
+    MoyoOperations *operations =
+        moyo_operations_from_number(159, MOYO_SETTING_STANDARD, -1, true);
+    assert(operations != NULL);
+
+    MoyoSpaceGroup *space_group = moyo_space_group_new(
+        operations->rotations, operations->translations, operations->num_operations,
+        NULL, MOYO_SETTING_STANDARD, -1, -1.0);
+    assert(space_group != NULL);
+    printf("number: %d, hall_number: %d\n", space_group->number,
+           space_group->hall_number);
+    assert(space_group->number == 159);
+    assert(1 <= space_group->hall_number && space_group->hall_number <= 530);
+    moyo_space_group_free(space_group);
+
+    // Invalid arguments return NULL
+    assert(moyo_space_group_new(NULL, operations->translations,
+                                operations->num_operations, NULL,
+                                MOYO_SETTING_STANDARD, -1, -1.0) == NULL);
+    assert(moyo_space_group_new(operations->rotations, operations->translations, 0,
+                                NULL, MOYO_SETTING_STANDARD, -1, -1.0) == NULL);
+    assert(moyo_space_group_new(operations->rotations, operations->translations,
+                                operations->num_operations, NULL,
+                                MOYO_SETTING_HALL_NUMBER, 0, -1.0) == NULL);
+
+    moyo_operations_free(operations);
+}
+
+void test_layer_group(void) {
+    // p6 (LG 65)
+    MoyoOperations *operations =
+        moyo_operations_from_layer_number(65, MOYO_LAYER_SETTING_STANDARD, -1, true);
+    assert(operations != NULL);
+
+    MoyoLayerGroup *layer_group = moyo_layer_group_new(
+        operations->rotations, operations->translations, operations->num_operations,
+        NULL, MOYO_LAYER_SETTING_STANDARD, -1, -1.0);
+    assert(layer_group != NULL);
+    printf("layer number: %d, layer hall_number: %d\n", layer_group->number,
+           layer_group->hall_number);
+    assert(layer_group->number == 65);
+    assert(1 <= layer_group->hall_number && layer_group->hall_number <= 116);
+    moyo_layer_group_free(layer_group);
+
+    // Identity basis exercises the from_lattice path
+    const double identity_basis[3][3] = {
+        {1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}};
+    MoyoLayerGroup *layer_group_with_basis = moyo_layer_group_new(
+        operations->rotations, operations->translations, operations->num_operations,
+        identity_basis, MOYO_LAYER_SETTING_STANDARD, -1, -1.0);
+    assert(layer_group_with_basis != NULL);
+    assert(layer_group_with_basis->number == 65);
+    moyo_layer_group_free(layer_group_with_basis);
+
+    moyo_operations_free(operations);
+}
+
+void test_magnetic_space_group(void) {
+    // R31'_c (UNI 1242)
+    MoyoMagneticOperations *magnetic_operations =
+        moyo_magnetic_operations_from_uni_number(1242, true);
+    assert(magnetic_operations != NULL);
+
+    MoyoMagneticSpaceGroup *magnetic_space_group = moyo_magnetic_space_group_new(
+        magnetic_operations->rotations, magnetic_operations->translations,
+        magnetic_operations->time_reversals, magnetic_operations->num_operations,
+        NULL, -1.0);
+    assert(magnetic_space_group != NULL);
+    printf("uni_number: %d\n", magnetic_space_group->uni_number);
+    assert(magnetic_space_group->uni_number == 1242);
+    moyo_magnetic_space_group_free(magnetic_space_group);
+
+    // Invalid arguments return NULL
+    assert(moyo_magnetic_space_group_new(
+               magnetic_operations->rotations, magnetic_operations->translations,
+               NULL, magnetic_operations->num_operations, NULL, -1.0) == NULL);
+
+    moyo_magnetic_operations_free(magnetic_operations);
+}
+
+int main(void) {
+    test_point_group();
+    test_space_group();
+    test_layer_group();
+    test_magnetic_space_group();
+    return 0;
+}


### PR DESCRIPTION
## Summary

Adds group identification to the moyoc C API (parity with moyopy's `PointGroup`, `SpaceGroup`, `LayerGroup`, and `MagneticSpaceGroup` classes), and mirrors it in the Fortran interface.

- `moyo_point_group_new(prim_rotations, num_operations, basis)` -- arithmetic crystal class (1-73) and primitive transformation matrix from a list of primitive rotations
- `moyo_space_group_new(prim_rotations, prim_translations, num_operations, basis, setting, hall_number, epsilon)` -- ITA number, Hall number, and transformation from primitive operations
- `moyo_layer_group_new(...)` -- layer-group number (1-80), layer Hall number, and transformation (same shape, with `MoyoLayerSetting`)
- `moyo_magnetic_space_group_new(prim_rotations, prim_translations, prim_time_reversals, num_operations, basis, epsilon)` -- UNI number and transformation from primitive magnetic operations
- Matching `*_free` functions; all constructors return NULL on failure or invalid input
- Conventions: `basis` is nullable (NULL assumes an identity basis, non-NULL exercises the `from_lattice` path); negative `epsilon` selects the moyopy default (1e-4); `hall_number` is only used with the `HALL_NUMBER` settings
- Fortran: `bind(c)` derived types and interfaces for all eight new functions, taking `type(c_ptr)` operation arrays so `moyo_operations_from_number` results pass through directly (keeps moyof a complete mirror of the C API)
- Root README interface matrix updated: C group identification rows are now ✅ for layer/magnetic and 🟡 for space group (`integral_normalizer` is not bound)

## Test plan

- [x] `cargo test -p moyoc` (4 new Rust round-trip tests), `cargo clippy -p moyoc --all-targets` clean
- [x] `ctest` passes under ASan: new `test_moyoc_identify` (P3c1 -> arithmetic class 45, P31c -> no. 159, p6 -> LG 65 with and without explicit basis, UNI 1242 round trip, NULL for invalid inputs)
- [x] Fortran `test_moyof_dataset` extended with a P31c identification round trip via `moyo_space_group_new`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
