### PR TITLE
ci: drop --release from rust coverage run

### DIFF
--- a/.github/workflows/rw-rust-tests.yaml
+++ b/.github/workflows/rw-rust-tests.yaml
@@ -13,7 +13,7 @@ jobs:
     - name: Install cargo-llvm-cov
       uses: taiki-e/install-action@50570a4fd0cb7e583e6a512c02bffb9ade28d868 # cargo-llvm-cov
     - name: Test
-      run: cargo llvm-cov --release --all-features --workspace --lcov --output-path lcov.info
+      run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
     - name: Upload coverage to Codecov
       if: github.event.repository.fork == false
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6


### PR DESCRIPTION
## Summary

Speeds up the `rust / test` CI job (~1m48s) by removing `--release` from the coverage command.

The job is **compile-bound, not test-bound**:
- `Finished release profile in 1m 23s` -> ~83s compiling
- All tests run in ~6s (heaviest 4.82s, 159 tests)

`cargo llvm-cov --release` builds the fully optimized release profile (opt-level 3) across nalgebra + the whole workspace. Coverage needs none of that, and release inlining actually reduces line-coverage accuracy. The repo already configures `[profile.test] opt-level = 1`, but `--release` bypasses it.

Dropping `--release` builds with the dev/test profile, cutting the dominant compile cost while keeping test runtime negligible.

## Test plan

- Verified locally that the heaviest test still runs in 2.71s under the dev/test profile (as fast as release).
- CI `rust / test` job should drop from ~108s to roughly ~50-60s.

[Claude Code] Generated with [Claude Code](https://claude.com/claude-code)
