### PR TITLE
Release v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 Unlisted patch versions (e.g. v0.7.1, v0.7.3, v0.7.6, v0.7.7) contain only dependency or build updates with no user-visible changes.
 
-## Unreleased
+## v0.17.0 - 2026-08-30
 
 ### moyo
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,7 +603,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "moyo"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "approx",
  "criterion",
@@ -626,7 +626,7 @@ dependencies = [
 
 [[package]]
 name = "moyo-wasm"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "moyo",
  "serde",
@@ -637,7 +637,7 @@ dependencies = [
 
 [[package]]
 name = "moyoc"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "approx",
  "moyo",
@@ -646,7 +646,7 @@ dependencies = [
 
 [[package]]
 name = "moyopy"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "approx",
  "itertools 0.15.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "2"
 authors = ["Kohei Shinohara <kshinohara0508@gmail.com>"]
 description = "Library for Crystal Symmetry in Rust"
 edition = "2024"
-version = "0.16.0"
+version = "0.17.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/spglib/moyo"
 

--- a/moyoc/Cargo.toml
+++ b/moyoc/Cargo.toml
@@ -16,7 +16,7 @@ name = "moyoc"
 crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
-moyo = { path = "../moyo", version = "0.16.0" }
+moyo = { path = "../moyo", version = "0.17.0" }
 
 [dev-dependencies]
 nalgebra.workspace = true

--- a/moyopy/Cargo.toml
+++ b/moyopy/Cargo.toml
@@ -17,7 +17,7 @@ name = "moyopy"
 crate-type = ["cdylib"]
 
 [dependencies]
-moyo = { path = "../moyo", version = "0.16.0" }
+moyo = { path = "../moyo", version = "0.17.0" }
 nalgebra.workspace = true
 serde.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION
## Summary

- bump the shared workspace version and internal Rust dependency constraints to v0.17.0
- finalize the current changelog entries as the v0.17.0 release dated 2026-08-30

## Test plan

- [x] `prek run --all-files`
- [x] `PYO3_PYTHON=moyopy/.venv/bin/python cargo test`
- [x] build the moyopy extension and run `moyopy/.venv/bin/python -m pytest -q moyopy/python/tests`
- [x] configure a clean CMake build and run all six C tests with `ctest`
- [x] run the 66 WASM tests with `npm test` in `moyo-wasm`
- [x] run the 24 web tests with `npm test` in `apps/web`
