### PR TITLE
Replace kiddo ImmutableKdTree with a safe uniform bin-grid neighbor search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 Unlisted patch versions (e.g. v0.7.1, v0.7.3, v0.7.6, v0.7.7) contain only dependency or build updates with no user-visible changes.
 
+## Unreleased
+
+### moyo
+
+- Replace the kiddo `ImmutableKdTree` behind the periodic nearest-neighbor search (`PeriodicKdTree`, now `PeriodicNeighborSearch`) with a safe uniform bin-grid implementation. This removes the only unsafe-heavy code in the symmetry-search call path, suspected of heap corruption crashes in long magnetic symmetry search runs, and avoids kiddo v5's known incorrect-results bug in best-n queries (sdd/kiddo#258). The grid is roughly as fast as the kd-tree at small cell sizes and 1.6-2.5x faster from 64 atoms up (#390)
+
 ## v0.13.0 - 2026-06-28
 
 ### moyo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Unlisted patch versions (e.g. v0.7.1, v0.7.3, v0.7.6, v0.7.7) contain only depen
 
 ### moyo
 
-- Replace the kiddo `ImmutableKdTree` behind the periodic nearest-neighbor search (`PeriodicKdTree`, now `PeriodicNeighborSearch`) with a safe uniform bin-grid implementation. This removes the only unsafe-heavy code in the symmetry-search call path, suspected of heap corruption crashes in long magnetic symmetry search runs, and avoids kiddo v5's known incorrect-results bug in best-n queries (sdd/kiddo#258). The grid is roughly as fast as the kd-tree at small cell sizes and 1.6-2.5x faster from 64 atoms up (#390)
+- Replace the kiddo `ImmutableKdTree` behind the periodic nearest-neighbor search (`PeriodicKdTree`, now `PeriodicNeighborSearch`) with a safe uniform bin-grid implementation. This removes the only unsafe-heavy code in the symmetry-search call path, suspected of heap corruption crashes in long magnetic symmetry search runs, and avoids kiddo v5's known incorrect-results bug in best-n queries (sdd/kiddo#258). The grid breaks even with the kd-tree around 27 atoms and is 2.5-6x faster from 64 atoms up (#390)
 
 ## v0.13.0 - 2026-06-28
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ math <- base <- data <- identify <- standardize <- lib
 
 - **base**: Core data structures (`Cell`, `Lattice`, `Operation`, `MagneticCell`, `Transformation`)
 - **math**: Lattice reduction algorithms (Niggli, Delaunay, Minkowski), integer linear algebra (HNF, SNF)
-- **search**: Symmetry operation finding using `PeriodicKdTree`, primitive cell identification
+- **search**: Symmetry operation finding using `PeriodicNeighborSearch`, primitive cell identification
 - **identify**: Space group and point group identification from symmetry operations
 - **data**: Embedded crystallographic databases (Hall symbols, Wyckoff positions, magnetic space groups)
 - **symmetrize**: Structure standardization to conventional/primitive cells

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,15 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aligned-vec"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
-dependencies = [
- "equator",
-]
-
-[[package]]
 name = "alloca"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,22 +101,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "array-init"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "az"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be5eb007b7cacc6c660343e96f650fedf4b5a77512399eb952ca6642cf8d13f7"
 
 [[package]]
 name = "bitflags"
@@ -231,12 +210,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
-name = "cmov"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
-
-[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,12 +291,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
-name = "divrem"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69dde51e8fef5e12c1d65e0929b03d66e4c0c18282bc30ed2ca050ad6f44dd82"
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -353,26 +320,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "equator"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
-dependencies = [
- "equator-macro",
-]
-
-[[package]]
-name = "equator-macro"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,19 +330,6 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "fixed"
-version = "1.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707070ccf8c4173548210893a0186e29c266901b71ed20cd9e2ca0193dfe95c3"
-dependencies = [
- "az",
- "bytemuck",
- "half",
- "num-traits",
- "typenum",
-]
 
 [[package]]
 name = "foldhash"
@@ -443,21 +377,6 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
-]
-
-[[package]]
-name = "generator"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
-dependencies = [
- "cc",
- "cfg-if",
- "libc",
- "log",
- "rustversion",
- "windows-link",
- "windows-result",
 ]
 
 [[package]]
