### PR TITLE
docs: update changelog and tidy interface documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 Unlisted patch versions (e.g. v0.7.1, v0.7.3, v0.7.6, v0.7.7) contain only dependency or build updates with no user-visible changes.
 
+## Unreleased
+
+### moyoc
+
+- Redesign the C API: rename the entry points to `moyo_dataset_new`/`moyo_dataset_free`, add `moyo_version()`, and use `int32_t` counts/index arrays and `const double (*)[3]` array parameters (#354)
+- Build and package moyoc with CMake and [corrosion](https://github.com/corrosion-rs/corrosion): consume the `moyo::moyoc` target via `FetchContent`, generate `moyoc.h` at build time, and `cmake --install` an include/lib layout for non-CMake users (#354)
+- Add magnetic dataset API: `moyo_collinear_magnetic_dataset_new` and `moyo_noncollinear_magnetic_dataset_new` (#355)
+- Add layer dataset API: `moyo_layer_dataset_new` (#356)
+- Add database operation generators: `moyo_operations_from_number`, `moyo_operations_from_layer_number`, and `moyo_magnetic_operations_from_uni_number` (#357)
+- Add group-type metadata lookups: `moyo_hall_symbol_entry_new`, `moyo_layer_hall_symbol_entry_new`, `moyo_space_group_type_new`, `moyo_layer_group_type_new`, and `moyo_magnetic_space_group_type_new` (#358)
+- Add a Fortran interface wrapping the complete C API, exposed as the optional `moyo::moyof` CMake target (`-DMOYOC_BUILD_FORTRAN=ON`) (#359)
+- Add group identification from primitive symmetry operations: `moyo_point_group_new`, `moyo_space_group_new`, `moyo_layer_group_new`, and `moyo_magnetic_space_group_new`, mirrored in the Fortran interface (#360)
+
 ## v0.11.0 - 2026-06-09
 
 ### moyo

--- a/README.md
+++ b/README.md
@@ -17,25 +17,25 @@ A fast and robust crystal symmetry finder, written in Rust.
     <figcaption><a href="bench/mp/analysis.ipynb">Several times faster symmetry detection than Spglib for Materials Project dataset</a></figcaption>
 </figure>
 
-- Rust support available via [crates.io](https://crates.io/crates/moyo): [Docs](https://docs.rs/moyo/latest/moyo/)
-- Python support available via [PyPI](https://pypi.org/project/moyopy/): [Docs](https://spglib.github.io/moyo/python/)
-- JavaScript and WebAssembly support available via [npm](https://www.npmjs.com/package/@spglib/moyo-wasm)
-- C and Fortran support available via CMake: [moyoc](moyoc/README.md)
-- Browse the 230 space groups, 80 layer groups, and 1651 magnetic space groups
-  in the **moyo Crystallographic Group Viewer** at
-  <https://spglib.github.io/moyo/> (static SPA powered by `moyo-wasm`).
-
 ## Interfaces
 
-- [Rust](moyo/README.md): core implementation
-- [Python](moyopy/README.md): Python binding
-- [C](moyoc/README.md): C binding
-- [Fortran](moyoc/README.md#fortran-interface): Fortran interface on top of the
-  C binding (optional `moyo::moyof` CMake target)
-- [JavaScript](moyo-wasm/README.md): JavaScript and WebAssembly binding
-- [Web viewer](apps/web/README.md): static Svelte + Vite + KaTeX SPA on top
-  of `moyo-wasm`, deployed to GitHub Pages via
-  `.github/workflows/deploy-web.yml`
+Each interface has its own README with installation, usage, and development
+instructions:
+
+- [Rust (`moyo`)](moyo/README.md): core implementation
+  ([crates.io](https://crates.io/crates/moyo),
+  [docs](https://docs.rs/moyo/latest/moyo/))
+- [Python (`moyopy`)](moyopy/README.md): Python binding
+  ([PyPI](https://pypi.org/project/moyopy/),
+  [docs](https://spglib.github.io/moyo/python/))
+- [C (`moyoc`)](moyoc/README.md): C binding, built and consumed with CMake
+- [Fortran](moyoc/README.md#fortran-interface): Fortran interface on top of
+  the C binding (optional `moyo::moyof` CMake target)
+- [JavaScript (`moyo-wasm`)](moyo-wasm/README.md): JavaScript and WebAssembly
+  binding ([npm](https://www.npmjs.com/package/@spglib/moyo-wasm))
+- [Web viewer](apps/web/README.md): browse the 230 space groups, 80 layer
+  groups, and 1651 magnetic space groups at <https://spglib.github.io/moyo/>
+  (static SPA powered by `moyo-wasm`)
 
 The functionality categories below mirror the sections of the [moyopy API
 reference](https://spglib.github.io/moyo/python/api.html).

--- a/moyo-wasm/README.md
+++ b/moyo-wasm/README.md
@@ -1,22 +1,26 @@
-# `moyo-wasm`
+# moyo-wasm
 
-WASM bindings for the Rust crystal symmetry library `moyo`, for use in web apps.
+[![image](https://img.shields.io/npm/v/%40spglib%2Fmoyo-wasm)](https://www.npmjs.com/package/@spglib/moyo-wasm)
+
+JavaScript and WebAssembly interface of [moyo](https://github.com/spglib/moyo), a fast and robust crystal symmetry finder.
+
+- npm: <https://www.npmjs.com/package/@spglib/moyo-wasm>
+
+## Installation
+
+```shell
+npm install @spglib/moyo-wasm
+# or from a cloned repo during development
+npm install file:/path/to/moyo/moyo-wasm/pkg
+```
 
 ## Usage
-
-Install from a registry or local path:
-
-```bash
-pnpm add moyo-wasm
-# or from cloned repo during development
-pnpm add file:/path/to/moyo/moyo-wasm/pkg
-```
 
 Initialize and analyze a structure:
 
 ```ts
-import init, { analyze_cell, type MoyoDataset, type MoyoCell } from 'moyo-wasm'
-import wasm_url from 'moyo-wasm/moyo_wasm_bg.wasm?url'
+import init, { analyze_cell, type MoyoDataset, type MoyoCell } from '@spglib/moyo-wasm'
+import wasm_url from '@spglib/moyo-wasm/moyo_wasm_bg.wasm?url'
 
 await init(wasm_url)
 
@@ -36,24 +40,18 @@ console.log(`Wyckoffs: ${result.wyckoffs.join(', ')}`)
 
 The package exports TypeScript types generated from Rust (e.g. `MoyoDataset`).
 
-## Building
+## Development
 
-```bash
-wasm-pack build moyo-wasm --target web --release
+Run from the repo root with `just` (or the equivalent npm commands from this directory):
+
+```shell
+just js-install   # npm install
+just js-build     # wasm-pack build --target web --release --scope spglib
+just js-test      # npm test
 ```
 
-The package code ready for publishing is in `moyo-wasm/pkg`.
+The package code ready for publishing is generated in `moyo-wasm/pkg`. It is published to npm by CI when a new git tag is pushed to the monorepo.
 
-## Testing
+## How to cite moyo-wasm
 
-```bash
-cd moyo-wasm
-# Install dependencies
-npm install
-# Run tests
-npm test
-```
-
-## Publish
-
-This crate is published as an [NPM package](https://www.npmjs.com/package/@spglib/moyo-wasm) with CI when a new `git` tag is pushed to the Rust monorepo.
+See the citation information in [the root README](https://github.com/spglib/moyo/blob/main/README.md)

--- a/moyo/README.md
+++ b/moyo/README.md
@@ -8,13 +8,6 @@ The core implementation of moyo in Rust
 - Crates.io: https://crates.io/crates/moyo
 - Document: https://docs.rs/moyo/latest/moyo/
 
-## Module dependency
-
-```
-math <- base <- data <- identify <- standardize <- lib
-        ^---- search <--------------|
-```
-
 ## Goals
 
 - Find symmetry operations of a given crystal structure, identify its crystallographic group, and symmetrize the given crystal structure
@@ -26,6 +19,22 @@ math <- base <- data <- identify <- standardize <- lib
 
 - Crystallographic groups in other than three dimensions
 - Matching two similar crystal structures
+
+## Development
+
+Run from the repo root with `just`:
+
+```shell
+just test   # cargo test
+just doc    # cargo doc --open
+```
+
+### Module dependency
+
+```
+math <- base <- data <- identify <- standardize <- lib
+        ^---- search <--------------|
+```
 
 ## How to cite moyo
 

--- a/moyoc/README.md
+++ b/moyoc/README.md
@@ -44,6 +44,8 @@ This installs `include/moyoc.h`, `lib/libmoyoc.a`, and `lib/libmoyoc.{so,dylib}`
 non-CMake consumers. Prebuilt archives with this layout are attached to
 [GitHub releases](https://github.com/spglib/moyo/releases).
 
+From the repo root, `just c-build` and `just c-test` wrap the configure/build/test steps.
+
 ## API
 
 See the generated `moyoc.h` for the full API. The main entry points are:
@@ -166,3 +168,7 @@ call c_f_pointer(handle, dataset)
 ! ... read dataset fields ...
 call moyo_dataset_free(handle)
 ```
+
+## How to cite moyoc
+
+See the citation information in [the root README](../README.md)

--- a/moyopy/README.md
+++ b/moyopy/README.md
@@ -18,6 +18,17 @@ pip install moyopy
 pip install moyopy[interface]
 ```
 
+## Development
+
+Run from the repo root with `just`:
+
+```shell
+just py-install   # uv sync
+just py-build     # maturin develop
+just py-test      # pytest
+just py-docs      # build and serve the Sphinx docs
+```
+
 ## How to cite moyopy
 
 See the citation information in [the root README](https://github.com/spglib/moyo/blob/main/README.md)


### PR DESCRIPTION
## Summary

- Add an `Unreleased` CHANGELOG section covering the moyoc overhaul merged since v0.11.0 (#354-#360): the CMake/corrosion rebuild and C API redesign, magnetic/layer dataset APIs, database operation generators, group-type metadata lookups, the Fortran interface, and group identification
- Tidy the scattered interface documentation:
  - Root README: merge the two overlapping interface lists (registry bullets + `Interfaces` section) into a single section linking each interface's README, registry, and docs
  - Align the per-interface READMEs (`moyo`, `moyopy`, `moyoc`, `moyo-wasm`) to a common shape: intro with registry/docs links, installation/usage, a Development section pointing at the `just` recipes, and a citation pointer to the root README
  - Fix the moyo-wasm README to install/import the published package name `@spglib/moyo-wasm` (it is built with `wasm-pack --scope spglib`; the previous unscoped `moyo-wasm` name does not exist on npm) and add the npm badge

## Test plan

- [x] `prek run --all-files` (mdformat, typos, etc.) passes
- [x] Docs-only change; no code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
