### PR TITLE
fix(symmetrize): derive the primitive standardized cell from the conventional one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 Unlisted patch versions (e.g. v0.7.1, v0.7.3, v0.7.6, v0.7.7) contain only dependency or build updates with no user-visible changes.
 
+## Unreleased
+
+### moyo
+
+- Derive the primitive standardized cell from the conventional one so that `A_std = A_prim Q` holds with the fixed primitive-to-conventional matrix `Q` of the centering, as documented. Previously the conventional-cell correction for monoclinic and orthorhombic systems was applied on the conventional side only, so `prim_std_cell` was not `std_cell` transformed by `Q^-1` (#431)
+
 ## v0.16.0 - 2026-08-23
 
 ### moyo

--- a/moyo/src/symmetrize/standardize.rs
+++ b/moyo/src/symmetrize/standardize.rs
@@ -12,8 +12,8 @@ use crate::base::{
     Transformation, UnimodularTransformation, project_rotations,
 };
 use crate::data::{
-    HallNumber, HallSymbol, LatticeSystem, WyckoffPosition, arithmetic_crystal_class_entry,
-    hall_symbol_entry, iter_wyckoff_positions,
+    Centering, HallNumber, HallSymbol, LatticeSystem, WyckoffPosition,
+    arithmetic_crystal_class_entry, hall_symbol_entry, iter_wyckoff_positions,
 };
 use crate::identify::SpaceGroup;
 
@@ -126,6 +126,11 @@ impl StandardizedCell {
         let lattice_system = arithmetic_crystal_class_entry(entry.arithmetic_number)
             .unwrap()
             .lattice_system();
+        // For monoclinic and orthorhombic systems, the identified setting leaves some
+        // freedom in the conventional basis. The chosen correction is folded into
+        // `prim_transformation` so that the primitive standardized cell is always
+        // related to the conventional one by the fixed centering matrix
+        // `entry.centering.linear()`.
         let (prim_transformation, conv_trans_linear) = match lattice_system {
             LatticeSystem::Triclinic => (
                 standardize_triclinic_cell(&prim_cell.lattice, &space_group.transformation),
@@ -139,7 +144,14 @@ impl StandardizedCell {
                     &hs.generators,
                     epsilon,
                 );
-                (space_group.transformation.clone(), trans_std_prim_to_conv)
+                (
+                    fold_conventional_correction(
+                        &space_group.transformation,
+                        &trans_std_prim_to_conv,
+                        entry.centering,
+                    ),
+                    entry.centering.linear(),
+                )
             }
             LatticeSystem::Orthorhombic => {
                 let trans_std_prim_to_conv = standardize_orthorhombic_conv_cell(
@@ -149,7 +161,14 @@ impl StandardizedCell {
                     &conv_std_operations,
                     epsilon,
                 );
-                (space_group.transformation.clone(), trans_std_prim_to_conv)
+                (
+                    fold_conventional_correction(
+                        &space_group.transformation,
+                        &trans_std_prim_to_conv,
+                        entry.centering,
+                    ),
+                    entry.centering.linear(),
+                )
             }
             _ => (space_group.transformation.clone(), entry.centering.linear()),
         };
@@ -268,6 +287,23 @@ pub(super) fn align_primitive_permutations(
                 .ok_or(MoyoError::StandardizationError)
         })
         .collect()
+}
+
+/// Fold a primitive-to-conventional transformation `Q corr` (as returned by the
+/// conventional-cell standardization, with `Q = centering.linear()`) into the
+/// primitive transformation, so that the primitive standardized cell is the
+/// conventional one transformed by the fixed `Q^-1`. The correction in the primitive
+/// basis is `Q corr Q^-1 = (Q corr) Q^-1`, which is integral because `corr` maps the
+/// centering lattice onto itself.
+fn fold_conventional_correction(
+    transformation_to_prim_std: &UnimodularTransformation,
+    trans_std_prim_to_conv: &Linear,
+    centering: Centering,
+) -> UnimodularTransformation {
+    let centering_linear_inv = centering.linear().map(|e| e as f64).try_inverse().unwrap();
+    let prim_correction =
+        (trans_std_prim_to_conv.map(|e| e as f64) * centering_linear_inv).map(|e| e.round() as i32);
+    transformation_to_prim_std.clone() * UnimodularTransformation::from_linear(prim_correction)
 }
 
 /// Niggli reduction for distorted triclinic lattice systems is numerically so challenging.

--- a/moyo/tests/test_moyo_dataset.rs
+++ b/moyo/tests/test_moyo_dataset.rs
@@ -8,7 +8,7 @@ use test_log::test;
 
 use moyo::MoyoDataset;
 use moyo::base::{AngleTolerance, Cell, Lattice, Operation, Permutation, Rotation, Translation};
-use moyo::data::{Setting, operations_from_number};
+use moyo::data::{Setting, hall_symbol_entry, operations_from_number};
 
 fn assert_dataset_with_default(cell: &Cell, symprec: f64) -> MoyoDataset {
     assert_dataset(cell, symprec, AngleTolerance::default(), Setting::default())
@@ -114,6 +114,19 @@ fn assert_dataset(
     );
     // TODO: std_origin_shift
     // TODO: prim_origin_shift
+
+    // The primitive standardized cell is related to the standardized cell by the fixed
+    // primitive-to-conventional matrix of the centering: A_std = A_prim * Q
+    let centering_linear = hall_symbol_entry(dataset.hall_number)
+        .unwrap()
+        .centering
+        .linear()
+        .map(|e| e as f64);
+    assert_relative_eq!(
+        dataset.prim_std_cell.lattice.basis * centering_linear,
+        dataset.std_cell.lattice.basis,
+        epsilon = 1e-8
+    );
 
     assert_eq!(dataset.mapping_std_prim.len(), cell.num_atoms());
 


### PR DESCRIPTION
## Summary

Second layer of the stack for #370, on top of `refactor/split-standardize-module`.

- `standardization.md` documents `A_std = A_prim Q` with the fixed primitive-to-conventional matrix `Q` of the centering, but the monoclinic / orthorhombic conventional-cell correction was applied on the conventional side only (`conv_trans_linear = Q corr`), so `prim_std_cell` was not `std_cell` transformed by `Q^-1` (e.g. every mC case in #370).
- `fold_conventional_correction` folds the correction into `prim_transformation` as `Q corr Q^-1` (integral because `corr` maps the centering lattice onto itself) and keeps `conv_trans_linear = Q`. The primitive standardized cell therefore inherits whatever reduction the conventional cell has.
- `assert_dataset` in the integration tests now checks `A_std = A_prim Q` for every dataset test.

The candidate search itself is unchanged here; #428 (affine-normalizer admissibility) and #427 (monoclinic Delaunay triple) follow.

Stack: `refactor/split-standardize-module` -> this PR -> #428 -> #427.

## Test plan

- [x] `cargo test -p moyo` (invariant added to `assert_dataset`)
- [ ] CI

[Claude Code] Generated with [Claude Code](https://claude.com/claude-code)
