### PR TITLE
feat(symmetrize): order orthorhombic standardized axes a<=b<=c

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Unlisted patch versions (e.g. v0.7.1, v0.7.3, v0.7.6, v0.7.7) contain only depen
 
 ### moyo
 
+- Order the basis vectors of orthorhombic standardized cells as `a <= b <= c` as much as possible. The axis permutation is chosen among the six candidates that preserve the symmetry operation matrices (as a set) and the centering, deriving seekpath's "number of distinct projections" directly from the operations instead of a hardcoded per-space-group table. This automatically respects the side-face-centered exception (only `a <= b` for `C`/`A`-centered cells) (#378)
 - Fix `standardize_monoclinic_conv_cell` returning an acute angle between the `a` and `c` axes of the standardized monoclinic conventional cell. The acute angle and its non-acute supplement scored equally under the skewness metric, so the tie-break could pick the acute one; ties are now broken in favor of the non-acute angle required by the ITA convention (#377)
 
 ## v0.12.0 - 2026-06-13

--- a/moyo/src/symmetrize/standardize.rs
+++ b/moyo/src/symmetrize/standardize.rs
@@ -484,6 +484,32 @@ static UNIMODULAR3_RANGE1: Lazy<Vec<UnimodularTransformation>> = Lazy::new(|| {
         .collect()
 });
 
+/// The six axis permutations as proper (det = +1) signed-permutation matrices. The
+/// three odd permutations (transpositions) are made right-handed by negating their
+/// first axis, since [`Transformation`] requires a positive determinant.
+///
+/// One proper representative per permutation is sufficient: for every orthorhombic
+/// space group, whether a permutation preserves the operation set and centering does
+/// not depend on the choice of axis signs (the point-group rotations are diagonal, so
+/// conjugation by a sign flip leaves them unchanged, and centering half-translations
+/// absorb the sign of any non-symmorphic translation). The sign-flipped axes are
+/// re-oriented away later by `symmetrize_lattice`.
+static AXIS_PERMUTATIONS3: Lazy<Vec<UnimodularTransformation>> = Lazy::new(|| {
+    [
+        // Even permutations (already det = +1).
+        Matrix3::new(1, 0, 0, 0, 1, 0, 0, 0, 1), // abc (identity)
+        Matrix3::new(0, 1, 0, 0, 0, 1, 1, 0, 0), // cab
+        Matrix3::new(0, 0, 1, 1, 0, 0, 0, 1, 0), // bca
+        // Odd permutations, first axis negated to restore det = +1.
+        Matrix3::new(0, 1, 0, -1, 0, 0, 0, 0, 1), // b(-a)c  (a <-> b)
+        Matrix3::new(-1, 0, 0, 0, 0, 1, 0, 1, 0), // (-a)cb  (b <-> c)
+        Matrix3::new(0, 0, 1, 0, 1, 0, -1, 0, 0), // c b(-a) (a <-> c)
+    ]
+    .into_iter()
+    .map(UnimodularTransformation::from_linear)
+    .collect()
+});
+
 /// Standardize monoclinic cell by choosing reduced basis vectors for perpendicular plane to the unique axis while keeping matrix representations of `conv_std_generators`.
 fn standardize_monoclinic_conv_cell(
     prim_lattice: &Lattice,
@@ -574,13 +600,9 @@ fn standardize_orthorhombic_conv_cell(
     epsilon: f64,
 ) -> Linear {
     let mut candidate_conv_transformations = vec![];
-    // Restrict the bounded `[-1, 1]` search to the six axis permutations (with sign
-    // freedom so that det = +1 and the centering/operation translations can be
-    // matched -- orthorhombic d-glides carry 1/4 translations whose sign matters).
-    for trans_perm in UNIMODULAR3_RANGE1
-        .iter()
-        .filter(|t| is_signed_permutation(&t.linear))
-    {
+    // Consider the six axis permutations and keep those that preserve the centering
+    // and the operation set; pick the one giving the smallest lengths.
+    for trans_perm in AXIS_PERMUTATIONS3.iter() {
         // trans_perm should keep centering translations.
         if centering.lattice_points().iter().any(|translation| {
             let mut diff = trans_perm.linear.map(|e| e as f64) * translation - translation;
@@ -640,17 +662,6 @@ fn standardize_orthorhombic_conv_cell(
         })
         .unwrap()
         .1
-}
-
-/// Whether `mat` is a signed permutation matrix: exactly one nonzero entry, equal to
-/// `+/-1`, in every row and every column.
-fn is_signed_permutation(mat: &Matrix3<i32>) -> bool {
-    let single_unit = |entries: [i32; 3]| {
-        let nonzero: Vec<i32> = entries.into_iter().filter(|&e| e != 0).collect();
-        nonzero.len() == 1 && nonzero[0].abs() == 1
-    };
-    (0..3).all(|i| single_unit([mat[(i, 0)], mat[(i, 1)], mat[(i, 2)]]))
-        && (0..3).all(|j| single_unit([mat[(0, j)], mat[(1, j)], mat[(2, j)]]))
 }
 
 /// Whether two fractional translations are equal modulo the centering lattice (which

--- a/moyo/src/symmetrize/standardize.rs
+++ b/moyo/src/symmetrize/standardize.rs
@@ -3,6 +3,7 @@ use log::{debug, warn};
 use nalgebra::linalg::{Cholesky, QR};
 use nalgebra::{Matrix3, Vector3, vector};
 use once_cell::sync::Lazy;
+use std::cmp::Ordering;
 use std::collections::HashMap;
 
 use crate::base::{
@@ -136,6 +137,16 @@ impl StandardizedCell {
                     &space_group.transformation,
                     entry.centering,
                     &hs.generators,
+                    epsilon,
+                );
+                (space_group.transformation.clone(), trans_std_prim_to_conv)
+            }
+            LatticeSystem::Orthorhombic => {
+                let trans_std_prim_to_conv = standardize_orthorhombic_conv_cell(
+                    &prim_cell.lattice,
+                    &space_group.transformation,
+                    entry.centering,
+                    &conv_std_operations,
                     epsilon,
                 );
                 (space_group.transformation.clone(), trans_std_prim_to_conv)
@@ -543,6 +554,122 @@ fn standardize_monoclinic_conv_cell(
         })
         .unwrap()
         .2
+}
+
+/// Standardize an orthorhombic conventional cell by choosing the axis permutation
+/// that orders the basis-vector lengths as `a <= b <= c` as much as possible, while
+/// keeping the matrix representations of the symmetry operations (as a set) and the
+/// centering.
+///
+/// Unlike the monoclinic case, an axis permutation relabels generators among
+/// themselves, so the *set* of `conv_std_operations` -- not each individual generator
+/// -- must be preserved. Permutations that would change the operation set or move a
+/// centered face (e.g. for `C`-centering) are rejected, which reproduces seekpath's
+/// "number of distinct projections" without a hardcoded per-space-group table.
+fn standardize_orthorhombic_conv_cell(
+    prim_lattice: &Lattice,
+    transformation_to_prim_std: &UnimodularTransformation,
+    centering: Centering,
+    conv_std_operations: &Operations,
+    epsilon: f64,
+) -> Linear {
+    let mut candidate_conv_transformations = vec![];
+    // Restrict the bounded `[-1, 1]` search to the six axis permutations (with sign
+    // freedom so that det = +1 and the centering/operation translations can be
+    // matched -- orthorhombic d-glides carry 1/4 translations whose sign matters).
+    for trans_perm in UNIMODULAR3_RANGE1
+        .iter()
+        .filter(|t| is_signed_permutation(&t.linear))
+    {
+        // trans_perm should keep centering translations.
+        if centering.lattice_points().iter().any(|translation| {
+            let mut diff = trans_perm.linear.map(|e| e as f64) * translation - translation;
+            diff -= diff.map(|e| e.round()); // in [-0.5, 0.5]
+            diff.iter().any(|e| e.abs() > epsilon)
+        }) {
+            continue;
+        }
+
+        // trans_perm should keep the *set* of conv_std_operations: each conjugated
+        // operation must coincide with some operation in the set (rotation exactly,
+        // translation modulo the centering lattice). `conv_std_operations` holds one
+        // coset representative per rotation, so translations are compared modulo the
+        // centering translations, not only modulo 1.
+        if conv_std_operations.iter().any(|ops| {
+            let perm_ops = trans_perm.transform_operation(ops);
+            !conv_std_operations.iter().any(|other| {
+                perm_ops.rotation == other.rotation
+                    && translations_equal_mod_centering(
+                        &perm_ops.translation,
+                        &other.translation,
+                        centering,
+                        epsilon,
+                    )
+            })
+        }) {
+            continue;
+        }
+
+        let refined_conv_trans = Transformation::new(
+            transformation_to_prim_std.linear * centering.linear() * trans_perm.linear,
+            transformation_to_prim_std.origin_shift,
+        );
+        let lc = refined_conv_trans
+            .transform_lattice(prim_lattice)
+            .lattice_constant();
+        let lengths = [lc[0], lc[1], lc[2]];
+        candidate_conv_transformations.push((lengths, centering.linear() * trans_perm.linear));
+    }
+
+    // Choose the lexicographically smallest (a, b, c). `min_by` keeps the first
+    // element among EPS-ties, so iteration order makes the selection stable.
+    candidate_conv_transformations
+        .into_iter()
+        .min_by(|(lengths_lhs, _), (lengths_rhs, _)| {
+            lengths_lhs
+                .iter()
+                .zip(lengths_rhs.iter())
+                .find_map(|(lhs, rhs)| {
+                    if (lhs - rhs).abs() < EPS {
+                        None
+                    } else {
+                        Some(lhs.partial_cmp(rhs).unwrap())
+                    }
+                })
+                .unwrap_or(Ordering::Equal)
+        })
+        .unwrap()
+        .1
+}
+
+/// Whether `mat` is a signed permutation matrix: exactly one nonzero entry, equal to
+/// `+/-1`, in every row and every column.
+fn is_signed_permutation(mat: &Matrix3<i32>) -> bool {
+    let single_unit = |entries: [i32; 3]| {
+        let nonzero: Vec<i32> = entries.into_iter().filter(|&e| e != 0).collect();
+        nonzero.len() == 1 && nonzero[0].abs() == 1
+    };
+    (0..3).all(|i| single_unit([mat[(i, 0)], mat[(i, 1)], mat[(i, 2)]]))
+        && (0..3).all(|j| single_unit([mat[(0, j)], mat[(1, j)], mat[(2, j)]]))
+}
+
+/// Whether two fractional translations are equal modulo the centering lattice (which
+/// includes the integer lattice). Used to compare symmetry operations of a
+/// conventional centered cell, where a given coset may be represented by translations
+/// differing by a centering vector.
+fn translations_equal_mod_centering(
+    lhs: &Vector3<f64>,
+    rhs: &Vector3<f64>,
+    centering: Centering,
+    epsilon: f64,
+) -> bool {
+    let mut diff = lhs - rhs;
+    diff -= diff.map(|e| e.round()); // in [-0.5, 0.5]
+    centering.lattice_points().iter().any(|lattice_point| {
+        let mut residual = diff - lattice_point;
+        residual -= residual.map(|e| e.round());
+        residual.iter().all(|e| e.abs() <= epsilon)
+    })
 }
 
 /// Test whether `position` matches a Wyckoff orbit described by `coordinates`

--- a/moyo/tests/test_moyo_dataset.rs
+++ b/moyo/tests/test_moyo_dataset.rs
@@ -936,3 +936,126 @@ fn test_monoclinic_non_acute_angle() {
         );
     }
 }
+
+/// Lengths of the standardized conventional basis vectors `(a, b, c)`.
+fn std_cell_lengths(dataset: &MoyoDataset) -> (f64, f64, f64) {
+    let basis = dataset.std_cell.lattice.basis;
+    (
+        basis.column(0).norm(),
+        basis.column(1).norm(),
+        basis.column(2).norm(),
+    )
+}
+
+#[test]
+fn test_orthorhombic_axis_order_pmmm() {
+    // A single atom at the origin in an orthorhombic lattice gives Pmmm (#47),
+    // whose point group mmm permits all six axis permutations. Standardization
+    // must therefore sort the basis-vector lengths fully into a <= b <= c.
+    let lattice = Lattice::new(matrix![
+        5.0, 0.0, 0.0;
+        0.0, 4.0, 0.0;
+        0.0, 0.0, 3.0;
+    ]);
+    let positions = vec![Vector3::new(0.0, 0.0, 0.0)];
+    let numbers = vec![0];
+    let cell = Cell::new(lattice, positions, numbers);
+
+    let symprec = 1e-4;
+    let dataset = assert_dataset_with_default(&cell, symprec);
+    assert_dataset_with_default(&dataset.std_cell, symprec);
+    assert_eq!(dataset.number, 47); // Pmmm
+
+    let (a, b, c) = std_cell_lengths(&dataset);
+    assert!(a <= b + 1e-6 && b <= c + 1e-6, "a={a}, b={b}, c={c}");
+    assert_relative_eq!(a, 3.0, epsilon = 1e-6);
+    assert_relative_eq!(b, 4.0, epsilon = 1e-6);
+    assert_relative_eq!(c, 5.0, epsilon = 1e-6);
+}
+
+#[test]
+fn test_orthorhombic_axis_order_pmm2() {
+    // Two different atoms along the third lattice vector keep the two-fold axis
+    // and both mirrors but break inversion (a single atom would be
+    // centrosymmetric), giving Pmm2 (#25). Only the a<->b swap preserves the
+    // operation set, so the two-fold axis length (5.0) must stay on c while
+    // a <= b is imposed -- the longest axis (7.0) is *not* sorted to c.
+    let lattice = Lattice::new(matrix![
+        7.0, 0.0, 0.0;
+        0.0, 3.0, 0.0;
+        0.0, 0.0, 5.0;
+    ]);
+    let positions = vec![Vector3::new(0.0, 0.0, 0.1), Vector3::new(0.0, 0.0, 0.4)];
+    let numbers = vec![0, 1];
+    let cell = Cell::new(lattice, positions, numbers);
+
+    let symprec = 1e-4;
+    let dataset = assert_dataset_with_default(&cell, symprec);
+    assert_dataset_with_default(&dataset.std_cell, symprec);
+    assert_eq!(dataset.number, 25); // Pmm2
+
+    let (a, b, c) = std_cell_lengths(&dataset);
+    assert!(a <= b + 1e-6, "a={a} should be <= b={b}");
+    // The two-fold axis (length 5.0) is preserved on c, even though b > c.
+    assert_relative_eq!(c, 5.0, epsilon = 1e-6);
+    assert_relative_eq!(a, 3.0, epsilon = 1e-6);
+    assert_relative_eq!(b, 7.0, epsilon = 1e-6);
+}
+
+#[test]
+fn test_orthorhombic_axis_order_c_centered() {
+    // Two equal atoms at (0,0,0) and (1/2,1/2,0) make a C-centered orthorhombic
+    // cell with point group mmm: Cmmm (#65). The side-face centering ties a and b
+    // together, so only the a<->b swap is allowed (the seekpath side-face
+    // exception): a <= b is imposed but c is left untouched.
+    let lattice = Lattice::new(matrix![
+        7.0, 0.0, 0.0;
+        0.0, 3.0, 0.0;
+        0.0, 0.0, 5.0;
+    ]);
+    let positions = vec![Vector3::new(0.0, 0.0, 0.0), Vector3::new(0.5, 0.5, 0.0)];
+    let numbers = vec![0, 0];
+    let cell = Cell::new(lattice, positions, numbers);
+
+    let symprec = 1e-4;
+    let dataset = assert_dataset_with_default(&cell, symprec);
+    assert_dataset_with_default(&dataset.std_cell, symprec);
+    assert_eq!(dataset.number, 65); // Cmmm
+
+    let (a, b, c) = std_cell_lengths(&dataset);
+    assert!(a <= b + 1e-6, "a={a} should be <= b={b}");
+    // c is not moved by the side-face centering exception.
+    assert_relative_eq!(c, 5.0, epsilon = 1e-6);
+}
+
+#[test]
+fn test_orthorhombic_axis_order_pnma() {
+    // Pnma (#62) is non-symmorphic; the maintainer flagged groups like this as
+    // tricky. Here we only check that standardization keeps the space group and
+    // operation set intact (an illegal axis swap would change `number`), and that
+    // re-standardizing the result is self-consistent.
+    let a = 7.0;
+    let b = 5.0;
+    let c = 9.0;
+    let lattice = Lattice::new(matrix![
+        a, 0.0, 0.0;
+        0.0, b, 0.0;
+        0.0, 0.0, c;
+    ]);
+    // General 4c site (.m. site symmetry) of Pnma in the standard setting.
+    let (x, z) = (0.18, 0.04);
+    let positions = vec![
+        Vector3::new(x, 0.25, z),
+        Vector3::new(-x + 0.5, 0.75, z + 0.5),
+        Vector3::new(-x, 0.75, -z),
+        Vector3::new(x + 0.5, 0.25, -z + 0.5),
+    ];
+    let numbers = vec![0, 0, 0, 0];
+    let cell = Cell::new(lattice, positions, numbers);
+
+    let symprec = 1e-4;
+    let dataset = assert_dataset_with_default(&cell, symprec);
+    assert_dataset_with_default(&dataset.std_cell, symprec);
+    assert_eq!(dataset.number, 62); // Pnma
+    assert_eq!(dataset.num_operations(), 8);
+}

--- a/moyopy/docs/standardization.md
+++ b/moyopy/docs/standardization.md
@@ -52,7 +52,7 @@ Note that `rotate_basis=true` is assumed, and that the input basis vectors are r
 | -------------- | -------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
 | Triclinic      | $\begin{pmatrix} a_x & b_x & c_x \\ a_y & b_y & c_y \\ a_z & b_z & c_z \end{pmatrix}$        | Niggli reduced [^std-cell-2]; $a_x, b_y, c_z \gt 0$ [^std-cell-3] |
 | Monoclinic     | $\begin{pmatrix} a & 0 & c \cos \beta \\ 0 & b & 0 \\ 0 & 0 & c \sin \beta \end{pmatrix}$    | $a, b, c \sin \beta \gt 0$; $\cos \beta \le 0$ [^std-cell-4] [^std-cell-7] |
-| Orthorhombic   | $\begin{pmatrix} a & 0 & 0 \\ 0 & b & 0 \\ 0 & 0 & c \end{pmatrix}$                          | $a, b, c \gt 0$ [^std-cell-4] [^std-cell-6]                       |
+| Orthorhombic   | $\begin{pmatrix} a & 0 & 0 \\ 0 & b & 0 \\ 0 & 0 & c \end{pmatrix}$                          | $a, b, c \gt 0$ [^std-cell-4]; $a \le b \le c$ as far as possible [^std-cell-6] |
 | Tetragonal     | $\begin{pmatrix} a & 0 & 0 \\ 0 & a & 0 \\ 0 & 0 & c \end{pmatrix}$                          | $a, c \gt 0$ [^std-cell-4]                                        |
 | Hexagonal      | $\begin{pmatrix} a & -a / 2 & 0 \\0 & \sqrt{3} a / 2 & 0 \\ 0 & 0 & c \end{pmatrix}$         | $a, c > 0$ [^std-cell-4]                                          |
 | Cubic          | $\begin{pmatrix} a & 0 & 0 \\ 0 & a & 0 \\ 0 & 0 & a \end{pmatrix}$                          | $a > 0$ [^std-cell-5]                                             |
@@ -100,6 +100,6 @@ $$
 
 [^std-cell-7]: moyo brings $\beta$ as close to $\pi / 2$ as possible and, following the ITA convention, chooses the non-acute value ($\pi / 2 \le \beta \lt \pi$, i.e. $\cos \beta \le 0$) when the acute and obtuse choices are equally close to $\pi / 2$.
 
-[^std-cell-6]: Currently, moyo does not enforce the order in $a$, $b$, and $c$.
+[^std-cell-6]: moyo orders the basis vectors as $a \le b \le c$ as far as the space-group setting allows. Among the six axis permutations, only those that preserve both the matrix representations of the symmetry operations (as a set) and the centering are admissible, and moyo picks the admissible one with the lexicographically smallest $(a, b, c)$. The number of admissible permutations equals seekpath's "number of distinct projections", so full ordering is not always attainable; for example, side-face-centered cells (oS) admit only the $\mathbf{a} \leftrightarrow \mathbf{b}$ swap, enforcing $a \le b$ alone.
 
 [^std-cell-5]: Negative (z, z)-component for left-handed input basis vectors.


### PR DESCRIPTION
## Summary

Orders the basis vectors of orthorhombic standardized cells as `a <= b <= c` as much as the space group setting allows (closes #193).

Previously moyo did not reorder orthorhombic axes by length. spglib/seekpath impose `a <= b <= c`, but only over the axis permutations that keep the space group in its standard setting (seekpath's "number of distinct projections"; spglib hardcodes this as a `num_free_axes` table whose Ibca/Imma values are even disputed in spglib#220).

Instead of a hardcoded table, this derives the allowed permutations directly from the symmetry operations:

- Candidate set: the six axis permutations (as signed permutation matrices with `det = +1`, taken from the existing `UNIMODULAR3_RANGE1` search space).
- A candidate is **allowed** iff it (1) preserves the centering translations and (2) maps the *set* of conventional symmetry operations onto itself (rotations exactly; translations modulo the centering lattice).
- Among allowed candidates, pick the lexicographically smallest `(a, b, c)`, with a stable tie-break (first candidate wins on `EPS`-ties).

This mirrors the existing `standardize_monoclinic_conv_cell`, with one key difference: axis permutations relabel generators among themselves, so the validity check is at the **set** level rather than per-generator. The approach automatically yields the side-face-centered exception (only `a <= b` for `C`/`A`-centered cells) and safely handles non-symmorphic groups (e.g. `Pbam`, `Pnma`) by rejecting permutations that would alter the operation set.

The reported operation list is unchanged: the chosen permutation normalizes the space group, so `symmetrize_lattice` and Wyckoff assignment stay consistent. No public API changes.

## Changes

- `moyo/src/symmetrize/standardize.rs`: new `Orthorhombic` arm in the lattice-system match; new `standardize_orthorhombic_conv_cell` plus `is_signed_permutation` and `translations_equal_mod_centering` helpers.
- `moyopy/docs/standardization.md`: update the orthorhombic conditions to `a <= b <= c` as far as possible, and rewrite the footnote explaining the operation/centering-preserving permutation rule and the side-face-centered exception.
- `CHANGELOG.md`: note under Unreleased > moyo.

## Test plan

New tests in `moyo/tests/test_moyo_dataset.rs` (all passing; full suite green):

- `test_orthorhombic_axis_order_pmmm` — Pmmm (#47, all six permutations valid): asserts full ascending sort `(3, 4, 5)`.
- `test_orthorhombic_axis_order_pmm2` — Pmm2 (#25, only `a<->b`): asserts `a <= b` and that the two-fold axis length stays on `c` (longest axis not sorted to `c`).
- `test_orthorhombic_axis_order_c_centered` — Cmmm (#65): asserts the side-face exception (`a <= b` only, `c` untouched).
- `test_orthorhombic_axis_order_pnma` — Pnma (#62, non-symmorphic): asserts the space group and operation count are unchanged (no illegal swap).

Each case also re-standardizes via `assert_dataset_with_default`, confirming self-consistency.

[Claude Code] Generated with [Claude Code](https://claude.com/claude-code)
