### PR TITLE
fix(math): accumulate the HNF transform with in-place column operations

### DIFF
--- a/moyo/benches/dataset.rs
+++ b/moyo/benches/dataset.rs
@@ -4,7 +4,43 @@ use std::fs;
 use std::path::Path;
 
 use moyo::MoyoDataset;
-use moyo::base::Cell;
+use moyo::base::{Cell, Lattice};
+use nalgebra::{Matrix3, Vector3};
+
+/// Conventional rocksalt cell repeated `n` times along each axis.
+///
+/// A perfect supercell is the worst case for the primitive-cell reduction: the
+/// pure-translation count grows as `4 * n^3`, and every translation becomes an
+/// extra column of the matrix handed to `HNF::new`.
+fn rocksalt_supercell(n: usize) -> Cell {
+    let base_positions = [
+        Vector3::new(0.0, 0.0, 0.0),
+        Vector3::new(0.0, 0.5, 0.5),
+        Vector3::new(0.5, 0.0, 0.5),
+        Vector3::new(0.5, 0.5, 0.0),
+        Vector3::new(0.5, 0.5, 0.5),
+        Vector3::new(0.5, 0.0, 0.0),
+        Vector3::new(0.0, 0.5, 0.0),
+        Vector3::new(0.0, 0.0, 0.5),
+    ];
+    let base_numbers = [0, 0, 0, 0, 1, 1, 1, 1];
+
+    let lattice = Lattice::new(Matrix3::identity() * (5.0 * n as f64));
+    let mut positions = vec![];
+    let mut numbers = vec![];
+    for i in 0..n {
+        for j in 0..n {
+            for k in 0..n {
+                let shift = Vector3::new(i as f64, j as f64, k as f64);
+                for (position, number) in base_positions.iter().zip(base_numbers.iter()) {
+                    positions.push((position + shift) / n as f64);
+                    numbers.push(*number);
+                }
+            }
+        }
+    }
+    Cell::new(lattice, positions, numbers)
+}
 
 pub fn benchmark(c: &mut Criterion) {
     let path = Path::new("tests/assets/mp-1201492.json");
@@ -13,6 +49,20 @@ pub fn benchmark(c: &mut Criterion) {
     c.bench_function("dataset_clathrate_Si", |b| {
         b.iter(|| MoyoDataset::with_default(&cell, symprec))
     });
+
+    // Tighter than the clathrate case above: the reported supercell slowdown was
+    // measured at 1e-5.
+    let supercell_symprec = 1e-5;
+    for n in [2, 3, 4] {
+        let cell = rocksalt_supercell(n);
+        c.bench_function(
+            &format!(
+                "dataset_rocksalt_supercell_{n}x{n}x{n}_{}_atoms",
+                cell.num_atoms()
+            ),
+            |b| b.iter(|| MoyoDataset::with_default(&cell, supercell_symprec)),
+        );
+    }
 }
 
 criterion_group!(benches, benchmark);

--- a/moyo/src/math/hnf.rs
+++ b/moyo/src/math/hnf.rs
@@ -1,10 +1,6 @@
 use nalgebra::base::allocator::Allocator;
 use nalgebra::{DefaultAllocator, Dim, OMatrix};
 
-use super::elementary::{
-    adding_column_matrix, changing_column_sign_matrix, swapping_column_matrix,
-};
-
 /// Hermite normal form of (M, N) matrix such that h = basis * r
 #[derive(Debug)]
 #[allow(clippy::upper_case_acronyms)]
@@ -39,14 +35,18 @@ where
                     .min_by_key(|&j| h[(s, j)].abs())
                     .unwrap();
                 h.swap_columns(s, pivot);
-                r *= swapping_column_matrix(n, s, pivot);
+                // r *= swapping_column_matrix(n, s, pivot);
+                r.swap_columns(s, pivot);
 
                 // Guarantee that h[(s, s)] is positive
                 if h[(s, s)] < 0 {
                     for i in 0..m.value() {
                         h[(i, s)] *= -1;
                     }
-                    r *= changing_column_sign_matrix(n, s);
+                    // r *= changing_column_sign_matrix(n, s);
+                    for i in 0..n.value() {
+                        r[(i, s)] *= -1;
+                    }
                 }
                 assert_ne!(h[(s, s)], 0);
 
@@ -64,7 +64,11 @@ where
                         for i in 0..m.value() {
                             h[(i, j)] -= k * h[(i, s)];
                         }
-                        r *= adding_column_matrix(n, s, j, -k);
+                        // r *= adding_column_matrix(n, s, j, -k);
+                        // r[(:, j)] -= k * r[(:, s)]
+                        for i in 0..n.value() {
+                            r[(i, j)] -= k * r[(i, s)];
+                        }
                     }
                 }
 
