### PR TITLE
Release v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 Unlisted patch versions (e.g. v0.7.1, v0.7.3, v0.7.6, v0.7.7) contain only dependency or build updates with no user-visible changes.
 
+## v0.18.0 - 2026-09-01
+
+### moyo
+
+- Fix `O(N^4)` scaling of `HNF::new` in the number of columns `N`. The transformation matrix was accumulated by multiplying in a dense `N x N` elementary matrix per column operation; the operations are now applied to it in place, as `SNF::new` already did. `N` is the number of pure lattice translations in `PrimitiveCell::new`, so perfect supercells were pathological: a 4x4x4 rocksalt supercell (512 atoms, 256 translations) took 1.05 s and now takes 3.9 ms, faster than spglib across the tested range (#436, thanks to @t-reents)
+
 ## v0.17.0 - 2026-08-30
 
 ### moyo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,7 +603,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "moyo"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "approx",
  "criterion",
@@ -626,7 +626,7 @@ dependencies = [
 
 [[package]]
 name = "moyo-wasm"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "moyo",
  "serde",
@@ -637,7 +637,7 @@ dependencies = [
 
 [[package]]
 name = "moyoc"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "approx",
  "moyo",
@@ -646,7 +646,7 @@ dependencies = [
 
 [[package]]
 name = "moyopy"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "approx",
  "itertools 0.15.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "2"
 authors = ["Kohei Shinohara <kshinohara0508@gmail.com>"]
 description = "Library for Crystal Symmetry in Rust"
 edition = "2024"
-version = "0.17.0"
+version = "0.18.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/spglib/moyo"
 

--- a/moyoc/Cargo.toml
+++ b/moyoc/Cargo.toml
@@ -16,7 +16,7 @@ name = "moyoc"
 crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
-moyo = { path = "../moyo", version = "0.17.0" }
+moyo = { path = "../moyo", version = "0.18.0" }
 
 [dev-dependencies]
 nalgebra.workspace = true

--- a/moyopy/Cargo.toml
+++ b/moyopy/Cargo.toml
@@ -17,7 +17,7 @@ name = "moyopy"
 crate-type = ["cdylib"]
 
 [dependencies]
-moyo = { path = "../moyo", version = "0.17.0" }
+moyo = { path = "../moyo", version = "0.18.0" }
 nalgebra.workspace = true
 serde.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION
## Summary

- bump the shared workspace version and internal Rust dependency constraints to v0.18.0
- add the v0.18.0 changelog entry dated 2026-09-01 for the `HNF::new` scaling fix (#436, thanks to @t-reents)

## Test plan

- [x] `prek run --files` on the changed files
- [x] `PYO3_PYTHON=moyopy/.venv/bin/python cargo test` (175 unit + 51 integration tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)