### PR TITLE
ci: add moyoc and web-viewer sections to release notes

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -26,6 +26,18 @@ changelog:
       exclude:
         labels:
           - renovate
+    - title: 🔧 moyoc
+      labels:
+        - moyoc
+      exclude:
+        labels:
+          - renovate
+    - title: 🌐 web-viewer
+      labels:
+        - web-viewer
+      exclude:
+        labels:
+          - renovate
     - title: 🐞 Bug fixes
       labels:
         - bug


### PR DESCRIPTION
## Summary
- Add `🔧 moyoc` and `🌐 web-viewer` categories to auto-generated release notes config (`.github/release.yaml`)
- Both follow the existing per-crate pattern: match the crate label, exclude `renovate`

## Test plan
- Config-only change; takes effect on next tagged release via `generate_release_notes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