@@ -634,26 +553,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kiddo"
-version = "5.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da26797630e4a7511fa95300ecb03250d8d91f7e44fe756d61febefbce1ea3be"
-dependencies = [
- "aligned-vec",
- "array-init",
- "az",
- "cmov",
- "divrem",
- "fixed",
- "generator",
- "num-traits",
- "ordered-float",
- "sorted-vec",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -710,12 +609,12 @@ dependencies = [
  "criterion",
  "env_logger",
  "itertools 0.15.0",
- "kiddo",
  "log",
  "nalgebra",
  "once_cell",
  "rand",
  "rstest",
+ "rustc-hash",
  "serde",
  "serde_json",
  "strum",
@@ -868,15 +767,6 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
-
-[[package]]
-name = "ordered-float"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "page_size"
@@ -1166,6 +1056,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1301,18 +1197,6 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
-
-[[package]]
-name = "smallvec"
-version = "1.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "sorted-vec"
-version = "0.8.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f58d7b0190c7f12df7e8be6b79767a0836059159811b869d5ab55721fe14d0"
 
 [[package]]
 name = "strum"
@@ -1457,19 +1341,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1504,7 +1376,6 @@ dependencies = [
  "once_cell",
  "regex-automata",
  "sharded-slab",
- "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
@@ -1738,15 +1609,6 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
 
 [[package]]
 name = "windows-sys"

--- a/docs/layer_architecture.md
+++ b/docs/layer_architecture.md
@@ -12,7 +12,7 @@ Spglib's implementation is referenced for cross-checking, but moyo deliberately 
 
 - Detect the layer group (one of 80 types) of a 3D crystal structure that has 2D periodicity (a layer system).
 - Produce a `MoyoLayerDataset` analogous to `MoyoDataset`: layer-group number, Hall symbol, layer-group operations in the input cell, primitive/standardized layer cells, Wyckoff positions, site symmetry, transformation matrices.
-- Reuse moyo's existing primitives (`Cell`, `Operation`, `PrimitiveCell`, `PeriodicKdTree`, identification machinery) rather than forking the pipeline.
+- Reuse moyo's existing primitives (`Cell`, `Operation`, `PrimitiveCell`, `PeriodicNeighborSearch`, identification machinery) rather than forking the pipeline.
 
 ### Non-goals (initial release)
 
@@ -178,7 +178,7 @@ Monoclinic-rectangular note (LG 8-18): the paper's appendix B carves out a speci
 
 ### Primitive 2D cell search
 
-Analogous to `PrimitiveCell::new`, but candidate translations are filtered to those with the `c`-component (in fractional coords) equal to 0 (within `symprec / |c|`). All other machinery (`PeriodicKdTree`, correspondence solver) carries over.
+Analogous to `PrimitiveCell::new`, but candidate translations are filtered to those with the `c`-component (in fractional coords) equal to 0 (within `symprec / |c|`). All other machinery (`PeriodicNeighborSearch`, correspondence solver) carries over.
 
 If a candidate translation has nonzero `c`-component, moyo **rejects the input** rather than try to interpret it — a 2D-periodic structure should not have spurious "stacking" translations along `c`. Concretely: if the user passes an AA-stacked bilayer with `c` being the stacking direction, we want them to either thicken the cell to a true 2D unit or pass `c` as the stacking length; a "translation" of `c/2` along `c` would falsify the layer-group hypothesis.
 

--- a/moyo/Cargo.toml
+++ b/moyo/Cargo.toml
@@ -24,8 +24,8 @@ thiserror = "2.0"
 union-find = "0.4"
 strum = "0.28"
 strum_macros = "0.28"
-kiddo = "5.2.1"
 once_cell = "1.21.3"
+rustc-hash = "2.1"
 
 [dev-dependencies]
 rand = "0.10"

--- a/moyo/benches/translation_search.rs
+++ b/moyo/benches/translation_search.rs
@@ -3,7 +3,7 @@ use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_m
 use nalgebra::{matrix, vector};
 
 use moyo::base::{Cell, Lattice, Position};
-use moyo::search::{PeriodicKdTree, solve_correspondence, solve_correspondence_naive};
+use moyo::search::{PeriodicNeighborSearch, solve_correspondence, solve_correspondence_naive};
 
 /// O(num_atoms^3)
 fn naive(reduced_cell: &Cell) {
@@ -21,11 +21,11 @@ fn naive(reduced_cell: &Cell) {
     }
 }
 
-/// O(num_atoms^2 * log(num_atoms))
-fn kdtree(reduced_cell: &Cell) {
+/// O(num_atoms^2) expected
+fn neighbor_search(reduced_cell: &Cell) {
     let num_atoms = reduced_cell.num_atoms();
     let symprec = 1e-5;
-    let pkdtree = PeriodicKdTree::new(reduced_cell, symprec);
+    let neighbor_search = PeriodicNeighborSearch::new(reduced_cell, symprec);
     for j in 0..num_atoms {
         let translation = reduced_cell.positions[j] - reduced_cell.positions[0];
         let new_positions: Vec<Position> = reduced_cell
@@ -34,7 +34,7 @@ fn kdtree(reduced_cell: &Cell) {
             .map(|pos| pos + translation)
             .collect();
 
-        solve_correspondence(&pkdtree, reduced_cell, &new_positions);
+        solve_correspondence(&neighbor_search, reduced_cell, &new_positions);
     }
 }
 
@@ -73,8 +73,8 @@ pub fn benchmark(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("naive", n), &cell, |b, cell| {
             b.iter(|| naive(&cell));
         });
-        group.bench_with_input(BenchmarkId::new("kdtree", n), &cell, |b, cell| {
-            b.iter(|| kdtree(&cell));
+        group.bench_with_input(BenchmarkId::new("neighbor_search", n), &cell, |b, cell| {
+            b.iter(|| neighbor_search(&cell));
         });
     }
     group.finish();

--- a/moyo/src/search.rs
+++ b/moyo/src/search.rs
@@ -6,7 +6,7 @@ mod symmetry_search;
 
 pub use layer::LayerPrimitiveSymmetrySearch;
 pub use solve::{
-    PeriodicKdTree, PeriodicNeighbor, solve_correspondence, solve_correspondence_naive,
+    PeriodicNeighbor, PeriodicNeighborSearch, solve_correspondence, solve_correspondence_naive,
 };
 
 pub(crate) use layer::{LayerPrimitiveCell, is_layer_block_form};

--- a/moyo/src/search/layer/layer_primitive_cell.rs
+++ b/moyo/src/search/layer/layer_primitive_cell.rs
@@ -42,8 +42,8 @@ pub(crate) struct LayerPrimitiveCell {
 impl LayerPrimitiveCell {
     /// Find the primitive cell of a 2D-periodic (layer) system.
     ///
-    /// In-plane axes are 2D-Minkowski-reduced before the kd-tree-based
-    /// translation search (the bulk `PeriodicKdTree` requires a Minkowski-
+    /// In-plane axes are 2D-Minkowski-reduced before the grid-based
+    /// translation search (the bulk `PeriodicNeighborSearch` requires a Minkowski-
     /// reduced basis for its `[-1, 1]^3` periodic-image enumeration to be
     /// exact). The aperiodic `c` axis is left untouched, so the layer
     /// contract is preserved. Candidate translations whose fractional
@@ -80,7 +80,7 @@ impl LayerPrimitiveCell {
             return Err(MoyoError::TooLargeToleranceError);
         }
 
-        // Reuse the bulk pure-translation search (kd-tree + correspondence +
+        // Reuse the bulk pure-translation search (neighbor search + correspondence +
         // symmetrize), which is correct on a Minkowski-reduced basis.
         let (raw_translations, raw_permutations) = search_pure_translations(&reduced_cell, symprec);
 
@@ -118,7 +118,7 @@ impl LayerPrimitiveCell {
 
         // Re-reduce so the returned layer cell satisfies the Minkowski-reduced
         // precondition of downstream bulk routines (`PrimitiveSymmetrySearch`,
-        // `PeriodicKdTree`, `search_bravais_group`). The HNF-derived primitive
+        // `PeriodicNeighborSearch`, `search_bravais_group`). The HNF-derived primitive
         // basis is upper-triangular, not Minkowski-reduced, so this step is
         // required even though the input was already reduced.
         let (reduced_prim_cell, prim_trans_mat) = minkowski_reduce_inplane(&primitive_cell)?;
@@ -294,7 +294,7 @@ mod tests {
     #[test]
     fn test_layer_skewed_in_plane_basis_is_reduced() {
         // Skewed in-plane basis: a = (1, 0, 0), b = (4, 1, 0), c along z.
-        // Without 2D Minkowski reduction the kd-tree's [-1, 1]^3 image search
+        // Without 2D Minkowski reduction the neighbor search's [-1, 1]^3 image search
         // can miss the true nearest periodic image. After reduction the
         // primitive cell finder still returns a single trivial translation
         // for a one-atom cell, and the linear field correctly maps the input

--- a/moyo/src/search/primitive_cell.rs
+++ b/moyo/src/search/primitive_cell.rs
@@ -4,7 +4,7 @@ use log::debug;
 use nalgebra::{Dyn, Matrix3, OMatrix, U3, Vector3};
 
 use super::solve::{
-    PeriodicKdTree, pivot_site_indices, solve_correspondence,
+    PeriodicNeighborSearch, pivot_site_indices, solve_correspondence,
     symmetrize_translation_from_permutation,
 };
 use crate::base::{
@@ -186,7 +186,7 @@ impl<M: MagneticMoment> PrimitiveMagneticCell<M> {
 /// permutations.
 ///
 /// Precondition: `reduced_cell.lattice.basis` must be Minkowski reduced.
-/// `PeriodicKdTree::new` only enumerates periodic images for offsets in
+/// `PeriodicNeighborSearch::new` only enumerates periodic images for offsets in
 /// `[-1, 1]^3`, which is exact under that precondition but can miss the
 /// nearest image on a strongly skewed basis.
 pub(crate) fn search_pure_translations(
@@ -195,7 +195,7 @@ pub(crate) fn search_pure_translations(
 ) -> (Vec<Translation>, Vec<Permutation>) {
     let rough_symprec = 2.0 * symprec;
     // Try possible translations: overlap the `src`-th site to the `dst`-th site
-    let pkdtree = PeriodicKdTree::new(reduced_cell, rough_symprec);
+    let neighbor_search = PeriodicNeighborSearch::new(reduced_cell, rough_symprec);
     let pivot_site_indices = pivot_site_indices(&reduced_cell.numbers);
     let mut permutations_translations_tmp = vec![];
     let src = pivot_site_indices[0];
@@ -209,7 +209,9 @@ pub(crate) fn search_pure_translations(
 
         // Because the translation may not be optimal to minimize distance between input and acted positions,
         // use a larger symprec (diameter of a Ball) for finding correspondence
-        if let Some(permutation) = solve_correspondence(&pkdtree, reduced_cell, &new_positions) {
+        if let Some(permutation) =
+            solve_correspondence(&neighbor_search, reduced_cell, &new_positions)
+        {
             permutations_translations_tmp.push((permutation, translation));
         }
     }

--- a/moyo/src/search/primitive_symmetry_search.rs
+++ b/moyo/src/search/primitive_symmetry_search.rs
@@ -8,7 +8,7 @@ use super::{
     PrimitiveCell,
     primitive_cell::PrimitiveMagneticCell,
     solve::{
-        PeriodicKdTree, pivot_site_indices, solve_correspondence,
+        PeriodicNeighborSearch, pivot_site_indices, solve_correspondence,
         symmetrize_translation_from_permutation,
     },
 };
@@ -47,7 +47,7 @@ impl PrimitiveSymmetrySearch {
         }
 
         // Search symmetry operations
-        let pkdtree = PeriodicKdTree::new(primitive_cell, rough_symprec);
+        let neighbor_search = PeriodicNeighborSearch::new(primitive_cell, rough_symprec);
         let bravais_group =
             search_bravais_group(&primitive_cell.lattice, symprec, angle_tolerance)?;
         let pivot_site_indices = pivot_site_indices(&primitive_cell.numbers);
@@ -68,7 +68,7 @@ impl PrimitiveSymmetrySearch {
                     .collect::<Vec<_>>();
 
                 if let Some(permutation) =
-                    solve_correspondence(&pkdtree, primitive_cell, &new_positions)
+                    solve_correspondence(&neighbor_search, primitive_cell, &new_positions)
                 {
                     symmetries_tmp.push((*rotation, translation, permutation));
                     // Do not break here because there may be multiple translations with the rough tolerance
@@ -194,7 +194,7 @@ impl PrimitiveMagneticSymmetrySearch {
             operations_in_cell(&prim_nonmag_cell, &prim_nonmag_symmetry.operations);
 
         // Find time reversal parts that keep magnetic moments
-        let pkdtree = PeriodicKdTree::new(&primitive_magnetic_cell.cell, symprec);
+        let neighbor_search = PeriodicNeighborSearch::new(&primitive_magnetic_cell.cell, symprec);
         let mut magnetic_operations = vec![];
         let mut permutations = vec![];
         for operation in candidate_operations.iter() {
@@ -204,9 +204,11 @@ impl PrimitiveMagneticSymmetrySearch {
                 .iter()
                 .map(|pos| operation.rotation.map(|e| e as f64) * pos + operation.translation)
                 .collect::<Vec<_>>();
-            if let Some(permutation) =
-                solve_correspondence(&pkdtree, &primitive_magnetic_cell.cell, &new_positions)
-            {
+            if let Some(permutation) = solve_correspondence(
+                &neighbor_search,
+                &primitive_magnetic_cell.cell,
+                &new_positions,
+            ) {
                 let cartesian_rotation =
                     operation.cartesian_rotation(&primitive_magnetic_cell.cell.lattice);
                 let rotated_magnetic_moments = primitive_magnetic_cell

--- a/moyo/src/search/solve.rs
+++ b/moyo/src/search/solve.rs
@@ -1,16 +1,27 @@
-use std::{collections::BTreeMap, num::NonZero};
+use std::collections::BTreeMap;
 
 use itertools::iproduct;
-use kiddo::{ImmutableKdTree, SquaredEuclidean};
-use nalgebra::{Rotation3, Vector3};
+use nalgebra::Vector3;
+use rustc_hash::FxHashMap;
 
 use crate::base::{AtomicSpecie, Cell, Lattice, Permutation, Position, Rotation, Translation};
 
+/// Nearest-neighbor search under periodic boundary conditions, backed by a
+/// uniform bin grid over Cartesian coordinates. Each point is registered in
+/// every bin its ball of radius `symprec` overlaps -- at most eight bins,
+/// because the bin size is at least `2 * symprec`. A query then only
+/// inspects the single bin containing the query position: any point within
+/// `symprec` of the query has registered itself there.
 #[doc(hidden)]
-pub struct PeriodicKdTree {
+pub struct PeriodicNeighborSearch {
     num_sites: usize,
     lattice: Lattice,
-    kdtree: ImmutableKdTree<f64, 3>,
+    bin_size: f64,
+    /// Bin index -> entries registered to the bin (indices into `cart_coords`
+    /// and `indices`)
+    bins: FxHashMap<(i64, i64, i64), Vec<usize>>,
+    cart_coords: Vec<Vector3<f64>>,
+    /// Entry -> site index in the original cell
     indices: Vec<usize>,
     symprec: f64,
 }
@@ -22,18 +33,20 @@ pub struct PeriodicNeighbor {
     pub distance: f64,
 }
 
-impl PeriodicKdTree {
-    /// Construct a periodic kd-tree from the given **Minkowski-reduced** cell.
+impl PeriodicNeighborSearch {
+    /// Construct a periodic neighbor search from the given **Minkowski-reduced** cell.
     pub fn new(reduced_cell: &Cell, symprec: f64) -> Self {
-        // Randomly rotate lattice to avoid align along x,y,z axes
-        let random_rotation_matrix = Rotation3::new(Vector3::new(0.01, 0.02, 0.03));
-        let new_lattice = reduced_cell.lattice.rotate(&random_rotation_matrix.into());
+        let lattice = reduced_cell.lattice.clone();
 
         // Twice the padding for safety
-        let padding = 2.0 * symprec
-            / (3.0 * (new_lattice.basis * new_lattice.basis.transpose()).trace()).sqrt();
+        let padding =
+            2.0 * symprec / (3.0 * (lattice.basis * lattice.basis.transpose()).trace()).sqrt();
 
-        let mut entries = vec![];
+        // `f64::EPSILON` floor keeps the bin size positive for degenerate symprec;
+        // queries then fall back to exact-match behavior instead of dividing by zero.
+        let bin_size = (2.0 * symprec).max(f64::EPSILON);
+        let mut bins: FxHashMap<(i64, i64, i64), Vec<usize>> = FxHashMap::default();
+        let mut cart_coords = vec![];
         let mut indices = vec![];
         for offset in iproduct!(-1..=1, -1..=1, -1..=1) {
             for (index, position) in reduced_cell.positions.iter().enumerate() {
@@ -50,45 +63,57 @@ impl PeriodicKdTree {
                     continue;
                 }
 
-                let cart_coords = new_lattice.cartesian_coords(&new_position);
-                entries.push([cart_coords.x, cart_coords.y, cart_coords.z]);
+                let cart = lattice.cartesian_coords(&new_position);
+                // Register the entry in every bin overlapping its symprec-ball
+                let lo = Self::bin_key(&cart.add_scalar(-symprec), bin_size);
+                let hi = Self::bin_key(&cart.add_scalar(symprec), bin_size);
+                for key in iproduct!(lo.0..=hi.0, lo.1..=hi.1, lo.2..=hi.2) {
+                    bins.entry(key).or_default().push(cart_coords.len());
+                }
+                cart_coords.push(cart);
                 indices.push(index);
             }
         }
 
         Self {
             num_sites: reduced_cell.num_atoms(),
-            lattice: new_lattice,
-            kdtree: ImmutableKdTree::new_from_slice(&entries),
+            lattice,
+            bin_size,
+            bins,
+            cart_coords,
             indices,
             symprec,
         }
+    }
+
+    fn bin_key(cart_coords: &Vector3<f64>, bin_size: f64) -> (i64, i64, i64) {
+        // `as i64` saturates on overflow, which only degrades bin locality,
+        // never memory safety.
+        (
+            (cart_coords.x / bin_size).floor() as i64,
+            (cart_coords.y / bin_size).floor() as i64,
+            (cart_coords.z / bin_size).floor() as i64,
+        )
     }
 
     /// Return the nearest neighbor within symprec if exists.
     pub fn nearest(&self, position: &Position) -> Option<PeriodicNeighbor> {
         let mut wrapped_position = *position;
         wrapped_position -= wrapped_position.map(|e| e.floor()); // [0, 1)
-        let cart_coords = self.lattice.cartesian_coords(&wrapped_position);
-        let mut within = self.kdtree.best_n_within::<SquaredEuclidean>(
-            &[cart_coords.x, cart_coords.y, cart_coords.z],
-            self.symprec.powi(2), // squared distance for KdTree
-            NonZero::new(1).unwrap(),
-        );
-        if let Some(entry) = within.next() {
-            let item = entry.item as usize;
-            let distance = entry.distance.sqrt();
-            if distance > self.symprec {
-                return None;
-            }
+        let cart = self.lattice.cartesian_coords(&wrapped_position);
 
-            Some(PeriodicNeighbor {
-                index: self.indices[item],
-                distance,
-            })
-        } else {
-            None
+        let mut nearest: Option<PeriodicNeighbor> = None;
+        let entries = self.bins.get(&Self::bin_key(&cart, self.bin_size))?;
+        for &entry in entries {
+            let distance = (self.cart_coords[entry] - cart).norm();
+            if distance <= self.symprec && nearest.as_ref().is_none_or(|n| distance < n.distance) {
+                nearest = Some(PeriodicNeighbor {
+                    index: self.indices[entry],
+                    distance,
+                });
+            }
         }
+        nearest
     }
 }
 
@@ -111,18 +136,18 @@ pub fn pivot_site_indices(numbers: &[AtomicSpecie]) -> Vec<usize> {
 /// Return correspondence between the input and acted positions.
 /// Search permutation such that new_positions\[i\] = reduced_cell.positions\[permutation\[i\]\].
 /// Then, a corresponding symmetry operation moves the i-th site into the permutation\[i\]-th site.
-/// This function takes O(num_atoms * log(num_atoms)) time.
+/// This function takes O(num_atoms) expected time thanks to the bin-grid nearest-neighbor queries.
 #[doc(hidden)]
 pub fn solve_correspondence(
-    pkdtree: &PeriodicKdTree,
+    neighbor_search: &PeriodicNeighborSearch,
     reduced_cell: &Cell,
     new_positions: &[Position],
 ) -> Option<Permutation> {
-    let num_atoms = pkdtree.num_sites;
+    let num_atoms = neighbor_search.num_sites;
     let mut mapping = vec![None; num_atoms];
 
     for i in 0..num_atoms {
-        let neighbor = pkdtree.nearest(&new_positions[i])?;
+        let neighbor = neighbor_search.nearest(&new_positions[i])?;
         let j = neighbor.index;
         if reduced_cell.numbers[i] != reduced_cell.numbers[j] {
             return None;
@@ -230,13 +255,13 @@ mod tests {
     use crate::base::{Cell, Lattice, Permutation, Rotation, Translation};
 
     use super::{
-        PeriodicKdTree, pivot_site_indices, solve_correspondence, solve_correspondence_naive,
-        symmetrize_translation_from_permutation,
+        PeriodicNeighborSearch, pivot_site_indices, solve_correspondence,
+        solve_correspondence_naive, symmetrize_translation_from_permutation,
     };
 
     #[test]
-    fn test_periodic_kdtree() {
-        let pkdtree = PeriodicKdTree::new(
+    fn test_periodic_neighbor_search() {
+        let neighbor_search = PeriodicNeighborSearch::new(
             &Cell::new(
                 Lattice::new(Matrix3::identity()),
                 vec![
@@ -251,18 +276,67 @@ mod tests {
         );
 
         {
-            let neighbor = pkdtree.nearest(&Vector3::new(0.0, 0.0, 0.0)).unwrap();
+            let neighbor = neighbor_search
+                .nearest(&Vector3::new(0.0, 0.0, 0.0))
+                .unwrap();
             assert!(neighbor.index == 0);
         }
 
         {
-            let neighbor = pkdtree.nearest(&Vector3::new(1.0, 0.5, 0.5)).unwrap();
+            let neighbor = neighbor_search
+                .nearest(&Vector3::new(1.0, 0.5, 0.5))
+                .unwrap();
             assert!(neighbor.index == 1);
         }
 
         {
-            let neighbor = pkdtree.nearest(&Vector3::new(1.5, -0.0, -0.5)).unwrap();
+            let neighbor = neighbor_search
+                .nearest(&Vector3::new(1.5, -0.0, -0.5))
+                .unwrap();
             assert!(neighbor.index == 2);
+        }
+    }
+
+    #[test]
+    fn test_periodic_neighbor_search_axis_aligned_grid() {
+        // Many sites sharing coordinate values on every axis (an axis-aligned
+        // n x n x n grid). Cross-check every translation against the naive
+        // O(num_atoms^2) solver.
+        let n = 4;
+        let mut positions = vec![];
+        let mut numbers = vec![];
+        for i in 0..n {
+            for j in 0..n {
+                for k in 0..n {
+                    positions.push(Vector3::new(
+                        i as f64 / n as f64,
+                        j as f64 / n as f64,
+                        k as f64 / n as f64,
+                    ));
+                    numbers.push(0);
+                }
+            }
+        }
+        let reduced_cell = Cell::new(
+            Lattice::new(Matrix3::identity() * n as f64),
+            positions,
+            numbers,
+        );
+        let symprec = 1e-4;
+        let neighbor_search = PeriodicNeighborSearch::new(&reduced_cell, symprec);
+
+        for dst in 0..reduced_cell.num_atoms() {
+            let translation = reduced_cell.positions[dst] - reduced_cell.positions[0];
+            let new_positions = reduced_cell
+                .positions
+                .iter()
+                .map(|pos| pos + translation)
+                .collect::<Vec<_>>();
+
+            let actual = solve_correspondence(&neighbor_search, &reduced_cell, &new_positions);
+            let expect = solve_correspondence_naive(&reduced_cell, &new_positions, symprec);
+            assert_eq!(actual, expect);
+            assert!(actual.is_some());
         }
     }
 
@@ -288,7 +362,7 @@ mod tests {
             vec![0, 0, 0, 0],
         );
         let symprec = 1e-4;
-        let pkdtree = PeriodicKdTree::new(&reduced_cell, symprec);
+        let neighbor_search = PeriodicNeighborSearch::new(&reduced_cell, symprec);
 
         {
             // Translation::new(0.0, 0.5, 0.5);
@@ -304,9 +378,9 @@ mod tests {
                 solve_correspondence_naive(&reduced_cell, &new_positions, symprec).unwrap();
             assert_eq!(actual_naive, expect);
 
-            let actual_kdtree =
-                solve_correspondence(&pkdtree, &reduced_cell, &new_positions).unwrap();
-            assert_eq!(actual_kdtree, expect);
+            let actual_neighbor_search =
+                solve_correspondence(&neighbor_search, &reduced_cell, &new_positions).unwrap();
+            assert_eq!(actual_neighbor_search, expect);
         }
         {
             // Translation::new(0.0, 0.5, 0.5 - 2 * symprec);
@@ -320,8 +394,9 @@ mod tests {
             let actual_naive = solve_correspondence_naive(&reduced_cell, &new_positions, symprec);
             assert_eq!(actual_naive, None);
 
-            let actual_kdtree = solve_correspondence(&pkdtree, &reduced_cell, &new_positions);
-            assert_eq!(actual_kdtree, None);
+            let actual_neighbor_search =
+                solve_correspondence(&neighbor_search, &reduced_cell, &new_positions);
+            assert_eq!(actual_neighbor_search, None);
         }
     }
 

--- a/moyo/src/search/solve.rs
+++ b/moyo/src/search/solve.rs
@@ -7,11 +7,34 @@ use rustc_hash::FxHashMap;
 use crate::base::{AtomicSpecie, Cell, Lattice, Permutation, Position, Rotation, Translation};
 
 /// Nearest-neighbor search under periodic boundary conditions, backed by a
-/// uniform bin grid over Cartesian coordinates. Each point is registered in
-/// every bin its ball of radius `symprec` overlaps -- at most eight bins,
-/// because the bin size is at least `2 * symprec`. A query then only
-/// inspects the single bin containing the query position: any point within
-/// `symprec` of the query has registered itself there.
+/// uniform bin grid over Cartesian coordinates.
+///
+/// **Registration.** Each point `p` is registered in every bin overlapped by
+/// the axis-aligned bounding box of its ball of radius `symprec`, so a single
+/// point may be stored in multiple bins. The bin size is at least
+/// `2 * symprec` -- the diameter of that ball -- so the box spans at most two
+/// bins per axis: `p` lands in at most 2^3 = 8 bins. A 2D cross-section, with
+/// `p` near a corner where four bins meet (`*` marks the bins storing `p`):
+///
+/// ```text
+/// +----------+----------+
+/// |          |          |
+/// |  *   ,---+---.   *  |  <-- ball of radius `symprec` around `p`
+/// |     /    |    \     |
+/// +----(-----p-----)----+
+/// |     \    |    /     |
+/// |  *   `---+---'   *  |
+/// |          |          |
+/// +----------+----------+
+///  bin_size >= 2 * symprec
+/// ```
+///
+/// **Query.** `nearest(q)` inspects only the single bin containing `q`, yet
+/// misses nothing: if `|p - q| <= symprec`, then `q` lies inside `p`'s ball,
+/// hence inside its bounding box, hence in one of the bins `p` was registered
+/// in. Points sharing the bin but farther than `symprec` are rejected by the
+/// exact distance check, so the duplicated registration only adds candidates,
+/// never wrong results.
 #[doc(hidden)]
 pub struct PeriodicNeighborSearch {
     num_sites: usize,


### PR DESCRIPTION
## Summary

Replaces `PeriodicKdTree` (backed by kiddo's `ImmutableKdTree`) with `PeriodicNeighborSearch`, a pure safe-Rust uniform bin grid over Cartesian coordinates, and drops the `kiddo` dependency entirely.

## Motivation

- **Suspected heap corruption in the magnetic symmetry search** (lan496/spinforge-dev#88): long noncoplanar magnetic-structure runs nondeterministically die with SIGTRAP / macOS malloc freelist corruption, with the native backtrace inside `PeriodicKdTree::new` → `PrimitiveMagneticSymmetrySearch` → `iterative_magnetic_symmetry_search` (`MoyoNonCollinearMagneticDataset`). It reproduces on both moyopy 0.7.9 and 0.13.0. moyo itself contains no `unsafe`; kiddo's `ImmutableKdTree` is the only unsafe-heavy code in that call path, so this removes the suspected source of the out-of-bounds write.
- **Confirmed wrong-results bug in kiddo v5's `ImmutableKdTree`** (sdd/kiddo#258: incorrect indices/distances from best-n queries), fixed only in the unreleased 6.0.0-alpha rewrite. A silently wrong nearest-neighbor index would corrupt `solve_correspondence` permutations, so moving off it is worthwhile independently of the crash.

## How it works

Each point is registered in every bin its `symprec`-ball overlaps — at most 8 bins, because the bin size is at least `2 * symprec` — so `nearest()` inspects only the single bin containing the query position: any point within `symprec` of the query has registered itself there. Construction is O(N), queries are O(1) expected. The periodic-image enumeration (offsets in `[-1, 1]^3` with padding, exact for Minkowski-reduced bases) is unchanged. The `PeriodicNeighborSearch` docstring explains this invariant with a 2D cross-section figure.

The random lattice rotation that worked around kd-tree axis-alignment pathologies is no longer needed and is removed.

## Performance

Full `cargo bench --bench translation_search` (criterion defaults, Apple M1), run on `main` (kiddo kd-tree) and on this branch (bin grid). Median times:

| n (atoms) | kd-tree (`main`) | bin grid (this PR) | speedup |
|---|---|---|---|
| 1 (1) | 424 ns | 3.48 µs | 0.12× |
| 2 (8) | 4.70 µs | 11.9 µs | 0.40× |
| 3 (27) | 45.2 µs | 41.0 µs | 1.1× |
| 4 (64) | 285 µs | 112 µs | 2.5× |
| 5 (125) | 1.19 ms | 0.29 ms | 4.1× |
| 6 (216) | 3.67 ms | 0.72 ms | 5.1× |
| 7 (343) | 9.93 ms | 1.73 ms | 5.8× |
| 8 (512) | 22.9 ms | 3.78 ms | 6.1× |

Break-even around 27 atoms, then 2.5–6.1× faster from 64 atoms up; the small-cell regression is microsecond-scale construction overhead (the grid builds a hash map where the kd-tree builds a flat array). The `naive` benchmark, identical code on both branches, serves as a control: it agrees within noise between the two runs (e.g. 53.6 ns vs 53.5 ns at n=1, 78.0 ms vs 77.6 ms at n=8), so the comparison is not skewed by machine load.

## Other changes

- Adds `rustc-hash` (FxHashMap) for fast bin hashing; removing kiddo drops 145 lines of transitive dependencies from `Cargo.lock`.
- Adds a regression test cross-checking `solve_correspondence` against the naive O(n²) solver on an axis-aligned n×n×n grid cell (many sites sharing coordinate values on every axis — the historically pathological input for the kd-tree).
- Renames the stale `PeriodicKdTree` references in `CLAUDE.md` and `docs/layer_architecture.md` to `PeriodicNeighborSearch`.
- `cargo test --workspace` passes; no new clippy warnings in touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DCEpnu98FdxbTE5P2GheZe

---
_Generated by [Claude Code](https://claude.ai/code/session_01DCEpnu98FdxbTE5P2GheZe)_
