### PR TITLE
ci: speed up deploy-web with npm and apt caching

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -63,6 +63,13 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
+          cache: 'npm'
+          # package-lock.json is gitignored in this repo, so key the npm
+          # download cache (~/.npm) on the package.json files instead. The
+          # cache still avoids re-downloading tarballs on `npm install`.
+          cache-dependency-path: |
+            apps/web/package.json
+            moyo-wasm/package.json
 
       - name: Install web app dependencies
         working-directory: apps/web
@@ -122,10 +129,10 @@ jobs:
           cp -r moyo-wasm/site apps/landing/site/js
 
       - name: Install Doxygen
-        run: |
-          set -e
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends doxygen
+        uses: awalsh128/cache-apt-pkgs-action@5513791f75b039e2a79653b1a92238d3fb8d99b4 # v1.6.2
+        with:
+          packages: doxygen
+          version: 1.0
 
       - name: Install cbindgen
         uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595 # v2.81.11


### PR DESCRIPTION
## Summary

Speeds up the **Deploy web app to GitHub Pages** workflow with caching, without splitting jobs or adding runner minutes (single serial build job, as before).

- **npm download caching**: `setup-node` now caches `~/.npm`, keyed on the `apps/web/package.json` and `moyo-wasm/package.json` files. (`package-lock.json` is gitignored repo-wide, so `npm install` is kept rather than `npm ci`, and the cache key uses package.json.) The cache avoids re-downloading tarballs on each `npm install`.
- **Doxygen install caching**: replaces `apt-get update && apt-get install -y doxygen` (~15s, dominated by `apt-get update`) with `awalsh128/cache-apt-pkgs-action`, which caches the **same** apt doxygen package across runs. Pinned to v1.6.2 SHA.

Deliberately avoided `ssciwr/doxygen-install` (downloads a different doxygen version and pulls Windows/Mac binaries on Linux); the apt-cache action keeps version parity.

The ~21-22s Rust builds (`wasm-pack`, `maturin`) are untouched and remain the floor.

## Measured impact (build job total)

| Run | Total |
|---|---|
| Before (no caching) | **129s** |
| Cold cache (first run, populates caches) | 114s |
| **Warm cache** | **95s** (~26% faster) |

Per-step (before -> warm): Install Doxygen 15s -> 3s; Install web deps 13s -> 7s; moyo-wasm TypeDoc 8s -> 5s.

## Test plan

- [x] `prek run --files .github/workflows/deploy-web.yml` passes (incl. actionlint "Validate GitHub Workflows")
- [x] CI run on this PR succeeds (run 28316102067)
- [x] Warm-cache re-run confirms speedup (129s -> 95s); npm + apt caches verified saved and hit

[Claude Code] Generated with [Claude Code](https://claude.com/claude-code)
