### PR TITLE
ci: eliminate release workflow warnings

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,34 @@ jobs:
     uses: ./.github/workflows/rw-python-release.yaml
     secrets: inherit
     with:
-      dry_run: ${{ ! startsWith(github.ref, 'refs/tags/') }}
+      # PyPI Trusted Publishing must run in this top-level workflow.
+      dry_run: true
+
+  python-publish:
+    if: "startsWith(github.ref, 'refs/tags/')"
+    name: Python Publish
+    runs-on: ubuntu-latest
+    needs: [python]
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: pypi-*
+          merge-multiple: true
+          path: dist
+      - name: Publish package to TestPyPI
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          attestations: false
+          verbose: true
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
+        with:
+          attestations: false
+          verbose: true
 
   c:
     name: C Release

--- a/.github/workflows/rw-python-release.yaml
+++ b/.github/workflows/rw-python-release.yaml
@@ -27,26 +27,26 @@ jobs:
           - os: ubuntu-latest
             system: linux
             target: x86_64
+            sccache: false
           - os: ubuntu-latest
             system: linux
             target: aarch64
+            sccache: false
           - os: macos-latest
             system: darwin
             target: x86_64
+            sccache: true
           - os: macos-latest
             system: darwin
             target: aarch64
+            sccache: true
           - os: windows-latest
             system: windows
             target: x64
+            sccache: true
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
-      - name: Install uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
-        with:
-          enable-cache: true
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -55,7 +55,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
           args: --release --out dist --find-interpreter --manifest-path moyopy/Cargo.toml
-          sccache: 'true'
+          sccache: ${{ matrix.sccache }}
           manylinux: auto
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7


### PR DESCRIPTION
## Summary
- avoid host-side cache failures in manylinux wheel jobs and remove the unused `setup-uv` cache step
- retain sccache for native macOS and Windows wheels while disabling it for Linux container builds
- publish TestPyPI and PyPI artifacts from the top-level release workflow so Trusted Publishing receives supported OIDC claims

## Test plan
- [x] `prek run --all-files`
- [x] `PYO3_PYTHON=/Users/shinohara/ghq/github.com/spglib/moyo/moyopy/.venv/bin/python cargo test`
- [x] `moyopy/.venv/bin/python -m pytest -q moyopy/python/tests` (56 passed)
- [x] C test suite in a clean build directory (6 passed)
- [x] `just js-test` (66 passed)
- [x] `just web-test` (24 passed)