@@ -81,7 +85,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use nalgebra::{SMatrix, matrix};
+    use itertools::iproduct;
+    use nalgebra::{Dyn, Matrix3, OMatrix, SMatrix, U3, Vector3, matrix};
     use rand::SeedableRng;
     use rand::prelude::*;
     use rand::rngs::StdRng;
@@ -126,6 +131,39 @@ mod tests {
             ];
             assert_eq!(hnf.h, expect);
         }
+    }
+
+    #[test]
+    fn test_hnf_wide() {
+        // The 3 x (3 + n) shape `transformation_matrix_from_translations` builds, one
+        // column per pure translation -- here the 256 of an fcc 4x4x4 supercell, scaled
+        // by 256. Accumulating `r` by matrix product made this shape cost O(n^4).
+        let n = 256;
+        let mut columns = vec![
+            Vector3::new(n, 0, 0),
+            Vector3::new(0, n, 0),
+            Vector3::new(0, 0, n),
+        ];
+        for (i, j, k) in iproduct!(0..4, 0..4, 0..4) {
+            for (di, dj, dk) in [(0, 0, 0), (0, 32, 32), (32, 0, 32), (32, 32, 0)] {
+                columns.push(Vector3::new(64 * i + di, 64 * j + dj, 64 * k + dk));
+            }
+        }
+        let basis = OMatrix::<i32, U3, Dyn>::from_columns(&columns);
+        assert_eq!(basis.ncols(), 3 + n as usize);
+
+        let hnf = HNF::new(&basis);
+        // Also asserted inside `HNF::new`; kept here in case that is ever relaxed.
+        assert_eq!(hnf.h, basis * &hnf.r);
+
+        // The leading block spans the translation lattice, of index 256.
+        let leading = Matrix3::from_columns(&[hnf.h.column(0), hnf.h.column(1), hnf.h.column(2)]);
+        assert_relative_eq!(
+            leading.map(|e| e as f64).determinant(),
+            (n as f64).powi(3) / n as f64
+        );
+        // The reduction clears everything past it.
+        assert!((3..hnf.h.ncols()).all(|j| hnf.h.column(j).iter().all(|&e| e == 0)));
     }
 
     #[test]

--- a/moyo/src/math/hnf.rs
+++ b/moyo/src/math/hnf.rs
@@ -35,7 +35,6 @@ where
                     .min_by_key(|&j| h[(s, j)].abs())
                     .unwrap();
                 h.swap_columns(s, pivot);
-                // r *= swapping_column_matrix(n, s, pivot);
                 r.swap_columns(s, pivot);
 
                 // Guarantee that h[(s, s)] is positive
@@ -43,7 +42,6 @@ where
                     for i in 0..m.value() {
                         h[(i, s)] *= -1;
                     }
-                    // r *= changing_column_sign_matrix(n, s);
                     for i in 0..n.value() {
                         r[(i, s)] *= -1;
                     }
@@ -64,7 +62,6 @@ where
                         for i in 0..m.value() {
                             h[(i, j)] -= k * h[(i, s)];
                         }
