### PR TITLE
docs: autogenerate the moyoc C API reference with Doxygen

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -7,6 +7,7 @@ on:
       - 'moyo/**'
       - 'moyo-wasm/**'
       - 'moyopy/**'
+      - 'moyoc/**'
       - 'apps/web/**'
       - '.github/workflows/deploy-web.yml'
   pull_request:
@@ -15,6 +16,7 @@ on:
       - 'moyo/**'
       - 'moyo-wasm/**'
       - 'moyopy/**'
+      - 'moyoc/**'
       - 'apps/web/**'
       - '.github/workflows/deploy-web.yml'
   workflow_dispatch:
@@ -92,6 +94,25 @@ jobs:
 
       - name: Build docs into web app under /python
         run: sphinx-build moyopy/docs apps/web/dist/python
+
+      - name: Install Doxygen
+        run: |
+          set -e
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends doxygen
+
+      - name: Install cbindgen
+        uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2.81.10
+        with:
+          tool: cbindgen
+
+      - name: Build C API docs into web app under /c
+        working-directory: moyoc
+        run: |
+          set -e
+          cbindgen --config cbindgen.toml --output build/moyoc.h
+          doxygen Doxyfile
+          cp -r build/docs/html ../apps/web/dist/c
 
       - name: Configure Pages
         if: github.event_name != 'pull_request'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Unlisted patch versions (e.g. v0.7.1, v0.7.3, v0.7.6, v0.7.7) contain only depen
 - Add group-type metadata lookups: `moyo_hall_symbol_entry_new`, `moyo_layer_hall_symbol_entry_new`, `moyo_space_group_type_new`, `moyo_layer_group_type_new`, and `moyo_magnetic_space_group_type_new` (#358)
 - Add a Fortran interface wrapping the complete C API, exposed as the optional `moyo::moyof` CMake target (`-DMOYOC_BUILD_FORTRAN=ON`) (#359)
 - Add group identification from primitive symmetry operations: `moyo_point_group_new`, `moyo_space_group_new`, `moyo_layer_group_new`, and `moyo_magnetic_space_group_new`, mirrored in the Fortran interface (#360)
+- Publish the Doxygen-generated C API reference at <https://spglib.github.io/moyo/c/> (#363)
 
 ## v0.11.0 - 2026-06-09
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ instructions:
   ([PyPI](https://pypi.org/project/moyopy/),
   [docs](https://spglib.github.io/moyo/python/))
 - [C (`moyoc`)](moyoc/README.md): C binding, built and consumed with CMake
+  ([docs](https://spglib.github.io/moyo/c/))
 - [Fortran](moyoc/README.md#fortran-interface): Fortran interface on top of
   the C binding (optional `moyo::moyof` CMake target)
 - [JavaScript (`moyo-wasm`)](moyo-wasm/README.md): JavaScript and WebAssembly

--- a/justfile
+++ b/justfile
@@ -72,6 +72,12 @@ c-test: c-build
 
 [group('c')]
 [working-directory: 'moyoc']
+c-docs:
+    cbindgen --config cbindgen.toml --output build/moyoc.h
+    doxygen Doxyfile
+
+[group('c')]
+[working-directory: 'moyoc']
 c-clean:
     rm -rf build
 

--- a/moyoc/Doxyfile
+++ b/moyoc/Doxyfile
@@ -1,0 +1,12 @@
+PROJECT_NAME           = "moyoc"
+PROJECT_BRIEF          = "C interface of moyo, a fast and robust crystal symmetry finder"
+INPUT                  = build/moyoc.h
+OUTPUT_DIRECTORY       = build/docs
+FULL_PATH_NAMES        = NO
+OPTIMIZE_OUTPUT_FOR_C  = YES
+TYPEDEF_HIDES_STRUCT   = YES
+EXTRACT_ALL            = YES
+JAVADOC_AUTOBRIEF      = YES
+GENERATE_LATEX         = NO
+QUIET                  = YES
+WARN_IF_UNDOCUMENTED   = NO

--- a/moyoc/README.md
+++ b/moyoc/README.md
@@ -3,6 +3,8 @@
 C bindings for [moyo](https://github.com/spglib/moyo), built with CMake and
 [corrosion](https://github.com/corrosion-rs/corrosion).
 
+- API reference: <https://spglib.github.io/moyo/c/>
+
 ## Requirements
 
 - CMake >= 3.23
@@ -48,7 +50,9 @@ From the repo root, `just c-build` and `just c-test` wrap the configure/build/te
 
 ## API
 
-See the generated `moyoc.h` for the full API. The main entry points are:
+See the [API reference](https://spglib.github.io/moyo/c/) (generated with
+Doxygen from `moyoc.h`; build it locally with `just c-docs`). The main entry
+points are:
 
 ```c
 // Space-group symmetry analysis


### PR DESCRIPTION
## Summary

- Autogenerate the moyoc C API reference with Doxygen and publish it at <https://spglib.github.io/moyo/c/> from the Pages deploy workflow. The single source of truth is the Rust `///` doc comments: cbindgen already emits them as `/** ... */` blocks in `moyoc.h`, so no documentation is hand-maintained.
- Add a minimal `moyoc/Doxyfile` (input: the generated `build/moyoc.h`, HTML-only output under `build/docs`)
- Add a `just c-docs` recipe to build the reference locally (`cbindgen` + `doxygen`)
- Extend `deploy-web.yml`: trigger on `moyoc/**` changes, install Doxygen and cbindgen (via `taiki-e/install-action`, SHA-pinned), generate the header, and copy the Doxygen HTML into `apps/web/dist/c`
- Link the published reference from the root README interface list and the moyoc README, and add a changelog entry

## Test plan

- [x] `cbindgen --config cbindgen.toml --output build/moyoc.h` verified locally: the generated header carries complete `/** */` doc blocks for every function, struct, and enum (cbindgen creates the output directory itself, so it works on a fresh checkout)
- [x] `prek run --all-files` passes
- [ ] The `deploy-web` build job runs on this PR (it touches the workflow file) and exercises the new Doxygen step end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)
