### PR TITLE
fix(symmetrize): prefer non-acute monoclinic angle in standardization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 Unlisted patch versions (e.g. v0.7.1, v0.7.3, v0.7.6, v0.7.7) contain only dependency or build updates with no user-visible changes.
 
+## Unreleased
+
+### moyo
+
+- Fix `standardize_monoclinic_conv_cell` returning an acute angle between the `a` and `c` axes of the standardized monoclinic conventional cell. The acute angle and its non-acute supplement scored equally under the skewness metric, so the tie-break could pick the acute one; ties are now broken in favor of the non-acute angle required by the ITA convention (#377)
+
 ## v0.12.0 - 2026-06-13
 
 ### moyoc

--- a/moyo/src/symmetrize/standardize.rs
+++ b/moyo/src/symmetrize/standardize.rs
@@ -513,21 +513,36 @@ fn standardize_monoclinic_conv_cell(
             transformation_to_prim_std.origin_shift,
         );
         let refined_conv_lattice = refined_conv_trans.transform_lattice(prim_lattice);
-        // `skewness` gets smaller as the basis vectors are closer to orthorhombic.
-        let skewness = refined_conv_lattice.lattice_constant()[3..]
+        let cos_angles = refined_conv_lattice.lattice_constant()[3..]
             .iter()
-            .map(|angle_deg| angle_deg.to_radians().cos().abs())
-            .sum::<f64>();
-        candidate_conv_transformations.push((skewness, centering.linear() * trans_corr.linear));
+            .map(|angle_deg| angle_deg.to_radians().cos())
+            .collect::<Vec<_>>();
+        // `skewness` gets smaller as the basis vectors are closer to orthorhombic.
+        let skewness = cos_angles.iter().map(|cos| cos.abs()).sum::<f64>();
+        // The monoclinic angle and its supplement give the same `skewness`
+        // (`|cos|` is symmetric about 90 deg), so the unimodular correction that
+        // flips the angle to its supplement is an equally valid candidate. Among
+        // such ties we follow the ITA convention and prefer a non-acute angle,
+        // i.e. the smaller (more negative) signed cosine sum.
+        let signed_cos_sum = cos_angles.iter().sum::<f64>();
+        candidate_conv_transformations.push((
+            skewness,
+            signed_cos_sum,
+            centering.linear() * trans_corr.linear,
+        ));
     }
 
     candidate_conv_transformations
         .into_iter()
-        .min_by(|(skewness_lhs, _), (skewness_rhs, _)| {
-            skewness_lhs.partial_cmp(skewness_rhs).unwrap()
+        .min_by(|(skewness_lhs, cos_lhs, _), (skewness_rhs, cos_rhs, _)| {
+            if (skewness_lhs - skewness_rhs).abs() < EPS {
+                cos_lhs.partial_cmp(cos_rhs).unwrap()
+            } else {
+                skewness_lhs.partial_cmp(skewness_rhs).unwrap()
+            }
         })
         .unwrap()
-        .1
+        .2
 }
 
 /// Test whether `position` matches a Wyckoff orbit described by `coordinates`

--- a/moyo/tests/test_moyo_dataset.rs
+++ b/moyo/tests/test_moyo_dataset.rs
@@ -901,3 +901,38 @@ fn test_with_nickeline() {
         epsilon = 1e-8
     );
 }
+
+#[test]
+fn test_monoclinic_non_acute_angle() {
+    // Primitive monoclinic lattice (unique axis b) whose `a`-`c` basis vectors
+    // subtend an acute angle (beta ~ 72 deg). A single atom at the origin gives
+    // space group P2/m (#10). The supplement transformation that flips beta to
+    // its obtuse partner preserves both the 2/m generators and the (trivial)
+    // primitive centering, so standardization must follow the ITA convention
+    // and return a non-acute monoclinic angle. Before the tie-break fix this
+    // input standardized to an acute beta (cos beta ~ 0.31).
+    let lattice = Lattice::new(matrix![
+        4.0, 0.0, 0.0;
+        0.0, 5.0, 0.0;
+        1.0, 0.0, 3.1;
+    ]);
+    let positions = vec![Vector3::new(0.0, 0.0, 0.0)];
+    let numbers = vec![0];
+    let cell = Cell::new(lattice, positions, numbers);
+
+    let symprec = 1e-4;
+    let dataset = assert_dataset_with_default(&cell, symprec);
+    assert_eq!(dataset.number, 10); // P2/m
+
+    // Every angle of the standardized conventional cell must be non-acute.
+    let basis = dataset.std_cell.lattice.basis;
+    for (i, j) in [(0, 1), (0, 2), (1, 2)] {
+        let vi = basis.column(i);
+        let vj = basis.column(j);
+        let cos_angle = vi.dot(&vj) / (vi.norm() * vj.norm());
+        assert!(
+            cos_angle < 1e-6,
+            "acute angle between basis vectors {i} and {j}: cos = {cos_angle}"
+        );
+    }
+}

