### PR TITLE
chore: automerge Renovate digest updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -52,7 +52,7 @@
     {
       "description": "Automerge CI and devDependencies non-major updates",
       "matchManagers": ["github-actions", "pre-commit"],
-      "matchUpdateTypes": ["minor", "patch"],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
       "automerge": true,
       "platformAutomerge": true
     },


### PR DESCRIPTION
## Summary

- include Renovate `digest` updates in the CI and pre-commit automerge rule
- allow grouped GitHub Actions digest updates to retain automerge eligibility

## Root cause

The CI and devDependencies group includes GitHub Actions digest updates, but its automerge rule matched only `minor` and `patch`. Any grouped digest update therefore left automerge disabled for the whole PR.

## Impact

Future grouped CI and pre-commit dependency PRs containing digest updates can use platform automerge after required checks and stability requirements pass.

## Validation

- `prek run --all-files`
- `git diff --check`