### PR TITLE
chore: migrate mdformat to rumdl

### DIFF
--- a/.claude/skills/port-rust-docs-to-pyi/SKILL.md
+++ b/.claude/skills/port-rust-docs-to-pyi/SKILL.md
@@ -62,6 +62,7 @@ Type-checker tooltips will go stale. After editing the Rust side, mirror to the 
 - **Style**: NumPy-style. Class-level docstring first, then per-method/getter/property. Constructors get a `Parameters` section. Avoid Google-style `Args:` -- the project uses NumPy throughout.
 - **Inline code**: double backticks (RST/Sphinx style): ` `cell.basis` `, ` `symprec` `. Markdown single backticks render wrong in Sphinx.
 - **Code blocks in Rust `///`**: never use indented blocks (rustdoc treats them as Rust and runs them as doctests). Use fenced ```` ```text ```` blocks:
+
   ````rust
   /// Same transformation convention as the standardized cell:
   ///
@@ -69,6 +70,7 @@ Type-checker tooltips will go stale. After editing the Rust side, mirror to the 
   /// std_cell.basis.T = std_rotation_matrix @ cell.basis.T @ std_linear
   /// ```
   ````
+
 - **Code blocks in `.pyi`**: RST `::` followed by indent, OR fenced -- both render in Sphinx. Match the existing surrounding style in the file you're editing.
 - **Cross-references in `.pyi`**: use `:attr:`, `:class:`, `:func:` (Sphinx). In Rust `///`, plain prose is fine -- the Rust doc tree is not used by the Python project.
 - **Module attribute** (CRITICAL): keep `#[pyo3(module = "moyopy")]` on every `#[pyclass]` and `#[pyfunction]`. Do **not** change to `"moyopy._moyopy"` -- it leaks the hidden submodule into `__module__`, `repr()`, and pickle. The reviewer rejected this.
@@ -78,7 +80,7 @@ Type-checker tooltips will go stale. After editing the Rust side, mirror to the 
 
 After porting, run all of:
 
-```
+```text
 # rebuild bindings
 PYO3_PYTHON=/path/to/moyopy/.venv/bin/python uv run --directory moyopy maturin develop --release --manifest-path Cargo.toml
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,17 +22,11 @@ repos:
         exclude: ^(moyopy|bench)/uv\.lock
       - id: check-merge-conflict
       - id: detect-private-key
-  - repo: https://github.com/executablebooks/mdformat
-    rev: 1.0.0
+  - repo: https://github.com/rvben/rumdl-pre-commit
+    rev: v0.2.23
     hooks:
-      - id: mdformat
-        additional_dependencies:
-          - mdformat-gfm
-          - mdformat-myst
-          - mdformat-admon
-        # Zensical pages use mkdocstrings (`:::`), autorefs (`[`x`][x]`) and
-        # pymdownx snippets (`--8<--`), which mdformat escapes and breaks.
-        exclude: ^moyopy/docs/(index|api|api_layer_group|api_magnetic_space_group|examples/index)\.md$
+      - id: rumdl
+        args: [--fix]
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.37.3
     hooks:

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -1,0 +1,14 @@
+# Markdown linting and formatting (replaces mdformat).
+# https://github.com/rvben/rumdl
+
+[global]
+flavor = "gfm"
+# mdformat never enforced these, and the repo relies on long lines, inline HTML
+# (README badges/figures), and non-heading first lines (HTML wrappers, snippets).
+disable = ["MD013", "MD033", "MD041"]
+
+# Zensical (MkDocs) pages use mkdocstrings (`:::`), autorefs (`[x][x]`) and
+# pymdownx snippets (`--8<--`). The mkdocs flavor understands this syntax, which
+# mdformat could not (those pages were previously excluded).
+[per-file-flavor]
+"moyopy/docs/**/*.md" = "mkdocs"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ RUST_LOG=debug cargo test -- --nocapture  # With debug output
 
 Module dependency graph within `moyo/`:
 
-```
+```text
 math <- base <- data <- identify <- standardize <- lib
         ^---- search <--------------|
 ```

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Notes:
 
 If you use moyo or its interfaces in your work, please cite the following figshare entry.
 
-```
+```text
 @misc{moyo,
   author = {Kohei Shinohara},
   title  = {{moyo: A fast and robust crystal symmetry finder, written in Rust}},

--- a/moyo/README.md
+++ b/moyo/README.md
@@ -5,8 +5,8 @@
 
 The core implementation of moyo in Rust
 
-- Crates.io: https://crates.io/crates/moyo
-- Document: https://docs.rs/moyo/latest/moyo/
+- Crates.io: <https://crates.io/crates/moyo>
+- Document: <https://docs.rs/moyo/latest/moyo/>
 
 ## Goals
 
@@ -31,7 +31,7 @@ just doc    # cargo doc --open
 
 ### Module dependency
 
-```
+```text
 math <- base <- data <- identify <- standardize <- lib
         ^---- search <--------------|
 ```

--- a/moyopy/docs/migration.md
+++ b/moyopy/docs/migration.md
@@ -37,7 +37,7 @@ Replace with `MoyoDataset`.
 
 If you need to specify `hall_number`, use
 
-```
+```text
 MoyoDataset(..., setting=Setting.hall_number(hall_number))
 ```
 


### PR DESCRIPTION
## Summary

Migrate the Markdown formatting hook from [mdformat](https://github.com/executablebooks/mdformat) to [rumdl](https://github.com/rvben/rumdl) (linter + auto-fix).

- **`.pre-commit-config.yaml`**: replace the `executablebooks/mdformat` hook (gfm/myst/admon deps + Zensical exclude) with `rvben/rumdl-pre-commit` `v0.2.23`, running `rumdl --fix`.
- **`.rumdl.toml`** (new, repo root -- there is no root `pyproject.toml`): configured to stay close to mdformat's behavior rather than rumdl's stricter defaults:
  - `flavor = "gfm"`
  - `disable = ["MD013", "MD033", "MD041"]` (line length, inline HTML, first-line H1). mdformat never enforced these, and the repo relies on long lines, README badges/figures, and HTML/snippet first lines. Without this, rumdl flagged 267 issues (94% line-length).
  - `per-file-flavor` -> `mkdocs` for `moyopy/docs/**`, so mkdocstrings (`:::`), autorefs (`[x][x]`) and pymdownx snippets (`--8<--`) are understood. These Zensical pages previously had to be excluded from mdformat; rumdl now handles them cleanly, so the exclude is dropped.
- Apply the resulting auto-fixes: bare code fences tagged `text`, bare URLs wrapped in angle brackets, blank lines around fences.

## Test plan

- [x] `prek run --all-files` passes all hooks, including `rumdl check`.
- [x] The 5 previously-excluded Zensical pages (`index`, `api`, `api_layer_group`, `api_magnetic_space_group`, `examples/index`) produce zero rumdl issues with the mkdocs flavor.

[Claude Code] Generated with [Claude Code](https://claude.com/claude-code)