--- a/moyopy/docs/standardization.md
+++ b/moyopy/docs/standardization.md
@@ -51,7 +51,7 @@ Note that `rotate_basis=true` is assumed, and that the input basis vectors are r
 | Crystal family | "Conventional" basis vectors $\mathbf{A}_{\mathrm{std}}$ <br> (`MoyoDataset.std_cell.basis`) | Additional conditions                                             |
 | -------------- | -------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
 | Triclinic      | $\begin{pmatrix} a_x & b_x & c_x \\ a_y & b_y & c_y \\ a_z & b_z & c_z \end{pmatrix}$        | Niggli reduced [^std-cell-2]; $a_x, b_y, c_z \gt 0$ [^std-cell-3] |
-| Monoclinic     | $\begin{pmatrix} a & 0 & c \cos \beta \\ 0 & b & 0 \\ 0 & 0 & c \sin \beta \end{pmatrix}$    | $a, b, c \sin \beta \gt 0$ [^std-cell-4] [^std-cell-7]            |
+| Monoclinic     | $\begin{pmatrix} a & 0 & c \cos \beta \\ 0 & b & 0 \\ 0 & 0 & c \sin \beta \end{pmatrix}$    | $a, b, c \sin \beta \gt 0$; $\cos \beta \le 0$ [^std-cell-4] [^std-cell-7] |
 | Orthorhombic   | $\begin{pmatrix} a & 0 & 0 \\ 0 & b & 0 \\ 0 & 0 & c \end{pmatrix}$                          | $a, b, c \gt 0$ [^std-cell-4] [^std-cell-6]                       |
 | Tetragonal     | $\begin{pmatrix} a & 0 & 0 \\ 0 & a & 0 \\ 0 & 0 & c \end{pmatrix}$                          | $a, c \gt 0$ [^std-cell-4]                                        |
 | Hexagonal      | $\begin{pmatrix} a & -a / 2 & 0 \\0 & \sqrt{3} a / 2 & 0 \\ 0 & 0 & c \end{pmatrix}$         | $a, c > 0$ [^std-cell-4]                                          |
@@ -98,7 +98,7 @@ $$
 
 [^std-cell-4]: $c < 0$ for left-handed input basis vectors.
 
-[^std-cell-7]: moyo tries to bring $\beta$ closer to $\pi / 2$ as much as possible.
+[^std-cell-7]: moyo brings $\beta$ as close to $\pi / 2$ as possible and, following the ITA convention, chooses the non-acute value ($\pi / 2 \le \beta \lt \pi$, i.e. $\cos \beta \le 0$) when the acute and obtuse choices are equally close to $\pi / 2$.
 
 [^std-cell-6]: Currently, moyo does not enforce the order in $a$, $b$, and $c$.
 


### PR DESCRIPTION
## Summary

`standardize_monoclinic_conv_cell` sometimes returned an **acute** angle between the `a` and `c` axes of the standardized monoclinic conventional cell, instead of the non-acute angle required by the ITA convention.

**Root cause:** candidate conventional cells are ranked by `skewness = sum |cos(angle)|`. Because `|cos|` is symmetric about 90 deg, an acute monoclinic angle and its obtuse supplement (`180 - beta`) score identically, so the `min_by` tie-break between them was arbitrary and could return the acute one.

This is **not** a fundamental conflict with preserving symmetry: the supplement transformation that flips the angle (e.g. `diag(-1, -1, 1)`) is in the bounded `UNIMODULAR3_RANGE1` search window, commutes with the monoclinic generators, and preserves P/C centering. So both the acute and obtuse cells are always equally-valid candidates with equal skewness.

**Fix:** break skewness ties (within `EPS`) in favor of the smaller (more negative) signed cosine sum, which selects the non-acute angle. Primary ordering is still by skewness, so genuinely better-reduced cells are unaffected; only true ties get the non-acute preference. When the obtuse supplement is not a valid candidate (would break a screw/glide), the code keeps whatever valid candidate exists, so symmetry can never be broken.

## Changes

- `moyo/src/symmetrize/standardize.rs`: tie-break selection now prefers the non-acute monoclinic angle.
- `moyo/tests/test_moyo_dataset.rs`: add `test_monoclinic_non_acute_angle` (P2/m).
- `CHANGELOG.md`: note the fix under a new Unreleased section.
- `moyopy/docs/standardization.md`: specify `cos beta <= 0` (non-acute, `pi/2 <= beta < pi`) for the standardized monoclinic cell and clarify footnote `[^std-cell-7]`.

## Test plan

- Added `test_monoclinic_non_acute_angle` (P2/m, unique axis b). Confirmed it **fails on the previous logic** (standardizes to `cos beta ~ 0.31`, acute) and **passes with the fix**.
- Full suite green: 202 tests (159 unit + integration + doctests), no regressions.
- `prek` pre-commit hooks pass.

[Claude Code] Generated with [Claude Code](https://claude.com/claude-code)