-                        // r *= adding_column_matrix(n, s, j, -k);
                         // r[(:, j)] -= k * r[(:, s)]
                         for i in 0..n.value() {
                             r[(i, j)] -= k * r[(i, s)];

--- a/moyo/tests/test_moyo_dataset.rs
+++ b/moyo/tests/test_moyo_dataset.rs
@@ -1251,3 +1251,64 @@ fn test_orthorhombic_axis_order_pnma() {
     assert_eq!(dataset.number, 62); // Pnma
     assert_eq!(dataset.num_operations(), 8);
 }
+
+#[test]
+fn test_with_rocksalt_supercell() {
+    // Rocksalt 3x3x3 supercell, Fm-3m (No. 225). Each pure translation becomes an
+    // extra column of the matrix `transformation_matrix_from_translations` hands to
+    // `HNF::new`, so a perfect supercell is the worst case for the primitive-cell
+    // reduction. 3x3x3 rather than 2x2x2 puts the coordinates on sixths, making the
+    // supercell periodicity coprime to the fcc centering instead of refining it.
+    // The wide `HNF` itself is covered by `math::hnf::tests::test_hnf_wide`.
+    let n = 3;
+    let base_positions = [
+        vector![0.0, 0.0, 0.0],
+        vector![0.0, 0.5, 0.5],
+        vector![0.5, 0.0, 0.5],
+        vector![0.5, 0.5, 0.0],
+        vector![0.5, 0.5, 0.5],
+        vector![0.5, 0.0, 0.0],
+        vector![0.0, 0.5, 0.0],
+        vector![0.0, 0.0, 0.5],
+    ];
+    let base_numbers = [0, 0, 0, 0, 1, 1, 1, 1];
+
+    let lattice = Lattice::new(Matrix3::identity() * (5.0 * n as f64));
+    let mut positions = vec![];
+    let mut numbers = vec![];
+    for i in 0..n {
+        for j in 0..n {
+            for k in 0..n {
+                let shift = vector![i as f64, j as f64, k as f64];
+                for (position, number) in base_positions.iter().zip(base_numbers.iter()) {
+                    positions.push((position + shift) / n as f64);
+                    numbers.push(*number);
+                }
+            }
+        }
+    }
+    let cell = Cell::new(lattice, positions, numbers);
+    assert_eq!(cell.num_atoms(), 8 * n * n * n);
+
+    let symprec = 1e-5;
+    // Not `assert_dataset_with_default`: that uses `Setting::Standard`, and the
+    // slowdown was reported under `Setting::Spglib`.
+    let dataset = assert_dataset(&cell, symprec, AngleTolerance::default(), Setting::Spglib);
+
+    assert_eq!(dataset.number, 225); // Fm-3m
+    // 48 point-group operations x 4 fcc centerings x n^3 supercell translations
+    assert_eq!(dataset.num_operations(), 48 * 4 * n * n * n);
+    // Reduced back to the 2-atom rocksalt primitive cell
+    assert_eq!(dataset.prim_std_cell.num_atoms(), 2);
+    assert_eq!(dataset.std_cell.num_atoms(), 8);
+    assert_eq!(dataset.pearson_symbol, "cF8");
+    // Every Na is one orbit, every Cl the other
+    assert_eq!(
+        dataset
+            .orbits
+            .iter()
+            .collect::<std::collections::HashSet<_>>()
+            .len(),
+        2
+    );
+}

--- a/moyo/tests/test_moyo_dataset.rs
+++ b/moyo/tests/test_moyo_dataset.rs
@@ -1291,9 +1291,7 @@ fn test_with_rocksalt_supercell() {
     assert_eq!(cell.num_atoms(), 8 * n * n * n);
 
     let symprec = 1e-5;
-    // Not `assert_dataset_with_default`: that uses `Setting::Standard`, and the
-    // slowdown was reported under `Setting::Spglib`.
-    let dataset = assert_dataset(&cell, symprec, AngleTolerance::default(), Setting::Spglib);
+    let dataset = assert_dataset_with_default(&cell, symprec);
 
     assert_eq!(dataset.number, 225); // Fm-3m
     // 48 point-group operations x 4 fcc centerings x n^3 supercell translations


### PR DESCRIPTION
Hi!

I originally found this while adding an optional `moyopy` backend to `seekpath` (materialscloud-org/seekpath#110), where perfect supercells are ordinary input. See the commit messages for the test and bench rationale.

Disclaimer, since I'm not super familiar with Rust and I was just curious to understand the bad scaling that I observed when comparing `moyo` and `spglib`, I used Claude to work on this fix and to prepare this PR. @lan496 For this reason, I mark it as a draft (even though it's in principle ready from my side and fixes the issue locally). Feel free to close it, in case the code quality is not sufficient or the bug is not real. Otherwise, I'm of course happy to iterate on this PR based on your input.

## Description

`HNF::new` tracked its transformation matrix `r` by materializing a full `N x N` elementary matrix per column operation and multiplying it in. A dense `N x N` product is `O(N^3)` and the reduction performs `O(N)` of them, so the routine ran in `O(N^4)`. `transformation_matrix_from_translations` passes one column per pure lattice translation, so `N` grows with supercell multiplicity and perfect supercells became pathological: 98% of the samples in `MoyoDataset::new` sat in that one call. Displacing a single atom, which destroys the translations but leaves the atom count untouched, brought it back to ~6 ms.

Here we apply each elementary operation to `r` directly, which is `O(N)` per operation instead of `O(N^3)`. `SNF::new` already accumulated its transforms this way; only `HNF::new` was left on the matrix-product form.

## Benchmark

| shape | atoms | ops | trans | spglib | before | after |
| --- | --- | --- | --- | --- | --- | --- |
| (1, 1, 1) | 8 | 192 | 4 | 7.9 ms | 1.3 ms | 1.7 ms |
| (2, 2, 2) | 64 | 1536 | 32 | 8.0 ms | 1.3 ms | 0.9 ms |
| (3, 3, 3) | 216 | 5184 | 108 | 8.7 ms | 31.1 ms | 1.5 ms |
| (4, 4, 1) | 128 | 1024 | 64 | 8.2 ms | 5.0 ms | 1.2 ms |
| (4, 4, 2) | 256 | 2048 | 128 | 8.6 ms | 60.8 ms | 1.6 ms |
| (4, 4, 4) | 512 | 12288 | 256 | 10.6 ms | 1047.6 ms | 3.9 ms |

Before/after are moyopy 0.17.0 from PyPI against this branch, same machine. moyo is now faster than spglib across the whole range.


<details>
<summary>Reproducer (needs only <code>moyopy</code> and <code>spglib</code>)</summary>

```python
"""Standalone reproducer: moyopy's cost on high-symmetry supercells."""
import itertools
import time

import numpy as np
import moyopy
import spglib

# Conventional FCC cell of a 2-species rocksalt-like structure (8 atoms)
BASE_CELL = np.diag([5.0, 5.0, 5.0])
BASE_POS = np.array([
    [0.0, 0.0, 0.0], [0.0, 0.5, 0.5], [0.5, 0.0, 0.5], [0.5, 0.5, 0.0],
    [0.5, 0.5, 0.5], [0.5, 0.0, 0.0], [0.0, 0.5, 0.0], [0.0, 0.0, 0.5],
])
BASE_NUM = [11, 11, 11, 11, 17, 17, 17, 17]


def supercell(nx, ny, nz):
    cell = BASE_CELL * np.array([[nx], [ny], [nz]], dtype=float)
    pos, num = [], []
    for i, j, k in itertools.product(range(nx), range(ny), range(nz)):
        for q, s in zip(BASE_POS, BASE_NUM):
            pos.append([(q[0] + i) / nx, (q[1] + j) / ny, (q[2] + k) / nz])
            num.append(s)
    return cell, np.array(pos), num


def time_moyo(cell, pos, num):
    mc = moyopy.Cell(list(cell), list(pos), list(num))
    start = time.perf_counter()
    moyopy.MoyoDataset(mc, symprec=1e-5, setting=moyopy.Setting.spglib())
    return time.perf_counter() - start


def time_spglib(structure, reps=3):
    start = time.perf_counter()
    for _ in range(reps):
        spglib.get_symmetry_dataset(structure, symprec=1e-5)
    return (time.perf_counter() - start) / reps


print(f'moyopy {moyopy.__version__}, spglib {spglib.__version__}\n')
print(f'{"shape":>10}{"atoms":>7}{"ops":>8}{"trans":>7}{"spglib ms":>11}{"moyo ms":>11}')
for shape in [(1, 1, 1), (2, 2, 2), (3, 3, 3), (4, 4, 1), (4, 4, 2), (4, 4, 4)]:
    cell, pos, num = supercell(*shape)
    dataset = spglib.get_symmetry_dataset((cell, pos, num), symprec=1e-5)
    n_trans = sum(1 for W in dataset.rotations if np.allclose(np.array(W), np.eye(3)))
    t_spg = time_spglib((cell, pos, num))
    t_moy = time_moyo(cell, pos, num)
    print(f'{str(shape):>10}{len(num):>7}{len(dataset.rotations):>8}{n_trans:>7}'
          f'{t_spg * 1000:>11.2f}{t_moy * 1000:>11.2f}')

# Controlled comparison: identical atom count, translations destroyed
cell, pos, num = supercell(4, 4, 4)
broken = pos.copy()
broken[0] += 0.02
print('\ncontrol, same 4x4x4 cell and atom count:')
print(f'  perfect supercell        : moyo {time_moyo(cell, pos, num) * 1000:9.2f} ms')
print(f'  one atom displaced by 0.02: moyo {time_moyo(cell, broken, num) * 1000:9.2f} ms')
```

Do not add larger shapes when running against the unfixed version — cost goes as `N^4` in the translation count, so a 6x6x6 cell takes minutes.

</details>