### PR TITLE
Fix labeling for pull requests from forks

### DIFF
--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -1,7 +1,7 @@
 name: label
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, ready_for_review]
 
 jobs:


### PR DESCRIPTION
## Summary

- Run the automatic labeler with `pull_request_target` so fork-originated pull requests receive a write-capable token.
- Preserve the existing event types and narrowly scoped `contents` and `pull-requests` permissions.

## Test plan

- [x] `prek run --all-files`
- [x] `PYO3_PYTHON=/Users/shinohara/ghq/github.com/spglib/moyo/moyopy/.venv/bin/python cargo test`
- [x] `git diff --check`
