### PR TITLE
Release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 Unlisted patch versions (e.g. v0.7.1, v0.7.3, v0.7.6, v0.7.7) contain only dependency or build updates with no user-visible changes.
 
-## Unreleased
+## v0.13.0 - 2026-06-28
 
 ### moyo
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,7 +704,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "moyo"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "approx",
  "criterion",
@@ -727,7 +727,7 @@ dependencies = [
 
 [[package]]
 name = "moyo-wasm"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "moyo",
  "serde",
@@ -738,7 +738,7 @@ dependencies = [
 
 [[package]]
 name = "moyoc"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "approx",
  "moyo",
@@ -747,7 +747,7 @@ dependencies = [
 
 [[package]]
 name = "moyopy"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "approx",
  "itertools 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "2"
 authors = ["Kohei Shinohara <kshinohara0508@gmail.com>"]
 description = "Library for Crystal Symmetry in Rust"
 edition = "2024"
-version = "0.12.0"
+version = "0.13.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/spglib/moyo"
 

--- a/moyoc/Cargo.toml
+++ b/moyoc/Cargo.toml
@@ -16,7 +16,7 @@ name = "moyoc"
 crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
-moyo = { path = "../moyo", version = "0.12.0" }
+moyo = { path = "../moyo", version = "0.13.0" }
 
 [dev-dependencies]
 nalgebra.workspace = true

--- a/moyopy/Cargo.toml
+++ b/moyopy/Cargo.toml
@@ -17,7 +17,7 @@ name = "moyopy"
 crate-type = ["cdylib"]
 
 [dependencies]
-moyo = { path = "../moyo", version = "0.12.0" }
+moyo = { path = "../moyo", version = "0.13.0" }
 nalgebra.workspace = true
 serde.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION
## Summary

Release v0.13.0.

### moyo

- Order the basis vectors of orthorhombic standardized cells as `a <= b <= c` as much as possible, deriving seekpath's "number of distinct projections" directly from the symmetry operations and respecting the side-face-centered exception (only `a <= b` for `C`/`A`-centered cells) (#378)
- Fix `standardize_monoclinic_conv_cell` returning an acute angle between the `a` and `c` axes; ties under the skewness metric are now broken in favor of the non-acute angle required by the ITA convention (#377)

## Test plan

- [x] `just test`

[Claude Code] Generated with [Claude Code](https://claude.com/claude-code)
